### PR TITLE
Seed governance-kit with three skills

### DIFF
--- a/doc-gardener/SKILL.md
+++ b/doc-gardener/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: doc-gardener
+description: Scans docs opted into freshness tracking, detects staleness (either by elapsed time or by drift against the code they describe), and produces a remediation PR. Two-tier handling — docs whose watched code has not changed since the last-verified stamp get a simple stamp bump; docs whose watched code has changed get a drafted content update for human review. Pairs with the governance-bootstrap skill's doc-freshness rule. Use when the user says "run doc gardener", "check doc freshness", "garden the docs", "update stale docs", or when governance reports doc-freshness violations. Also designed to be invoked by /loop or a scheduled task for autonomous gardening.
+license: MIT
+metadata:
+  author: governance-kit
+  version: "0.1"
+  companion-of: governance-bootstrap
+---
+
+# doc-gardener
+
+The `doc-freshness` rule in `governance-bootstrap` makes staleness *visible*. This skill makes it *actionable*. It is the harness-engineering pattern: a recurring agent that scans for docs that no longer reflect the code, and opens fix-up PRs so a human can approve the remediation.
+
+Two classes of staleness, handled differently:
+
+| Case | Evidence | Action |
+|---|---|---|
+| **Stamp expired, code unchanged** | `last-verified` is older than the window, but none of the watched code has changed since that date. | Low-risk auto-bump. Update the stamp, open a minimal PR explaining "verified still accurate". |
+| **Stamp expired, code changed** | `last-verified` is older than the window *and* watched code has been modified since then. | Draft a content update. Summarize what changed in the code, propose a doc edit, open the PR as **Draft** for human review. |
+
+The skill never auto-merges. Every change lands through a PR and a human approval — that's the whole point.
+
+---
+
+## Activation flow
+
+### Step 1 — Build the tracked-doc set
+
+Run from the repo root (`git rev-parse --show-toplevel` confirms git). The tracked-doc set is the **union** of two sources:
+
+**(a) Baseline — well-known docs that almost any repo should keep fresh.** The gardener always considers these if they exist on disk, even without any config. Glob each pattern relative to the repo root and keep the hits:
+
+```
+AGENTS.md
+CLAUDE.md
+README.md
+CHANGELOG.md
+CHANGELOG/**/*.md
+SECURITY.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+CONSTITUTION.md
+docs/**/*.md
+doc/**/*.md
+plans/**/*.md
+plan/**/*.md
+adrs/**/*.md
+adr/**/*.md
+docs/adrs/**/*.md
+docs/adr/**/*.md
+rfcs/**/*.md
+.github/AGENTS.md
+.github/SECURITY.md
+```
+
+Skip obvious machine-generated paths (`node_modules/`, `vendor/`, `dist/`, `build/`, `target/`, `.venv/`, `__pycache__/`). If a file appears in both the baseline and the explicit config, dedupe.
+
+**(b) Explicit opt-in — `tests/governance/freshness.conf`.** One path per line; `#` comments and blank lines ignored. This is where the user adds docs the baseline misses (a README inside a subpackage, a runbook with a non-standard name, anything outside `docs/`). If the file is absent, treat it as empty — the baseline alone is still a valid tracked set.
+
+If the union is empty (no baseline hits, no config), stop and tell the user: this repo has no markdown docs in the conventional locations and no explicit config — there's nothing for the gardener to do.
+
+### Step 2 — Enumerate stale docs
+
+For each path in the tracked set:
+
+1. Read the file. Extract the `<!-- last-verified: YYYY-MM-DD -->` stamp.
+2. If the stamp is missing → classify as **`no-stamp`** (treat as stale).
+3. If the stamp is within the window (default 90 days; env `GOVERNANCE_FRESHNESS_DAYS` overrides) → **skip**.
+4. Otherwise → classify as **`stale`** and proceed to Step 3.
+
+Also surface **orphans**: files listed in `freshness.conf` that no longer exist on disk. Report them; do not attempt to fix. The user decides whether to remove them from the config or restore the file. (Baseline-sourced paths can't be orphaned — they're discovered by globbing, so a missing file simply isn't in the set.)
+
+### Step 3 — Determine what each stale doc watches
+
+For each stale doc, build a **watch set** — the list of paths whose changes matter. Look for evidence in this order (use the first that yields results):
+
+**(a) Explicit annotation** (preferred):
+```markdown
+<!-- gardener-watches: src/auth/, src/session/session.py, docs/security.md -->
+```
+Parse the comma-separated list. Paths are relative to the repo root.
+
+**(b) Fenced code blocks** with filenames: ```` ```python:src/auth/tokens.py ```` style, or a filename on the line preceding the fence.
+
+**(c) Inline path references** — grep the doc for strings that look like tracked file paths (`[a-z_][a-z0-9_/.-]+\.(py|js|ts|go|rs|md|yml|yaml|sh)`) and keep only those that actually exist under the repo root.
+
+**(d) Fallback — directory sibling**: if the doc lives at `docs/auth/README.md`, watch `src/auth/` (if it exists). If the doc lives at the repo root, no directory sibling.
+
+**(e) Well-known-file fallback**: for common repo-root docs, use these defaults if (a)–(d) haven't produced a watch set. The aim is low-friction coverage — explicit `gardener-watches` annotations should still be preferred.
+
+| Doc | Default watch set |
+|---|---|
+| `AGENTS.md`, `CLAUDE.md` | top-level source dirs that exist: `src/`, `lib/`, `app/`, `pkg/`, `cmd/`, `internal/` |
+| `README.md` (repo root) | `src/` (if present) + `package.json` / `pyproject.toml` / `go.mod` / `Cargo.toml` / `pom.xml` (whichever exist) |
+| `SECURITY.md` | `.github/workflows/`, and any of `src/auth/`, `src/security/`, `auth/`, `security/` that exist |
+| `CONSTITUTION.md` | `tests/governance/rules/`, `tests/governance/lib.sh` |
+| `CONTRIBUTING.md` | `.github/`, hooks under `.git/hooks/` are not tracked, so watch `tests/` instead if present |
+| `CHANGELOG.md`, `CHANGELOG/**` | skip the gardener — changelogs are written by humans at release time, not drift-driven. Classify as `skip-changelog` (don't bump, don't draft, don't warn). |
+| `docs/adrs/**`, `adrs/**`, `docs/adr/**`, `adr/**` | ADRs are historical records; once written they shouldn't drift. Classify as `skip-adr` (same handling as changelog). |
+
+If none of (a)–(e) yields anything, classify the doc as **`unwatched-stale`**: the stamp has expired but we don't know what to check it against. Report it; suggest adding an explicit `<!-- gardener-watches: ... -->` annotation. Do not bump the stamp.
+
+See `references/WATCH_ANNOTATIONS.md` for the annotation format.
+
+### Step 4 — Classify each doc
+
+For each stale-with-watches doc:
+
+- `stamp_date = <last-verified stamp>`
+- `changes = git log --since="$stamp_date" --pretty=oneline -- <watch-paths...>`
+
+| `changes` | Classification |
+|---|---|
+| empty | **`bump-only`** — watched code unchanged since stamp; auto-bump is safe. |
+| non-empty | **`needs-update`** — watched code has drifted; draft a content update. |
+
+### Step 5 — Present the findings
+
+Before acting, show the user a summary:
+
+```
+Freshness report (<N> docs tracked, <M> stale):
+
+  bump-only        (<count>):  docs where watched code is unchanged
+    - docs/security.md          (stamp: 2025-11-01, 172 days old)
+    - docs/deploy.md            (stamp: 2025-10-15, 189 days old)
+
+  needs-update     (<count>):  docs where watched code drifted
+    - docs/auth/session.md      (stamp: 2025-09-10, 5 commits since)
+
+  unwatched-stale  (<count>):  stale, but no watch set inferable
+    - docs/misc/notes.md        (add a gardener-watches annotation)
+
+  no-stamp         (<count>):  no last-verified marker found
+    - docs/new-thing.md         (add a stamp to opt in)
+
+  orphaned         (<count>):  listed in freshness.conf but missing
+    - docs/removed.md
+
+  skipped          (<count>):  intentionally excluded (changelogs, ADRs)
+    - CHANGELOG.md, docs/adrs/0003-auth.md
+
+Proceed with:
+  (1) bump-only PR    — <count> stamp updates, low risk
+  (2) needs-update PRs — <count> draft PRs for review
+  (3) both
+  (4) dry-run only — no PRs
+```
+
+Use `AskUserQuestion` to get the decision. Default (and the right choice for autonomous loops) is **dry-run only** the first time the user invokes the skill in a session — they should see the report before the skill starts opening PRs.
+
+### Step 6 — Create the PRs
+
+Do this from a clean working tree. If the tree is dirty, stop and tell the user to commit or stash first — the skill must not mix its output with unrelated user changes.
+
+**Bump-only PR** (one PR for the batch):
+
+1. `git checkout -b doc-gardener/stamp-bumps-<YYYY-MM-DD>`
+2. For each `bump-only` doc: replace the `<!-- last-verified: OLD -->` with today's date. Use `Edit`, not `Write`.
+3. `git add <files>` and commit with message: `docs(gardener): bump last-verified stamps — <count> docs, code unchanged`
+4. `git push -u origin <branch>` (if `origin` exists and push is allowed).
+5. `gh pr create` with title `docs(gardener): bump stamps for <count> unchanged docs` and a body from `assets/gardener-pr-bump.template.md`. Mark **ready for review** (not draft) — these are low-risk and batch-reviewable.
+
+**Needs-update PRs** (one PR per doc — they need individual review):
+
+For each `needs-update` doc:
+1. `git checkout -b doc-gardener/update-<slug>-<YYYY-MM-DD>`
+2. Read the doc. Read the commit messages + diffs of the changed watch-set files since `stamp_date`. Produce:
+   - A **Summary of changes** section for the PR body (one bullet per relevant commit, paraphrased — not a raw log dump).
+   - A **proposed diff** against the doc that reflects the drift. Be conservative: change what the drift actually implies, don't refactor the whole doc.
+3. Apply the diff via `Edit`. Update the stamp to today.
+4. Commit: `docs(gardener): draft update for <doc path> — code drift since <stamp_date>`
+5. `git push -u origin <branch>`
+6. `gh pr create --draft` (draft — human must review the content). Body from `assets/gardener-pr-update.template.md`, including the Summary of changes and a "What I inferred" section listing the watch-set commits.
+
+**Never force-push.** If a branch with the same name already exists, use a suffix (`-v2`, `-v3`) rather than overwriting — previous gardener runs may be mid-review.
+
+### Step 7 — Report back
+
+Print a compact summary:
+- Branches created.
+- PR URLs (from `gh pr create` output).
+- What the user should do next (review the drafts, merge the bump-PR quickly).
+- Remaining issues: `unwatched-stale`, `no-stamp`, `orphaned` — list them as a "needs your attention" section.
+
+If invoked via `/loop`, the skill should exit cleanly after this report. Do not recurse or re-run without an explicit user trigger.
+
+---
+
+## Key design rules
+
+- **Two tiers, sharply separated.** A stamp bump is a near-trivial PR; a content update is a significant draft. Never collapse them into one PR — reviewers will either under-scrutinize the update or over-scrutinize the bumps.
+
+- **Drafts for content changes, always.** The gardener writes a first pass; humans decide whether it's right. Opening a non-draft PR for inferred content changes would invite rubber-stamping.
+
+- **Never auto-merge.** Even bump-only PRs need a human to click the button. The cost of a mistaken bump is a doc that falsely claims accuracy.
+
+- **Refuse to work on a dirty tree.** This skill touches many files across many branches. Mixing its output with unrelated user changes creates unfixable confusion.
+
+- **Honor the watch set, nothing else.** Do not update a doc based on evidence outside its declared watches. If a user wants broader tracking, they add paths to the annotation.
+
+- **Be honest in the PR body.** The `What I inferred` section should be specific about which commits were consulted and what was extrapolated. If the skill had to guess, it should say so — reviewers need to know the confidence level.
+
+## References
+
+- `assets/gardener-pr-bump.template.md` — PR body for the batched stamp-bump PR.
+- `assets/gardener-pr-update.template.md` — PR body for individual content-update drafts.
+- `references/WATCH_ANNOTATIONS.md` — the `<!-- gardener-watches: ... -->` annotation format and worked examples.

--- a/doc-gardener/assets/gardener-pr-bump.template.md
+++ b/doc-gardener/assets/gardener-pr-bump.template.md
@@ -1,0 +1,22 @@
+## Stamp bumps — <count> docs, no code drift
+
+Automated by the `doc-gardener` skill. Every doc listed below was re-verified: the code its `<!-- gardener-watches: ... -->` annotation points at has **not** changed since the previous `<!-- last-verified: ... -->` stamp. The docs are still accurate; the stamps have been advanced to today.
+
+### Docs updated
+
+<!-- One bullet per doc. Format:
+- `<path>` — previous stamp: `YYYY-MM-DD` → `YYYY-MM-DD` (no drift across N files: <list>)
+-->
+
+### Review checklist
+
+- [ ] Spot-check one or two of the listed docs against their watch set — does "no drift" look right?
+- [ ] If any bump is wrong, remove that file from this PR and open the doc for real editing.
+
+### What this PR does NOT contain
+
+- Any prose changes.
+- Any new annotations.
+- Any changes outside the `<!-- last-verified: ... -->` stamps.
+
+If you see anything else in the diff, something went wrong — do not merge. Open an issue.

--- a/doc-gardener/assets/gardener-pr-update.template.md
+++ b/doc-gardener/assets/gardener-pr-update.template.md
@@ -1,0 +1,45 @@
+## Draft update — `<doc path>`
+
+**Status:** draft. The code this doc watches has drifted since the last `<!-- last-verified: ... -->` stamp; the gardener has proposed an update. This PR needs a human review before merging.
+
+### Watched set
+
+<!-- List the paths from the doc's <!-- gardener-watches: ... --> annotation, or the inferred watch set. -->
+
+- `<path>`
+- `<path>`
+
+### Summary of changes in the watched code since `<stamp_date>`
+
+<!-- Paraphrased bullets — one per relevant commit. Not a raw git log dump.
+Example:
+- `<short-sha>` — refactored `TokenSigner` to use HS512; doc still references HS256.
+- `<short-sha>` — removed the `legacy_refresh()` entrypoint the doc walks through.
+-->
+
+### What I changed in the doc
+
+<!-- One bullet per substantive edit in this PR's diff.
+Example:
+- Updated the signing-algorithm reference from HS256 to HS512 (section "Session lifecycle").
+- Removed the paragraph describing `legacy_refresh()` — the function no longer exists.
+-->
+
+### What I inferred (and where I might be wrong)
+
+<!-- Be specific about confidence. Reviewers need to know which edits are mechanical (high confidence) and which are interpretive (low confidence). Flag any place the gardener guessed.
+Example:
+- High confidence: the HS256 → HS512 swap — the commit message and diff are unambiguous.
+- Lower confidence: the replacement paragraph for `legacy_refresh()` — the commit that removed it didn't leave a replacement, so the new wording is a best guess from surrounding context.
+-->
+
+### Stamp
+
+Updated `<!-- last-verified: YYYY-MM-DD -->` to today's date. **Only merge this PR if the content changes above are correct** — a merged PR with wrong content under a fresh stamp is strictly worse than a missing stamp.
+
+### Review checklist
+
+- [ ] Do the "Summary of changes" bullets accurately reflect what happened in the watched code?
+- [ ] Do the "What I changed" edits accurately translate those changes into doc updates?
+- [ ] Is any low-confidence inference wrong? (Edit or revert before merging.)
+- [ ] Are there drifts in the watched code that the gardener missed? (Add them in a follow-up commit.)

--- a/doc-gardener/evals/evals.json
+++ b/doc-gardener/evals/evals.json
@@ -1,0 +1,64 @@
+{
+  "skill_name": "doc-gardener",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run doc gardener on this repo. Show me what's stale before you open anything.",
+      "expected_output": "A freshness report classifies the tracked docs into bump-only, needs-update, unwatched-stale, no-stamp, and orphaned buckets, with counts and per-doc lines. The skill asks via AskUserQuestion how to proceed (dry-run, bump-only, needs-update, or both) and defaults to dry-run on the first invocation. No PRs or branches are created before the user answers.",
+      "files": ["evals/files/mixed-staleness-repo/"],
+      "assertions": [
+        "The skill printed a freshness report with all classification buckets named (bump-only, needs-update, unwatched-stale, no-stamp, orphaned, skipped)",
+        "The tracked-doc set was built as the UNION of the baseline (AGENTS.md, README.md, SECURITY.md, docs/**, plans/**, adrs/**, etc. that exist) and tests/governance/freshness.conf — not just the config",
+        "CHANGELOG.md and any adrs/** entries were classified as 'skipped' rather than processed",
+        "Each listed doc in the report shows its path and its stamp date (or 'no stamp')",
+        "The skill invoked AskUserQuestion to get the user's decision",
+        "No branches matching 'doc-gardener/*' were created before the user answered",
+        "No PRs were opened before the user answered",
+        "The working tree was not modified before the user answered"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Garden the docs. Proceed with both bump-only and needs-update PRs.",
+      "expected_output": "One branch for the batched bump-only PR (contains only stamp edits — no prose changes) and one branch per needs-update doc (contains a drafted content update plus a stamp bump). The bump-only PR is opened as ready-for-review; the needs-update PRs are opened as Draft. Each PR body comes from the respective template and lists the watched set and summary of code changes. The skill refuses to run if the working tree is dirty.",
+      "files": ["evals/files/mixed-staleness-repo/"],
+      "assertions": [
+        "Exactly one branch named 'doc-gardener/stamp-bumps-<YYYY-MM-DD>' was created",
+        "The bump-only branch's diff contains ONLY changes to <!-- last-verified: ... --> lines — no prose edits",
+        "A separate branch named 'doc-gardener/update-<slug>-<YYYY-MM-DD>' was created for each needs-update doc",
+        "Each needs-update branch's diff includes both a stamp update AND substantive content edits",
+        "The bump-only PR was opened as ready-for-review (not draft)",
+        "Each needs-update PR was opened as Draft",
+        "Each PR body includes the watched set as a bulleted list",
+        "Each needs-update PR body includes a 'What I inferred' section distinguishing high- and low-confidence edits",
+        "No force-push was used; if a branch name collided, a -v2 suffix was used instead"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Run the gardener. I have some uncommitted work in this tree, but just skip past that — I want the report.",
+      "expected_output": "The skill refuses to perform any git operations on a dirty working tree, even when the user asks it to proceed. It tells the user to commit or stash first. It may still produce the read-only freshness report, but must not create branches, commits, or PRs.",
+      "files": ["evals/files/dirty-tree-repo/"],
+      "assertions": [
+        "The skill detected the dirty working tree (uncommitted changes or untracked files)",
+        "The skill explicitly refused to create branches, commits, or PRs and told the user to commit/stash first",
+        "No new branches were created",
+        "No commits were made",
+        "No PRs were opened",
+        "The skill did not cave to the user's 'skip past that' — it held the rule because the rationale (don't mix gardener output with unrelated changes) still applies"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Garden the docs. This repo has one doc with an explicit gardener-watches annotation pointing at files that haven't changed since the stamp, and one doc with no annotation at all.",
+      "expected_output": "The annotated doc is classified as bump-only (the gardener can prove nothing changed in its watch set). The unannotated doc is classified as unwatched-stale only if no watch set can be inferred via fenced code blocks, inline paths, or the directory-sibling fallback — otherwise it should be handled like a normal doc. The report is specific about which inference rule matched (or that none did).",
+      "files": ["evals/files/annotation-vs-inference-repo/"],
+      "assertions": [
+        "The annotated doc was classified as bump-only",
+        "For the unannotated doc, the report names which inference rule was applied (explicit annotation / fenced blocks / inline refs / directory sibling / none)",
+        "If no inference succeeded, the doc is classified as unwatched-stale and NO PR is opened for it",
+        "The unwatched-stale doc is explicitly surfaced in the 'needs your attention' section of the final report with a suggestion to add a gardener-watches annotation"
+      ]
+    }
+  ]
+}

--- a/doc-gardener/evals/files/README.md
+++ b/doc-gardener/evals/files/README.md
@@ -1,0 +1,15 @@
+# Eval fixtures
+
+Each subdirectory is a seed repo state for one eval case. Before running, copy the fixture into a fresh temp directory and `git init && git add -A && git commit -m "seed"`. For cases that need a history (to make `git log --since` return results), apply follow-up commits after the seed commit — see per-case notes below.
+
+- `mixed-staleness-repo/` — used by evals 1 and 2. Contains:
+  - `tests/governance/freshness.conf` listing 4 docs.
+  - `docs/security.md` with a stamp of ~200 days ago and a `gardener-watches` annotation pointing at a file that has NOT been touched since the stamp → expected **bump-only**.
+  - `docs/auth/session.md` with a stamp of ~200 days ago and watches pointing at `src/auth/*.py` → apply a follow-up commit editing one of those files so the gardener sees drift → expected **needs-update**.
+  - `docs/misc/notes.md` with a stale stamp, no annotation, no inferable paths → expected **unwatched-stale**.
+  - `docs/new-thing.md` with no stamp at all → expected **no-stamp**.
+  - `freshness.conf` also lists `docs/removed.md`, which does not exist → expected **orphaned**.
+
+- `dirty-tree-repo/` — used by eval 3. Same scaffolding as `mixed-staleness-repo`, but the fixture setup script leaves an untracked file (`scratch.md`) and an unstaged edit to a tracked file before the gardener is invoked.
+
+- `annotation-vs-inference-repo/` — used by eval 4. Contains exactly two docs: one with an explicit `<!-- gardener-watches: ... -->` annotation and one without. The unannotated doc has no fenced code blocks, no inline path references, and sits at the repo root (no directory sibling) — so inference should fail and it should be flagged as unwatched-stale.

--- a/doc-gardener/references/WATCH_ANNOTATIONS.md
+++ b/doc-gardener/references/WATCH_ANNOTATIONS.md
@@ -1,0 +1,74 @@
+# Watch annotations
+
+The `doc-gardener` skill decides whether a stale doc needs a content update by diffing the paths that doc "watches" against the doc's last-verified date. The most reliable way to tell it what to watch is an explicit annotation.
+
+## Syntax
+
+Anywhere in the doc — conventionally near the top, after the title — add:
+
+```markdown
+<!-- gardener-watches: <comma-separated paths> -->
+```
+
+Paths are relative to the repo root. They can be:
+
+- Files: `src/auth/session.py`
+- Directories (trailing slash required): `src/auth/`
+- Globs (shell-style, passed to `git ls-files`): `src/auth/**/*.py`
+
+Multiple annotations in one doc are allowed and concatenated. One per logical concern is clearest:
+
+```markdown
+<!-- gardener-watches: src/auth/ -->
+<!-- gardener-watches: docs/security.md -->
+```
+
+## A worked example
+
+**`docs/auth/session.md`** — a doc describing how sessions are created, stored, and expired.
+
+```markdown
+# Session lifecycle
+
+<!-- last-verified: 2026-03-14 -->
+<!-- gardener-watches: src/auth/session.py, src/auth/tokens.py, src/middleware/cookies.py -->
+
+Sessions are created in `create_session()` (src/auth/session.py), signed using...
+```
+
+When the gardener runs:
+
+1. Reads `last-verified: 2026-03-14`.
+2. Reads the watches: three specific files.
+3. Runs `git log --since="2026-03-14" -- src/auth/session.py src/auth/tokens.py src/middleware/cookies.py`.
+4. If the log is empty → bump the stamp (code unchanged).
+5. If the log has commits → draft a content update that summarizes those commits and adjusts the doc.
+
+## Choosing the watch set
+
+Some rules of thumb:
+
+- **Prefer specific files over whole directories.** `src/auth/session.py` gives the gardener a narrow signal; `src/` gives it noise. A doc that "watches" too much will be flagged as drifted by every unrelated change.
+- **Include the test file if the doc describes observable behavior.** Tests encode the contract the doc explains; a test change often means the doc's examples need updating.
+- **Include siblings the doc cross-references.** If the session doc says "see the token doc for details," include `docs/auth/tokens.md` — a change to the token doc may imply a change here too.
+- **Don't include generated files.** `db-schema.md` watching `src/generated/` is a false-positive machine — the generated code changes constantly. If the source of generation is meaningful, watch *that* instead.
+
+## Inference fallback (no annotation)
+
+If the doc has no `gardener-watches` annotation, the gardener will try in order:
+
+1. **Fenced code blocks** with filename hints: ```` ```python:src/auth/session.py ````
+2. **Inline path references** that look like tracked files: `src/auth/session.py`, `lib/tokens.js`.
+3. **Directory sibling**: a doc at `docs/auth/README.md` without other evidence is assumed to watch `src/auth/` (if present).
+4. **Well-known-file defaults**: for common repo-root docs (AGENTS.md, README.md, SECURITY.md, CONSTITUTION.md, etc.) the gardener falls back to a built-in watch set — e.g., AGENTS.md watches top-level source dirs; SECURITY.md watches `.github/workflows/` and auth/security folders; CONSTITUTION.md watches `tests/governance/rules/`. `CHANGELOG.md` and `adrs/**` are explicitly **skipped** — they're historical records, not drift-tracked docs. See the table in `SKILL.md` Step 3(e) for the full list.
+
+Inference is best-effort. Docs that matter should have explicit annotations — it's one line, it's permanent, and it makes the gardener's PRs predictable.
+
+## Opting out
+
+A doc listed in `tests/governance/freshness.conf` but without a watch set (no annotation, no inferable evidence) will be reported as `unwatched-stale` — flagged, but no PR created. Either:
+
+- Add a `gardener-watches` annotation.
+- Remove the doc from `freshness.conf` (opt out of tracking entirely).
+
+Do not leave a doc in `unwatched-stale` indefinitely — it's governance noise. Pick one.

--- a/governance-amend/SKILL.md
+++ b/governance-amend/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: governance-amend
+description: Amends an existing governance-kit setup — adds a new rule (or modifies an existing one) atomically across three artifacts that must land in the same commit: a new test script under tests/governance/rules/, a new Invariants subsection in CONSTITUTION.md, and an entry in the Evolution Log. Enforces the cardinal rule of governance-driven development — a rule and its enforcing test evolve together. Use when the user says "add a governance rule", "add a new invariant", "amend the constitution", "add a rule to CONSTITUTION.md", "update governance", or "evolve governance".
+license: MIT
+metadata:
+  author: governance-kit
+  version: "0.1"
+  companion-of: governance-bootstrap
+---
+
+# governance-amend
+
+The `governance-bootstrap` skill sets up the system of record. **This skill evolves it.**
+
+Governance-driven development's cardinal rule: *the constitution and the enforcing tests evolve together, in one commit.* This skill makes obeying that rule cheap and makes breaking it harder than following it.
+
+Every amendment this skill produces is three artifacts, staged atomically:
+
+1. A new (or updated) test script at `tests/governance/rules/<rule-name>.sh`.
+2. A new **Invariants** subsection in `CONSTITUTION.md`.
+3. A new entry in the `CONSTITUTION.md` **Evolution Log**.
+
+The skill does **not** commit. The user reviews and commits. But the three files are staged together and the skill refuses to finish with a partial amendment on disk.
+
+---
+
+## Activation flow
+
+### Step 1 — Verify the kit is installed
+
+Run in parallel:
+- `git rev-parse --show-toplevel` — confirm we're inside a git repo; capture the root.
+- Check for `<root>/CONSTITUTION.md`.
+- Check for `<root>/tests/governance/rules/` (directory).
+- Check for `<root>/tests/governance/run.sh` (executable).
+
+If any is missing, stop. The user needs `governance-bootstrap` first — don't pretend to amend something that isn't there. Tell them that explicitly.
+
+If `CONSTITUTION.md` lacks an **Invariants** or **Evolution Log** heading, still stop and tell the user which is missing — adding those sections is a kit-structure change, not an amendment, and belongs to bootstrap.
+
+### Step 2 — Collect the rule specification
+
+Most requests will already give you most of this — extract what you can from the user's prompt before asking. What you need:
+
+| Field | Constraint |
+|---|---|
+| **Rule name** | `[a-z][a-z0-9-]*[a-z0-9]`, ≤ 50 chars, matches the filename. No spaces, no uppercase. |
+| **Rule statement** | One sentence, present tense, naming what the code **must** or **must not** do. |
+| **Rationale** | Why this matters. Ideally references a concrete incident, policy, or constraint. |
+| **Check logic** | What the script actually inspects — files, patterns, paths, size thresholds, git state, etc. |
+| **Exceptions** | How approved deviations are documented. Default: no exceptions. Otherwise: waiver comment `governance: allow-<rule-name> <ticket>` or a named config file the rule reads. |
+
+If any field is ambiguous, **ask one question at a time** via `AskUserQuestion` or free text — don't dump a four-question form on the user. The most common blocker is "check logic" being too vague; iterate until you have something concrete enough to write bash that either passes or fails deterministically.
+
+**Check for collisions before you proceed:**
+- If `tests/governance/rules/<name>.sh` already exists → this is an **update**, not a new rule. Confirm with the user before overwriting, and treat the matching `CONSTITUTION.md` subsection as an update too (not a new insertion).
+- If `CONSTITUTION.md` already has a subsection whose header closely matches the proposed name → same thing, confirm.
+
+### Step 3 — Draft the test script
+
+Start from `assets/rule.template.sh`. Substitute:
+- `<rule-name>` → the chosen name.
+- The commented block → the actual check.
+
+The script must:
+- Source `../lib.sh` (the helpers from governance-bootstrap).
+- Call `rule_start "<name>"` at the top and `rule_end` at the bottom.
+- Call `require_git` if it touches `git ls-files` / `git grep`.
+- On every violation: call `violation "<file>:<line> — <specific-message>"`. A rule without a location in the message is less useful — always include one if the check is per-file or per-line.
+- Honor in-source waivers via `has_waiver "$file" "$line_no" "<rule-name>"` wherever violations are line-level, *unless* the user explicitly said no exceptions.
+
+**Before showing the draft to the user**, syntax-check it: `bash -n tests/governance/rules/<name>.sh`. If it fails, fix and re-check. Do not put syntactically broken bash in front of the user.
+
+Show the draft. Ask whether it's the check they want. Iterate. When the user signs off, write it to disk.
+
+### Step 4 — Smoke-test the script
+
+Run `bash tests/governance/rules/<name>.sh` against the current repo and capture the result.
+
+- **Exits 0 (passes)** — fine. The rule isn't flagging the current tree. Proceed.
+- **Exits 1 (fails)** — show the user the output and ask: is this a real violation that needs fixing now, or is the rule overly strict? They choose: (a) fix the code so the rule passes, or (b) loosen the rule, or (c) add a waiver comment for the specific existing cases.
+- **Any other exit code / crashes** — the rule has a bug. Back to Step 3.
+
+Never ship an amendment that crashes. Exit-1 is legitimate (that's a rule detecting a violation); exit-2+ or a stack trace is a broken rule.
+
+### Step 5 — Edit CONSTITUTION.md
+
+Two edits, both in the same file:
+
+**(a) Insert an Invariants subsection**, alphabetical by rule name (or append at the end if no natural alphabetical spot). Use `assets/invariant-section.template.md` as the shape:
+
+```markdown
+### <rule-name>
+
+- **Rule**: <one-sentence statement>.
+- **Rationale**: <why this matters, link incident if applicable>.
+- **Enforced by**: `tests/governance/rules/<rule-name>.sh`
+- **Exceptions**: <none | waiver comment format | config file reference>
+```
+
+Preserve everything else in the file verbatim. Use `Edit`, not `Write`.
+
+**(b) Append an Evolution Log entry** in the format the file already uses (check the existing entries — the format is per-project). Default template:
+
+```markdown
+- YYYY-MM-DD — @<git-config-user> — Add `<rule-name>`: <one-line summary>.
+```
+
+Use today's date from the session environment (not a placeholder).
+
+### Step 6 — Stage the three artifacts
+
+`git add tests/governance/rules/<rule-name>.sh CONSTITUTION.md`
+
+Then run `git status` to confirm the three changes are staged and nothing else unrelated is picked up. If other unstaged changes exist, leave them unstaged — they're not part of this amendment.
+
+**Do not commit.** The user commits, with a message they write. Suggest a commit message in the summary (Step 7) but don't run `git commit`.
+
+### Step 7 — Report to the user
+
+Print:
+- The rule name.
+- The three files changed (with paths).
+- A suggested commit message in Conventional Commits format: `feat(governance): add <rule-name> — <one-line summary>`
+- How to test locally: `bash tests/governance/run.sh <rule-name>`
+- A reminder that the pre-commit hook and CI workflow already pick up the new rule — no hook reinstall needed.
+
+---
+
+## Key design rules
+
+- **Three artifacts or nothing.** If you can only produce two of the three (e.g., the script is ambiguous and can't be written yet), stop and report. Do not edit `CONSTITUTION.md` for a rule whose test doesn't exist yet, and do not write a test whose invariant isn't in the constitution. That is exactly the drift this skill is built to prevent.
+
+- **Iterate on the check before staging.** The user should see the script, approve it, and see it pass a smoke test *before* anything is staged. A staged half-baked rule is worse than no rule — it invites a quick commit to "clean up git status" and ships broken governance.
+
+- **Never invent rationale.** If the user didn't give a reason, ask. "Because it's best practice" is not a rationale — governance derives authority from *named* incidents and *real* constraints. A rule without one is a speed bump nobody respects.
+
+- **Respect existing formatting.** The constitution is a living document. Match the indent style, list marker, and heading level conventions already in the file. Don't rewrite prose the user has been tending to.
+
+- **Don't commit.** The skill ends at `git add`, not `git commit`. The user's review is the final gate.
+
+## References
+
+- `assets/rule.template.sh` — the starter shape for a new rule script.
+- `assets/invariant-section.template.md` — the shape for the Invariants subsection.
+- `references/RULE_AUTHORING.md` — patterns and anti-patterns for writing good governance checks.

--- a/governance-amend/assets/invariant-section.template.md
+++ b/governance-amend/assets/invariant-section.template.md
@@ -1,0 +1,10 @@
+### <rule-name>
+
+- **Rule**: <one-sentence present-tense statement of what code must or must not do>.
+- **Rationale**: <why this matters — link to the incident, policy, or constraint that motivates it>.
+- **Enforced by**: `tests/governance/rules/<rule-name>.sh`
+- **Exceptions**: <one of:
+    - `none` — no deviations allowed.
+    - `Waiver comment: # governance: allow-<rule-name> <ticket-id>` — approved deviation, per-line.
+    - `Config file: tests/governance/<rule-name>.conf` — opt-in / opt-out via a tracked list.
+  >

--- a/governance-amend/assets/rule.template.sh
+++ b/governance-amend/assets/rule.template.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Rule: <one-sentence statement of the rule>
+# Rationale: <why this matters — link incident / policy / constraint if possible>
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "<rule-name>"    # MUST match the filename without .sh
+require_git                  # remove if the rule does not touch git
+
+# ──────────────────────────────────────────────────────────────
+# The check goes here. Patterns:
+#
+# (a) File-level existence/content:
+#   [[ -f "$ROOT/FILE" ]] || violation "FILE missing"
+#
+# (b) Per-line grep over tracked files:
+#   while IFS=: read -r file line_no match; do
+#       [[ -z "$file" ]] && continue
+#       has_waiver "$file" "$line_no" "<rule-name>" && continue
+#       violation "$file:$line_no — <what went wrong>"
+#   done < <(git grep -nE '<pattern>' -- '<pathspec>' 2>/dev/null || true)
+#
+# (c) Per-file metric:
+#   while IFS= read -r f; do
+#       [[ -z "$f" ]] && continue
+#       # compute metric and call violation if bad
+#   done < <(git ls-files -- '<pathspec>' 2>/dev/null || true)
+# ──────────────────────────────────────────────────────────────
+
+rule_end

--- a/governance-amend/evals/evals.json
+++ b/governance-amend/evals/evals.json
@@ -1,0 +1,48 @@
+{
+  "skill_name": "governance-amend",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We had an incident yesterday (INC-4117) — someone committed a private key file (*.pem) and we had to rotate half our credentials. Add a governance rule that blocks committing *.pem, *.key, and *.p12 files. Wire it into the constitution properly.",
+      "expected_output": "Three coordinated artifacts land together: (a) a new tests/governance/rules/<rule-name>.sh that blocks committing the listed key/cert extensions, (b) a new Invariants subsection in CONSTITUTION.md describing the rule and citing INC-4117, and (c) an Evolution Log entry with today's date summarizing the amendment. The rule is tested against a seeded repo with and without a .pem file. The skill does not commit the change without showing the three artifacts to the user.",
+      "files": ["evals/files/seeded-repo/"],
+      "assertions": [
+        "A new rule script was created under tests/governance/rules/ with a name matching the invariant (e.g., no-key-material.sh)",
+        "The rule script blocks at least these extensions: .pem, .key, .p12",
+        "The rule script has a rationale comment naming INC-4117",
+        "The rule script uses rule_start, violation, rule_end, and sources lib.sh (consistent with existing conventions)",
+        "CONSTITUTION.md gained a new Invariants subsection that names the rule and cites INC-4117",
+        "CONSTITUTION.md's Evolution Log gained a new entry dated today describing the amendment",
+        "Running tests/governance/run.sh on a repo containing a staged *.pem file produces a violation referencing the new rule",
+        "Running tests/governance/run.sh on a clean repo (no key files) exits 0 after the amendment",
+        "The skill presented the three artifacts (test, invariant section, evolution log entry) as a coordinated set before applying them — it did not apply them piecemeal"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "We want to raise our file-size-limit from 500 lines to 800 lines — the old limit is triggering too many false positives in the data-pipeline package. Amend the constitution.",
+      "expected_output": "The existing file-size-limit rule's limit is updated (either directly in the script or via the GOVERNANCE_FILE_SIZE_LIMIT env var convention). The constitution's invariant section for file-size-limit is updated to reflect 800. A new Evolution Log entry records the change with a reason (false positives in data-pipeline). No new rule script is created — this is an amendment to an existing rule, not a new one.",
+      "files": ["evals/files/repo-with-file-size-rule/"],
+      "assertions": [
+        "The existing file-size-limit rule script was edited (not duplicated)",
+        "The new limit value (800) appears in the rule script or its env var default",
+        "The CONSTITUTION.md invariant for file-size-limit references 800 (not 500)",
+        "A new Evolution Log entry was added with today's date describing the limit change and citing the data-pipeline false-positive reason",
+        "No new rule script file was created"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Remove the no-console-log rule — we're keeping structured logs via pino and the rule is noisy. Do it properly.",
+      "expected_output": "Three coordinated deletions/edits: the rule script is removed, the corresponding Invariants subsection is removed from CONSTITUTION.md, and an Evolution Log entry records the removal with a reason (structured logging via pino makes the rule redundant). The skill warns if any other docs or code references the removed rule by name.",
+      "files": ["evals/files/repo-with-console-log-rule/"],
+      "assertions": [
+        "tests/governance/rules/no-console-log.sh no longer exists",
+        "The Invariants section of CONSTITUTION.md no longer describes no-console-log",
+        "A new Evolution Log entry dated today records the removal with the stated reason",
+        "Running tests/governance/run.sh still exits 0 on the seeded repo after removal",
+        "If the repo contains any references to the removed rule name (e.g., in a README or CI doc), the skill surfaced them to the user rather than silently leaving dangling references"
+      ]
+    }
+  ]
+}

--- a/governance-amend/evals/files/README.md
+++ b/governance-amend/evals/files/README.md
@@ -1,0 +1,9 @@
+# Eval fixtures
+
+Each subdirectory is a seed repo state for one eval case. Before running, copy the fixture, `git init && git add -A && git commit -m "seed"`, and point the skill at that directory.
+
+- `seeded-repo/` — a repo that has already run `governance-bootstrap` (has `tests/governance/`, `CONSTITUTION.md`, hooks). No key-material rule yet. For eval 1.
+- `repo-with-file-size-rule/` — seeded repo with `tests/governance/rules/file-size-limit.sh` at the default 500-line limit. For eval 2.
+- `repo-with-console-log-rule/` — seeded repo with `tests/governance/rules/no-console-log.sh` enabled and documented in CONSTITUTION.md. For eval 3.
+
+All three share the same scaffolding; they differ only in which rules are pre-installed and what the constitution records.

--- a/governance-amend/references/RULE_AUTHORING.md
+++ b/governance-amend/references/RULE_AUTHORING.md
@@ -1,0 +1,92 @@
+# Writing good governance rules
+
+The constitution is only as strong as the rules inside it. A bad rule — one that fires noisily, catches nothing real, or can't be reasoned about — gets waived, disabled, or quietly removed. Here are the patterns to aim for and the anti-patterns to avoid.
+
+## Aim for
+
+**Deterministic.** Given the same repo state, the rule produces the same verdict every time. No network calls, no clock-dependent logic (except freshness rules that are *intentionally* clock-dependent), no parallelism races.
+
+**Fast.** Every rule runs on every commit. A slow rule will be the reason someone adds `SKIP_GOVERNANCE=1` to their muscle memory. Target under a second. If a rule is unavoidably slow (dependency scan, type check), run it in CI only — not the pre-commit hook.
+
+**Specific.** When a rule fires, the message must tell the developer *what* failed, *where*, and *why*. `"✗ bad code"` is worthless. `"src/auth/session.py:47 — pdb import left in source"` tells the developer exactly what to do.
+
+**Minimal scope.** One rule, one concern. `no-secrets` scans for secrets. `dotenv-gitignored` checks `.env` handling. Do not combine them. A fused rule's failure is ambiguous.
+
+**Waivable when warranted.** If legitimate exceptions exist, support the `governance: allow-<rule>` comment waiver. If the rule is genuinely absolute (no secrets, ever), say so explicitly in the rationale and skip the waiver logic.
+
+## Avoid
+
+**Stylistic opinions dressed as governance.** Indent style, quote style, import ordering — these belong in a formatter (prettier, black, gofmt), not a governance rule. Mixing format preferences into the constitution erodes the authority of the real invariants.
+
+**Rules without rationale.** "We just always do it this way" is not a reason. Any rule added without a named incident, policy, or constraint gets deleted the first time it's inconvenient.
+
+**Rules that lie.** A check that claims to enforce X but actually enforces a weak proxy for X is worse than no check — it creates false confidence. If you can only enforce an approximation, say so in the rationale, and name the gap.
+
+**Checks that double as documentation.** If a rule's failure message is "see docs/SECURITY.md for why this matters", fine — but the message must *first* say what's wrong and where. Never make the developer read documentation to understand which line failed.
+
+**Non-idempotent logic.** A rule that modifies the repo while checking is a bug. Governance reads; remediation writes. Keep them separate. (If the rule needs writable scratch space, use `mktemp -d`.)
+
+**Reaching across the network.** Network calls from a pre-commit hook mean a flaky hook, which means developers skip it, which means governance runs only in CI, which means it doesn't block broken code locally. If you need a remote check (e.g., CVE database), run it in CI only.
+
+## Patterns by rule class
+
+### Existence / content checks (`*-exists`)
+
+- Check at the repo root, or in a small known set of locations (`X.md`, `docs/X.md`, `.github/X.md`).
+- Validate a minimum size or a minimum content signal (e.g., "contains an email address").
+- Fail fast on the first missing condition — no reason to keep checking if the file is absent.
+
+### Pattern-scan checks (`no-*`)
+
+- Use `git grep` (not raw `grep`) so `.gitignore` is respected.
+- Exclude the rule file itself from its own scan (common foot-gun).
+- Support `has_waiver` per-line for false-positive escape.
+- Anchor patterns carefully — `\beval\b` catches `eval(`, `my_eval(`, and `evaluate(`. Make sure that's what you want.
+
+### Metric checks (`*-limit`)
+
+- Expose the limit as an env var override (`GOVERNANCE_<RULE>_LIMIT`). Projects need to tune without forking the script.
+- Report the actual value vs. the limit in the violation message. "file X has 612 lines (limit: 500)" is actionable; "file X is too large" isn't.
+
+### Structural checks (`*-hardened`, `*-current`)
+
+- These often have sub-checks. Name each sub-check in the violation message so the developer knows *which* part failed.
+- If any sub-check fails, report all of them before exiting — don't bail on the first one. Developers want the full list.
+
+## A concrete anti-pattern
+
+Bad:
+
+```bash
+# Rule: code quality is good
+while read f; do
+    # if file is ugly, fail
+    grep -q "bad" "$f" && violation "bad code"
+done < <(ls)
+```
+
+Wrong on five axes: no rationale, non-specific rule statement, uses `ls` (includes gitignored files and directories), violation message has no location, pattern is meaningless.
+
+Good:
+
+```bash
+#!/usr/bin/env bash
+# Rule: no `pdb.set_trace()` left in tracked Python source.
+# Rationale: pdb breakpoints committed to prod caused INC-2041 — the service
+# stalled on every request waiting for a stdin that didn't exist.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-pdb-breakpoints"
+require_git
+
+while IFS=: read -r file line_no match; do
+    [[ -z "$file" ]] && continue
+    [[ "$file" == tests/* ]] && continue
+    has_waiver "$file" "$line_no" "no-pdb-breakpoints" && continue
+    violation "$file:$line_no — pdb breakpoint: ${match:0:80}"
+done < <(git grep -nE 'pdb\.set_trace\(\)|breakpoint\(\)' -- '*.py' 2>/dev/null || true)
+
+rule_end
+```
+
+Named, justified with a specific incident, scoped to the relevant language, excludes tests (where breakpoints during development are fine), supports waivers, shows the developer the exact line.

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: governance-bootstrap
+description: Bootstraps governance-driven development in a repository — scaffolds a CONSTITUTION.md, a test suite under tests/governance/ that enforces the constitution, pre-commit and commit-msg hooks (skippable), and a GitHub Actions workflow. Offers a menu of ready-made rules across five categories (Foundation, Security, System of record, Commit hygiene, Quality) including Conventional Commits, secret scanning, .env hygiene, GitHub Actions hardening, AGENTS.md / ARCHITECTURE.md / SECURITY.md checks, broken-link detection, doc freshness, and merge-conflict-marker detection. Use when the user wants to set up governance, add a constitution, enforce invariants, install conventional commits, harden workflows, or when they say "bootstrap governance", "set up governance tests", "governance-driven development", or reference a constitution document.
+license: MIT
+metadata:
+  author: governance-kit
+  version: "0.1"
+---
+
+# governance-bootstrap
+
+This skill sets up **governance-driven development** in the current repository:
+
+1. A `CONSTITUTION.md` at the repo root — the evolving source of truth for rules, guidelines, and invariants.
+2. Machine-enforced tests under `tests/governance/` — every rule in the constitution has a corresponding test.
+3. A pre-commit hook — runs `tests/governance/` before commits, with `SKIP_GOVERNANCE=1` and `git commit --no-verify` as escape hatches.
+4. A GitHub Actions workflow at `.github/workflows/governance.yml` — same tests, enforced in CI on every PR.
+
+Governance evolves: new rules get added to `CONSTITUTION.md` *and* to `tests/governance/` together. The constitution without the tests is just a wishlist.
+
+---
+
+## Activation flow
+
+Run these steps in order. Do not skip steps unless noted.
+
+### Step 1 — Survey the repository
+
+Before touching anything, run these in parallel:
+
+- `git rev-parse --show-toplevel` to confirm this is a git repo and find the root.
+- `ls -la` at the root.
+- Check for stack markers: `package.json`, `pyproject.toml`, `setup.py`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `build.gradle`, `Gemfile`.
+- Check for existing `CONSTITUTION.md`, `tests/governance/`, `.github/workflows/governance.yml`, `.git/hooks/pre-commit`.
+
+If this is not a git repo, stop and tell the user — governance-bootstrap requires git.
+
+If artifacts already exist, report what's there and ask whether to **augment** (add missing pieces, preserve existing) or **overwrite** (fresh start). Default to augment.
+
+### Step 2 — Classify the project stack
+
+Pick exactly one primary stack from the markers:
+
+| Marker                              | Stack     | Test runner                  |
+| ----------------------------------- | --------- | ---------------------------- |
+| `pyproject.toml` / `requirements.txt` | python    | pytest                       |
+| `package.json`                      | node      | detect jest / vitest / node  |
+| `go.mod`                            | go        | `go test`                    |
+| `Cargo.toml`                        | rust      | `cargo test`                 |
+| none of the above                   | generic   | bash                         |
+
+Multiple markers → pick the one the user points to. If unclear, ask once.
+
+**Default** for every stack: also install the universal **bash** test runner from `assets/tests-bash/`. Bash tests are language-agnostic (grep/find/wc based) and work anywhere. The native test runner is a second, stack-idiomatic copy that lets governance rules integrate with the project's normal test command. The user picks in Step 3 whether to install native tests, bash tests, or both.
+
+### Step 3 — Offer the rule menu
+
+The rule catalog is five categories, presented across **two `AskUserQuestion` calls** (the tool caps at four questions per call). Use `multiSelect: true` for every question. "Other" appears automatically — if the user picks it and describes a rule, generate a new `.sh` file under `tests/governance/rules/` following the template in `references/RULES_CATALOG.md` and add a matching Invariants subsection to `CONSTITUTION.md`.
+
+**Always installed — do not put in the menu:**
+- `no-merge-conflict-markers` — no `<<<<<<<` / `=======` / `>>>>>>>` in any tracked file. Zero false positives, zero config. Install unconditionally.
+
+**First `AskUserQuestion` call — four questions:**
+
+**Q1 — "Which foundation rules should the constitution enforce?"** (header: `Foundation`)
+- `constitution-exists` — CONSTITUTION.md exists, non-empty, ≥ 10 lines. *(Recommended — the meta-rule)*
+- `readme-exists` — README.md exists with a heading and ≥ 30 words.
+- `license-exists` — A LICENSE (or variant) exists at the repo root.
+- `agents-md-exists` — AGENTS.md exists at the repo root, 30–250 lines, with ≥ 3 links to other docs. *(Recommended — the harness-engineering agent entry point)*
+
+**Q2 — "Which security rules should the constitution enforce?"** (header: `Security`)
+- `no-secrets` — Heuristic scan for AWS / GCP / GitHub / Slack / Stripe / private-key patterns. *(Recommended)*
+- `dotenv-gitignored` — `.env` is listed in `.gitignore` and not tracked. *(Recommended)*
+- `security-md-exists` — `SECURITY.md` (root, `docs/`, or `.github/`) with a contact email or URL.
+- `workflows-hardened` — GitHub Actions workflows declare a `permissions:` block and pin third-party actions to a commit SHA. *(Recommended)*
+
+**Q3 — "Which system-of-record rules should the constitution enforce?"** (header: `SystemOfRecord`)
+- `architecture-doc-exists` — `ARCHITECTURE.md` (root or `docs/`) exists, ≥ 20 lines.
+- `no-broken-internal-doc-links` — Markdown links to local paths resolve. *(Recommended)*
+- `doc-freshness` — Docs opted into `tests/governance/freshness.conf` carry a `<!-- last-verified: YYYY-MM-DD -->` marker within the last 90 days.
+- `ci-workflow-exists` — At least one non-governance workflow exists under `.github/workflows/`.
+
+**Q4 — "Which commit-hygiene rules should the constitution enforce?"** (header: `CommitHygiene`)
+- `conventional-commits` — Commit messages match `<type>(scope)?!?: subject`. *(Recommended — installs a `commit-msg` hook)*
+- `no-orphan-todos` — Every `TODO` / `FIXME` references `#123` or `ABC-123`.
+
+*(This question has only 2 options; that's valid. Do not pad with filler.)*
+
+**Second `AskUserQuestion` call — one question:**
+
+**Q5 — "Which quality rules should the constitution enforce?"** (header: `Quality`)
+- `no-debug-statements` — No stray `console.log`, `debugger`, `breakpoint()`, `pdb`, `dbg!`.
+- `file-size-limit` — No source file exceeds 500 lines (configurable).
+- `no-large-files` — No tracked file exceeds 5 MB (configurable). *(Recommended)*
+- `no-committed-build-artifacts` — No `__pycache__`, `*.pyc`, `node_modules/`, `dist/`, `build/`, `target/`, `out/`, `.DS_Store` etc. are tracked. *(Recommended)*
+
+For each selected rule, copy `assets/tests-bash/rules/<rule>.sh` into `tests/governance/rules/` in the target repo. Also copy `assets/tests-bash/rules/no-merge-conflict-markers.sh` regardless of what the user picked.
+
+If the user selects `conventional-commits`, remember that `commit-msg` will also be installed in Step 6.
+
+If the user selects `doc-freshness`, also copy `assets/freshness.conf` to `tests/governance/freshness.conf`. The seed file is commented — every path is opt-in by uncommenting. The companion `doc-gardener` skill also checks a built-in baseline set of well-known docs (AGENTS.md, README.md, SECURITY.md, docs/**, plans/**, adrs/**) on top of this config, so the seed only lists paths the baseline might miss.
+
+If the user asks for rules that exist in `references/RULES_CATALOG.md` under "Also available" (e.g. `env-example-current`, `no-curl-bash-pipe`, `docs-dir-minimum`), copy those too — they are supported, just not in the default menu.
+
+### Step 4 — Write the constitution
+
+Copy `assets/CONSTITUTION.template.md` to `<repo-root>/CONSTITUTION.md`. Then tailor it:
+
+- Fill the **Principles** section with 3-5 high-level principles inferred from the rules the user picked, plus a generic starter like "Changes to the constitution require changes to the enforcing tests."
+- Under **Invariants**, list one subsection per selected rule. Each subsection must have:
+  - **Rule** (one-sentence statement)
+  - **Rationale** (why this matters)
+  - **Enforced by** (path to the test file, e.g. `tests/governance/rules/no-secrets.sh`)
+  - **Exceptions** (how to document approved deviations)
+- Leave the **Evolution Log** section with a template entry and a note that each amendment needs a commit.
+
+Do not invent principles the user did not pick. It is better to ship a short constitution than a bloated one.
+
+### Step 5 — Install the test runner
+
+Copy `assets/tests-bash/run.sh` to `tests/governance/run.sh` and mark it executable (`chmod +x`). This is the entrypoint — it discovers and runs every `*.sh` in `tests/governance/rules/`, prints a summary, and exits non-zero on any failure.
+
+Copy `assets/tests-bash/lib.sh` to `tests/governance/lib.sh` — shared helpers (pass/fail/skip output, `tracked_files` helper that respects `.gitignore`).
+
+If the user wants **native** tests in addition to bash, read `references/NATIVE_TESTS.md` for the port pattern for their stack (pytest / jest / go test). Generate the native test file(s) inline — do not invent a separate `run.sh` for the native side; the project's existing test runner (`pytest tests/governance`, `npx jest tests/governance`, `go test ./tests/governance/...`) is the entrypoint.
+
+### Step 6 — Install the git hooks
+
+Copy `assets/pre-commit` to `.git/hooks/pre-commit` and `chmod +x` it. The hook:
+- Skips if `SKIP_GOVERNANCE=1` is set.
+- Runs `tests/governance/run.sh` (bash mode) and/or the native command (if native tests are installed — detect and run both if present).
+- On failure, prints the rule that failed, the `SKIP_GOVERNANCE=1 git commit` escape hatch, and `git commit --no-verify` as the nuclear option.
+
+**If, and only if, the user selected `conventional-commits`**, also copy `assets/commit-msg` to `.git/hooks/commit-msg` and `chmod +x` it. This hook validates the pending commit message against the Conventional Commits regex before the commit is finalized. It honors the same `SKIP_GOVERNANCE=1` / `--no-verify` escape hatches.
+
+If the project uses `husky` or the `pre-commit` framework, *do not* overwrite `.git/hooks/pre-commit`. Instead, add a hook entry to the existing config (ask the user which framework they use). See `references/NATIVE_TESTS.md` for the husky / pre-commit.com snippets. The `commit-msg` hook registers analogously (`npx husky add .husky/commit-msg '...'` for husky).
+
+### Step 7 — Install the CI workflow
+
+Copy `assets/governance.yml` to `.github/workflows/governance.yml`. Adjust the test-runner step based on the stack chosen in Step 2. The workflow runs on `push` to `main` and on every `pull_request`, and it never skips — CI is the backstop the pre-commit hook can be bypassed around.
+
+### Step 8 — Report to the user
+
+Print a concise summary:
+- Stack detected.
+- Rules installed (with file paths).
+- How to run locally: `bash tests/governance/run.sh`.
+- How to skip the hook: `SKIP_GOVERNANCE=1 git commit ...` or `git commit --no-verify`.
+- Reminder: **constitution amendments must land with their test.** Point to `references/RULES_CATALOG.md` for the template.
+
+Do **not** commit the new files. Leave that to the user — the first commit of their governance system should be intentional, and the pre-commit hook is now active.
+
+---
+
+## Key design rules for this skill
+
+- **The constitution and the tests evolve together.** Never add a rule to the constitution without a test. Never add a test without a rule. If the user asks to add one in isolation, push back and do both.
+- **Escape hatches are a feature, not a bug.** `SKIP_GOVERNANCE=1` exists because governance that blocks emergency hotfixes will get ripped out. CI enforces the rule even when the hook is skipped, which is the right layering.
+- **Bash-first, native as enhancement.** Bash tests work in any repo, in any CI, without install steps. Native tests (pytest etc.) are nicer DX but add friction. Default to bash; offer native.
+- **No invented rules.** When writing the constitution, only include rules the user selected. Governance loses authority the moment it contains rules nobody signed off on.
+
+## References
+
+- `references/RULES_CATALOG.md` — full list of ready-made rules with descriptions, and the template for adding new ones.
+- `references/NATIVE_TESTS.md` — how to port bash rules to pytest / jest / go test, and husky / pre-commit-framework snippets.

--- a/governance-bootstrap/assets/CONSTITUTION.template.md
+++ b/governance-bootstrap/assets/CONSTITUTION.template.md
@@ -1,0 +1,59 @@
+# Constitution
+
+This document is the source of truth for the rules, guidelines, and invariants that govern development in this repository. Every rule here is enforced by an executable test under `tests/governance/`. A rule with no enforcing test is not a rule — it is a wish.
+
+> **The cardinal rule:** Amendments to this constitution must land in the same commit as the change to its enforcing test. No exceptions.
+
+## Principles
+
+<!-- High-level philosophy. 3-5 statements max. These are not enforced automatically — they frame the invariants below and guide what rules belong here. -->
+
+- Changes to this constitution must land with a corresponding change to the enforcing tests.
+- Escape hatches exist (`SKIP_GOVERNANCE=1`, `git commit --no-verify`) — but every skipped commit is still checked in CI.
+- Governance rules should fail loudly and cheaply. If a rule cannot be mechanically checked, it does not belong here.
+
+<!-- Replace / extend with project-specific principles. -->
+
+## Invariants
+
+<!--
+For each invariant, use this structure:
+
+### <short name>
+
+- **Rule**: one-sentence statement of the rule, in the present tense.
+- **Rationale**: why this matters — ideally linked to a past incident or concrete cost.
+- **Enforced by**: relative path to the test file.
+- **Exceptions**: how approved deviations are documented (e.g., `# governance: allow-secret <ticket-id>`).
+-->
+
+### Example — constitution-exists (meta-rule)
+
+- **Rule**: A `CONSTITUTION.md` exists at the repo root and is non-empty.
+- **Rationale**: Governance without a discoverable source of truth is tribal knowledge.
+- **Enforced by**: `tests/governance/rules/constitution-exists.sh`
+- **Exceptions**: none.
+
+<!-- governance-bootstrap will inject one subsection per rule the user selected. -->
+
+## Amendment process
+
+1. Open a PR that modifies this file **and** `tests/governance/rules/` in the same commit.
+2. The PR description states *what* changed and *why* — link the incident, RFC, or discussion that motivated it.
+3. Add an entry to the **Evolution Log** below.
+4. At least one reviewer with governance authority approves.
+
+## Evolution Log
+
+<!-- Append, do not rewrite history. Format: YYYY-MM-DD — <author> — <one-line summary>. Link the PR. -->
+
+- YYYY-MM-DD — @you — Initial constitution bootstrapped via governance-bootstrap.
+
+## Escape hatches
+
+Governance is enforced at two layers:
+
+1. **Pre-commit hook** — runs `tests/governance/run.sh` before each commit. Skip with `SKIP_GOVERNANCE=1 git commit ...` or `git commit --no-verify` when a hotfix cannot wait.
+2. **CI workflow** — `.github/workflows/governance.yml` runs the same tests on every PR and push to the default branch. CI cannot be skipped from a developer machine.
+
+The hook is for speed; CI is for enforcement. If a commit lands with the hook skipped, CI will catch it.

--- a/governance-bootstrap/assets/commit-msg
+++ b/governance-bootstrap/assets/commit-msg
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Governance commit-msg hook — validates the pending commit message.
+# Currently runs only the conventional-commits rule (if installed).
+#
+# Escape hatches:
+#   SKIP_GOVERNANCE=1 git commit ...   # telegraphs intent; CI still enforces
+#   git commit --no-verify             # skips all hooks
+
+set -u
+
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then
+    exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+RULE="$ROOT/tests/governance/rules/conventional-commits.sh"
+
+if [[ ! -x "$RULE" ]]; then
+    # conventional-commits not installed; nothing to enforce at commit-msg time.
+    exit 0
+fi
+
+if ! bash "$RULE" "$1"; then
+    cat >&2 <<EOF
+
+────────────────────────────────────────
+✗ Commit message blocked by governance.
+
+Conventional Commits format:
+    <type>(<optional-scope>)!?: <subject>
+
+Types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
+Example: fix(auth): reject tokens with empty 'sub' claim
+
+Bypass (CI will still enforce on PR):
+    SKIP_GOVERNANCE=1 git commit ...
+    git commit --no-verify
+────────────────────────────────────────
+EOF
+    exit 1
+fi
+
+exit 0

--- a/governance-bootstrap/assets/freshness.conf
+++ b/governance-bootstrap/assets/freshness.conf
@@ -1,0 +1,19 @@
+# tests/governance/freshness.conf
+#
+# One path per line, relative to the repo root. Blank lines and lines
+# starting with '#' are ignored. The `doc-freshness` rule checks that
+# each listed file carries a recent `<!-- last-verified: YYYY-MM-DD -->`
+# marker (default window: 90 days; override with GOVERNANCE_FRESHNESS_DAYS).
+#
+# The `doc-gardener` skill ALSO checks a built-in baseline set of
+# well-known docs — AGENTS.md, README.md, SECURITY.md, CONTRIBUTING.md,
+# CONSTITUTION.md, docs/**, plans/**, adrs/** — whether or not they
+# appear here. This file is for paths the baseline misses:
+# runbooks, per-package READMEs, non-standard locations, etc.
+#
+# Examples (uncomment to opt in):
+#
+# ops/runbooks/incident-response.md
+# services/api/README.md
+# services/worker/DEPLOY.md
+# docs/data-dictionary.md

--- a/governance-bootstrap/assets/governance.yml
+++ b/governance-bootstrap/assets/governance.yml
@@ -1,0 +1,56 @@
+name: Governance
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so git-grep-based rules can inspect all tracked files.
+          fetch-depth: 0
+
+      - name: Run bash governance rules
+        if: hashFiles('tests/governance/run.sh') != ''
+        run: bash tests/governance/run.sh
+
+      # ─── Native test runners (remove any that don't apply to this repo) ───
+
+      - name: Set up Python
+        if: hashFiles('tests/governance/test_*.py') != ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run pytest governance rules
+        if: hashFiles('tests/governance/test_*.py') != ''
+        run: |
+          python -m pip install --upgrade pip pytest
+          pytest tests/governance -q
+
+      - name: Set up Node
+        if: hashFiles('tests/governance/*.test.*') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Run jest/vitest governance rules
+        if: hashFiles('tests/governance/*.test.*') != ''
+        run: |
+          npm ci --ignore-scripts || npm install --ignore-scripts
+          npx jest tests/governance 2>/dev/null || npx vitest run tests/governance
+
+      - name: Set up Go
+        if: hashFiles('tests/governance/*_test.go') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run go test governance rules
+        if: hashFiles('tests/governance/*_test.go') != ''
+        run: go test ./tests/governance/...

--- a/governance-bootstrap/assets/pre-commit
+++ b/governance-bootstrap/assets/pre-commit
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Governance pre-commit hook — installed by governance-bootstrap.
+# Runs tests/governance/ before allowing a commit.
+#
+# Escape hatches (in order of preference):
+#   SKIP_GOVERNANCE=1 git commit ...    # telegraphs intent; CI still enforces
+#   git commit --no-verify              # skips all hooks; CI still enforces
+
+set -u
+
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then
+    echo "⊘ governance pre-commit skipped (SKIP_GOVERNANCE=1)" >&2
+    exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+BASH_RUNNER="$ROOT/tests/governance/run.sh"
+
+ran_something=0
+fail=0
+
+# Bash runner (universal)
+if [[ -x "$BASH_RUNNER" ]]; then
+    ran_something=1
+    bash "$BASH_RUNNER" || fail=1
+fi
+
+# Native test runners — if the project has governance tests in its native
+# framework, run them too. These detectors are intentionally loose; rip out
+# any that don't apply.
+if [[ -d "$ROOT/tests/governance" ]]; then
+    # pytest
+    if compgen -G "$ROOT/tests/governance/test_*.py" >/dev/null && command -v pytest >/dev/null 2>&1; then
+        ran_something=1
+        (cd "$ROOT" && pytest tests/governance -q) || fail=1
+    fi
+    # jest / vitest (package.json declares it)
+    if [[ -f "$ROOT/package.json" ]] && compgen -G "$ROOT/tests/governance/*.test.*" >/dev/null; then
+        ran_something=1
+        if command -v npx >/dev/null 2>&1; then
+            (cd "$ROOT" && npx --no-install jest tests/governance 2>/dev/null \
+                || npx --no-install vitest run tests/governance 2>/dev/null) || fail=1
+        fi
+    fi
+    # go test
+    if [[ -f "$ROOT/go.mod" ]] && compgen -G "$ROOT/tests/governance/*_test.go" >/dev/null; then
+        ran_something=1
+        (cd "$ROOT" && go test ./tests/governance/...) || fail=1
+    fi
+fi
+
+if [[ $ran_something -eq 0 ]]; then
+    echo "⊘ no governance tests found — hook is a no-op" >&2
+    exit 0
+fi
+
+if [[ $fail -ne 0 ]]; then
+    cat >&2 <<EOF
+
+────────────────────────────────────────
+✗ Commit blocked by governance.
+
+Fix the violations above, or bypass (CI will still enforce):
+    SKIP_GOVERNANCE=1 git commit ...
+    git commit --no-verify
+────────────────────────────────────────
+EOF
+    exit 1
+fi
+
+exit 0

--- a/governance-bootstrap/assets/tests-bash/lib.sh
+++ b/governance-bootstrap/assets/tests-bash/lib.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Shared helpers for governance rule tests.
+# Source this from every rule file: `source "$(dirname "$0")/../lib.sh"`
+
+set -u
+
+# Color output only when stdout is a terminal.
+if [[ -t 1 ]]; then
+    readonly C_RED=$'\033[31m'
+    readonly C_GREEN=$'\033[32m'
+    readonly C_YELLOW=$'\033[33m'
+    readonly C_BOLD=$'\033[1m'
+    readonly C_RESET=$'\033[0m'
+else
+    readonly C_RED=""
+    readonly C_GREEN=""
+    readonly C_YELLOW=""
+    readonly C_BOLD=""
+    readonly C_RESET=""
+fi
+
+# Track violations for the current rule. Each rule should call `rule_start`
+# at the top, then `violation` for each problem found, then `rule_end` at the
+# bottom. `rule_end` exits 0 if no violations, 1 otherwise.
+_RULE_NAME=""
+_VIOLATION_COUNT=0
+_VIOLATIONS=()
+
+rule_start() {
+    _RULE_NAME="$1"
+    _VIOLATION_COUNT=0
+    _VIOLATIONS=()
+}
+
+violation() {
+    _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1))
+    _VIOLATIONS+=("$1")
+}
+
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then
+        printf "%s✓%s %s\n" "$C_GREEN" "$C_RESET" "$_RULE_NAME"
+        exit 0
+    fi
+    printf "%s✗ %s%s (%d violation%s)\n" "$C_RED" "$_RULE_NAME" "$C_RESET" \
+        "$_VIOLATION_COUNT" "$([[ $_VIOLATION_COUNT -eq 1 ]] || echo s)"
+    for v in "${_VIOLATIONS[@]}"; do
+        printf "    %s\n" "$v"
+    done
+    exit 1
+}
+
+# Emit tracked files (respects .gitignore), optionally filtered by a pathspec.
+# Usage: tracked_files                → all tracked files
+#        tracked_files '*.py'         → all tracked .py files
+#        tracked_files ':!vendor/**'  → all tracked files excluding vendor/
+tracked_files() {
+    if [[ $# -eq 0 ]]; then
+        git ls-files
+    else
+        git ls-files "$@"
+    fi
+}
+
+# Exit with skip status if we're not inside a git working tree.
+require_git() {
+    if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+        printf "%s⊘%s %s (not a git repo — skipped)\n" \
+            "$C_YELLOW" "$C_RESET" "$_RULE_NAME"
+        exit 0
+    fi
+}
+
+# Allow in-source waivers. Rules that support exceptions should grep for
+# `governance: allow-<rule-name>` on the violating line and skip it.
+# Example: `foo = "AKIA..."  # governance: allow-no-secrets TICKET-123`
+has_waiver() {
+    local file="$1" line_no="$2" rule="$3"
+    sed -n "${line_no}p" "$file" | grep -q "governance: allow-${rule}"
+}

--- a/governance-bootstrap/assets/tests-bash/rules/agents-md-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/agents-md-exists.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Rule: AGENTS.md exists at the repo root and functions as an index (not a manual).
+# Rationale: The harness-engineering pattern — a brief, link-heavy entry point for
+# agents that points at deeper docs. Enforcing size keeps it from drifting into a
+# god-file that nobody reads.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "agents-md-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+FILE="$ROOT/AGENTS.md"
+
+if [[ ! -f "$FILE" ]]; then
+    violation "AGENTS.md not found at repo root"
+    rule_end
+fi
+
+lines=$(wc -l < "$FILE" | tr -d ' ')
+MIN_LINES="${GOVERNANCE_AGENTS_MD_MIN:-30}"
+MAX_LINES="${GOVERNANCE_AGENTS_MD_MAX:-250}"
+
+if [[ $lines -lt $MIN_LINES ]]; then
+    violation "AGENTS.md has $lines lines — looks like a stub (min: $MIN_LINES)"
+fi
+
+if [[ $lines -gt $MAX_LINES ]]; then
+    violation "AGENTS.md has $lines lines — drifting toward a manual (max: $MAX_LINES). Move detail into linked docs."
+fi
+
+# It's an *index*, so it must actually link to other repo files.
+# Count markdown links to local paths (not http/https/mailto).
+link_count=$(grep -oE '\]\([^)]+\)' "$FILE" 2>/dev/null \
+    | grep -cvE '\((https?://|mailto:|tel:|#)' 2>/dev/null || true)
+link_count="${link_count:-0}"
+MIN_LINKS="${GOVERNANCE_AGENTS_MD_MIN_LINKS:-3}"
+if [[ $link_count -lt $MIN_LINKS ]]; then
+    violation "AGENTS.md has $link_count internal links — an index should link out (min: $MIN_LINKS)"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/architecture-doc-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/architecture-doc-exists.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Rule: ARCHITECTURE.md exists and is substantive.
+# Rationale: The harness-engineering "top-level map of domains and package
+# layering". Without it, agents lack a mental model of the repo.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "architecture-doc-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+FILE=""
+for candidate in ARCHITECTURE.md docs/ARCHITECTURE.md ARCHITECTURE.rst docs/architecture.md; do
+    [[ -f "$ROOT/$candidate" ]] && { FILE="$ROOT/$candidate"; break; }
+done
+
+if [[ -z "$FILE" ]]; then
+    violation "no ARCHITECTURE.md (looked at: ARCHITECTURE.md, docs/ARCHITECTURE.md, ARCHITECTURE.rst, docs/architecture.md)"
+    rule_end
+fi
+
+if [[ ! -s "$FILE" ]]; then
+    violation "$FILE exists but is empty"
+    rule_end
+fi
+
+lines=$(wc -l < "$FILE" | tr -d ' ')
+MIN_LINES="${GOVERNANCE_ARCHITECTURE_MIN:-20}"
+if [[ $lines -lt $MIN_LINES ]]; then
+    violation "$FILE has $lines lines — looks like a stub (min: $MIN_LINES)"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/ci-workflow-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/ci-workflow-exists.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Rule: At least one non-governance GitHub Actions workflow exists.
+# Rationale: CI is the backstop for the pre-commit hook (which is skippable).
+# If the only workflow is governance.yml itself, there's nothing verifying the
+# rest of the project. Governance without CI for the code it protects is honor-system.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "ci-workflow-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+WF_DIR="$ROOT/.github/workflows"
+
+if [[ ! -d "$WF_DIR" ]]; then
+    violation "no .github/workflows/ directory"
+    rule_end
+fi
+
+shopt -s nullglob
+count=0
+for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+    # Don't count governance.yml itself — this rule wants CI for the actual project.
+    [[ "$(basename "$f")" == "governance.yml" || "$(basename "$f")" == "governance.yaml" ]] && continue
+    count=$((count + 1))
+done
+shopt -u nullglob
+
+if [[ $count -eq 0 ]]; then
+    violation ".github/workflows/ has no non-governance workflow (CI is the backstop for skipped hooks)"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/constitution-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/constitution-exists.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Rule: CONSTITUTION.md exists at the repo root and is non-empty.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "constitution-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+FILE="$ROOT/CONSTITUTION.md"
+
+if [[ ! -f "$FILE" ]]; then
+    violation "CONSTITUTION.md not found at repo root"
+elif [[ ! -s "$FILE" ]]; then
+    violation "CONSTITUTION.md exists but is empty"
+elif [[ $(wc -l < "$FILE") -lt 10 ]]; then
+    violation "CONSTITUTION.md has fewer than 10 lines — looks like a stub"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/conventional-commits.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/conventional-commits.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Rule: Commit messages follow Conventional Commits.
+#   <type>(<optional-scope>)!?: <subject>
+# Allowed types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
+# Extend via GOVERNANCE_CC_EXTRA_TYPES="foo bar baz".
+#
+# Usage modes:
+#   Mode A — commit-msg hook: `bash conventional-commits.sh <path-to-msg-file>`
+#   Mode B — CI / run.sh:     `bash conventional-commits.sh`
+#       Validates every commit from the default-branch merge-base to HEAD.
+#
+# Merge commits and commits authored by bots (dependabot, renovate) are skipped.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "conventional-commits"
+require_git
+
+DEFAULT_TYPES="feat fix chore docs refactor test perf build ci revert style"
+EXTRA_TYPES="${GOVERNANCE_CC_EXTRA_TYPES:-}"
+ALL_TYPES="$DEFAULT_TYPES $EXTRA_TYPES"
+# Build an alternation for the regex.
+types_alt=$(echo "$ALL_TYPES" | tr -s ' ' '|' | sed 's/^|//;s/|$//')
+# Conventional Commits header regex (first line only).
+HEADER_RE="^(${types_alt})(\([^)]+\))?!?: .+"
+
+validate_subject() {
+    local subject="$1"
+    local label="$2"
+    # Merge commits — skip.
+    [[ "$subject" == Merge\ * ]] && return 0
+    # Revert commits — git's auto-format starts with `Revert "..."`.
+    [[ "$subject" == Revert\ \"* ]] && return 0
+    # Fixup / squash / autosquash — not for a clean history but not our fight here.
+    [[ "$subject" == fixup!\ * || "$subject" == squash!\ * || "$subject" == amend!\ * ]] && return 0
+
+    if [[ ! "$subject" =~ $HEADER_RE ]]; then
+        violation "$label — '$subject' does not match Conventional Commits (<type>(scope)?: <subject>)"
+        return 1
+    fi
+    # Subject ≤ 100 chars keeps PR titles and log output readable.
+    if [[ ${#subject} -gt 100 ]]; then
+        violation "$label — subject is ${#subject} chars (max 100)"
+        return 1
+    fi
+    return 0
+}
+
+if [[ $# -gt 0 ]]; then
+    # Mode A — commit-msg hook.
+    msg_file="$1"
+    [[ ! -f "$msg_file" ]] && { violation "commit-msg file not found: $msg_file"; rule_end; }
+    # First non-comment, non-blank line is the subject.
+    subject=$(grep -vE '^[[:space:]]*($|#)' "$msg_file" | head -n1)
+    validate_subject "$subject" "pending commit"
+    rule_end
+fi
+
+# Mode B — CI / run.sh.
+# Pick a base ref. Prefer origin/main or origin/master. Fall back to the last
+# commit only (so the rule still exercises something in fresh repos or detached heads).
+base=""
+for candidate in origin/main origin/master main master; do
+    if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+        mb=$(git merge-base HEAD "$candidate" 2>/dev/null || echo "")
+        if [[ -n "$mb" && "$mb" != "$(git rev-parse HEAD)" ]]; then
+            base="$mb"
+            break
+        fi
+    fi
+done
+
+if [[ -z "$base" ]]; then
+    # Validate just the tip commit.
+    subject=$(git log -1 --format=%s HEAD 2>/dev/null || echo "")
+    [[ -n "$subject" ]] && validate_subject "$subject" "HEAD"
+    rule_end
+fi
+
+while IFS=$'\t' read -r sha author_email subject; do
+    [[ -z "$sha" ]] && continue
+    # Skip bots — they have their own conventions we can't control.
+    case "$author_email" in
+        *dependabot*|*renovate*|*[bot]*@*) continue ;;
+    esac
+    validate_subject "$subject" "$sha"
+done < <(git log "$base..HEAD" --format='%H%x09%ae%x09%s')
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/doc-freshness.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/doc-freshness.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Rule: Freshness-tracked docs carry a recent `<!-- last-verified: YYYY-MM-DD -->`
+# marker. Mechanical version of the harness-engineering "doc-gardening" practice.
+#
+# Config: tests/governance/freshness.conf
+#   One path per line, relative to repo root. Blank lines and lines starting with
+#   # are ignored. If this file is missing or empty, the rule is a no-op — users
+#   explicitly opt docs into freshness tracking.
+#
+# Default staleness window: 90 days. Override with GOVERNANCE_FRESHNESS_DAYS.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "doc-freshness"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+CONF="$ROOT/tests/governance/freshness.conf"
+MAX_DAYS="${GOVERNANCE_FRESHNESS_DAYS:-90}"
+
+if [[ ! -f "$CONF" ]]; then
+    # Nothing opted in. Pass.
+    rule_end
+fi
+
+now_epoch=$(date +%s)
+max_secs=$((MAX_DAYS * 86400))
+
+# Portable ISO-date → epoch. Try GNU then BSD.
+iso_to_epoch() {
+    local iso="$1"
+    date -d "$iso" +%s 2>/dev/null && return 0
+    date -j -f "%Y-%m-%d" "$iso" +%s 2>/dev/null && return 0
+    return 1
+}
+
+while IFS= read -r raw; do
+    # Strip comments and whitespace.
+    entry="${raw%%#*}"
+    entry="${entry#"${entry%%[![:space:]]*}"}"
+    entry="${entry%"${entry##*[![:space:]]}"}"
+    [[ -z "$entry" ]] && continue
+
+    path="$ROOT/$entry"
+    if [[ ! -f "$path" ]]; then
+        violation "$entry listed in freshness.conf but does not exist"
+        continue
+    fi
+
+    # Extract the last-verified date. Pattern: <!-- last-verified: YYYY-MM-DD -->
+    stamp=$(grep -oE 'last-verified:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}' "$path" | head -n1 | awk '{print $NF}')
+    if [[ -z "$stamp" ]]; then
+        violation "$entry has no '<!-- last-verified: YYYY-MM-DD -->' marker"
+        continue
+    fi
+
+    stamp_epoch=$(iso_to_epoch "$stamp" || echo "")
+    if [[ -z "$stamp_epoch" ]]; then
+        violation "$entry has unparseable date '$stamp'"
+        continue
+    fi
+
+    age=$((now_epoch - stamp_epoch))
+    if [[ $age -gt $max_secs ]]; then
+        days=$((age / 86400))
+        violation "$entry last verified $stamp ($days days ago, max: $MAX_DAYS)"
+    fi
+done < "$CONF"
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/dotenv-gitignored.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/dotenv-gitignored.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Rule: .env is gitignored and not currently tracked.
+# Rationale: The most common path for real secrets to land in a repo. Grep-based
+# scanners miss secrets that never match a known pattern; this rule closes the
+# door entirely by keeping .env out of git.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "dotenv-gitignored"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Check 1 — .env files must not be tracked.
+while IFS= read -r tracked; do
+    [[ -z "$tracked" ]] && continue
+    violation "$tracked is tracked — remove with: git rm --cached $tracked"
+done < <(git ls-files -- '.env' '.env.*' ':!.env.example' ':!.env.sample' ':!.env.template' 2>/dev/null || true)
+
+# Check 2 — .gitignore must cover .env.
+if [[ ! -f .gitignore ]]; then
+    violation ".gitignore is missing at repo root"
+elif ! git check-ignore -q .env 2>/dev/null; then
+    # git check-ignore only works if .env is not tracked; fall back to grep if needed.
+    if ! grep -qE '^\.env(\s|$|#)' .gitignore && ! grep -qE '^\*\.env(\s|$|#)' .gitignore; then
+        violation ".gitignore does not list .env"
+    fi
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/env-example-current.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/env-example-current.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Rule: .env.example lists every key present in a local .env (if one exists).
+# Keeps the reference file in sync so new contributors know what env vars they need.
+# .env itself is assumed to be gitignored — this rule is a no-op when no local .env exists.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "env-example-current"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+ENV_FILE="$ROOT/.env"
+EXAMPLE_FILE="$ROOT/.env.example"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    # No local .env; nothing to compare against. This is the expected state in CI.
+    rule_end
+fi
+
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+    violation ".env exists but .env.example is missing"
+    rule_end
+fi
+
+# Extract keys (left side of `=`), ignore blank lines and comments.
+extract_keys() {
+    grep -vE '^[[:space:]]*(#|$)' "$1" | sed -E 's/^[[:space:]]*export[[:space:]]+//' \
+        | awk -F= '{print $1}' | sed 's/[[:space:]]*$//' | sort -u
+}
+
+env_keys=$(extract_keys "$ENV_FILE")
+example_keys=$(extract_keys "$EXAMPLE_FILE")
+
+while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    if ! grep -qxF "$key" <<<"$example_keys"; then
+        violation ".env has key '$key' but .env.example does not"
+    fi
+done <<<"$env_keys"
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/file-size-limit.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/file-size-limit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Rule: No tracked source file exceeds the line-count limit.
+# Default 500 lines. Override with GOVERNANCE_FILE_SIZE_LIMIT in the environment.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "file-size-limit"
+require_git
+
+LIMIT="${GOVERNANCE_FILE_SIZE_LIMIT:-500}"
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Source extensions we care about. Tweak this list as the project's stack dictates.
+extensions=(
+    "*.py" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs"
+    "*.go" "*.rs" "*.rb" "*.java" "*.kt" "*.scala"
+    "*.c" "*.cc" "*.cpp" "*.h" "*.hpp"
+    "*.swift" "*.php" "*.cs"
+)
+
+# Excludes: vendor, generated, migrations, lock files.
+excludes=(
+    ":!vendor/**"
+    ":!**/node_modules/**"
+    ":!**/generated/**"
+    ":!**/*_pb2.py"
+    ":!**/*.pb.go"
+    ":!**/migrations/**"
+)
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    [[ ! -f "$file" ]] && continue
+    lines=$(wc -l < "$file" | tr -d ' ')
+    if [[ "$lines" -gt "$LIMIT" ]]; then
+        violation "$file — $lines lines (limit: $LIMIT)"
+    fi
+done < <(git ls-files -- "${extensions[@]}" "${excludes[@]}" 2>/dev/null || true)
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/license-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/license-exists.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Rule: A LICENSE file exists at the repo root.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "license-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+found=""
+for candidate in LICENSE LICENSE.md LICENSE.txt COPYING COPYING.md; do
+    [[ -f "$ROOT/$candidate" ]] && { found="$candidate"; break; }
+done
+
+if [[ -z "$found" ]]; then
+    violation "no LICENSE file at repo root (looked for LICENSE, LICENSE.md, LICENSE.txt, COPYING, COPYING.md)"
+elif [[ ! -s "$ROOT/$found" ]]; then
+    violation "$found exists but is empty"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-broken-internal-doc-links.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-broken-internal-doc-links.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Rule: Every markdown link to a local path in a tracked .md file resolves.
+# Rationale: Doc rot is invisible until an agent follows a dead link and bails.
+# This rule only checks link *targets*, not anchors — validating #heading
+# fragments mechanically is fragile and generates noise.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-broken-internal-doc-links"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# One-pass extractor: for each tracked .md file, pull out every [text](target)
+# as `line_no:[text](target)`, then parse each in shell without iterative regex.
+link_re_extract='\[[^]]*\]\([^)]+\)'
+# Match everything from `](` up to the next `)`, capturing the target.
+target_re='^\[[^]]*\]\(([^)]+)\)$'
+
+check_link() {
+    local file="$1" line_no="$2" match="$3"
+    # Extract target from "[text](target)"
+    local target
+    target="${match##*(}"   # strip leading "[text]("
+    target="${target%)}"    # strip trailing ")"
+    # Drop optional title: `path "Title"` → `path`.
+    target="${target%% *}"
+
+    case "$target" in
+        http://*|https://*|mailto:*|tel:*|'#'*|'<'*|'') return 0 ;;
+    esac
+    # Drop anchor fragment.
+    local path="${target%%#*}"
+    [[ -z "$path" ]] && return 0
+
+    local dir resolved
+    dir=$(dirname "$file")
+    if [[ "$path" == /* ]]; then
+        resolved="${ROOT}${path}"
+    else
+        resolved="${ROOT}/${dir}/${path}"
+    fi
+
+    if [[ -e "$resolved" ]]; then
+        return 0
+    fi
+
+    has_waiver "$file" "$line_no" "no-broken-internal-doc-links" && return 0
+    violation "$file:$line_no — broken link to '$target'"
+}
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    # Skip files inside governance rules — they contain regex strings that look like links.
+    [[ "$file" == tests/governance/rules/* ]] && continue
+    # grep -noE gives "line_no:match" per match, one per line.
+    while IFS=: read -r line_no match; do
+        [[ -z "$line_no" || -z "$match" ]] && continue
+        check_link "$file" "$line_no" "$match"
+    done < <(grep -noE "$link_re_extract" "$file" 2>/dev/null || true)
+done < <(git ls-files -- '*.md' '*.markdown' ':!vendor/**' ':!node_modules/**' 2>/dev/null || true)
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-committed-build-artifacts.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-committed-build-artifacts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Rule: No common build artifacts are tracked in the repo.
+# Only flags unambiguous artifacts — things that are almost never intentionally
+# checked in. Deliberately excludes .so / .jar / .dll because some projects
+# legitimately ship those.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-committed-build-artifacts"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# (pattern, label) pairs.
+checks=(
+    '*.pyc|Python bytecode'
+    '*.pyo|Python optimized bytecode'
+    '__pycache__/**|Python cache dir'
+    '*.class|Java class file'
+    '*.o|compiled object file'
+    'node_modules/**|node_modules committed'
+    'dist/**|dist/ build output'
+    'build/**|build/ output'
+    'target/**|target/ (JVM / Rust) build output'
+    'out/**|out/ build output'
+    '.DS_Store|macOS metadata'
+    'Thumbs.db|Windows metadata'
+    '*.swp|editor swap file'
+    '*.swo|editor swap file'
+)
+
+for entry in "${checks[@]}"; do
+    IFS='|' read -r pattern label <<<"$entry"
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        violation "$f — $label"
+    done < <(git ls-files -- "$pattern" 2>/dev/null || true)
+done
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-debug-statements.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-debug-statements.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Rule: No leftover debug statements in tracked source files.
+# Covers the common traps: console.log, debugger, print(, pdb, dbg!, fmt.Println.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-debug-statements"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Format: "<label>|<pattern>|<pathspec>"
+# pathspec restricts where the pattern applies (so we don't flag print() in Python docs).
+checks=(
+    "console.log|console\.log\s*\(|*.js *.jsx *.ts *.tsx *.mjs *.cjs"
+    "debugger statement|^[[:space:]]*debugger[[:space:]]*;?|*.js *.jsx *.ts *.tsx *.mjs *.cjs"
+    "Python breakpoint|^[[:space:]]*breakpoint\s*\(|*.py"
+    "pdb.set_trace|import pdb|*.py"
+    "Rust dbg! macro|\bdbg!\s*\(|*.rs"
+    "fmt.Println debug|^[[:space:]]*fmt\.Println\s*\(|*.go"
+)
+
+for entry in "${checks[@]}"; do
+    IFS='|' read -r label pattern pathspec <<<"$entry"
+    # shellcheck disable=SC2206
+    pathspec_args=($pathspec)
+    while IFS=: read -r file line_no _; do
+        [[ -z "$file" ]] && continue
+        # Skip this rule file (contains the patterns).
+        [[ "$file" == tests/governance/rules/no-debug-statements.sh ]] && continue
+        # Skip test files — debug output in tests is sometimes legitimate.
+        [[ "$file" == *_test.* ]] && continue
+        [[ "$file" == *.test.* ]] && continue
+        [[ "$file" == *test_*.py ]] && continue
+        [[ "$file" == tests/* ]] && continue
+        has_waiver "$file" "$line_no" "no-debug-statements" && continue
+        violation "$file:$line_no — $label"
+    done < <(git grep -InE "$pattern" -- "${pathspec_args[@]}" 2>/dev/null || true)
+done
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-large-files.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-large-files.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Rule: No tracked file exceeds the size limit.
+# Default: 5 MB. Override with GOVERNANCE_MAX_FILE_SIZE_MB.
+# Rationale: bloated repos slow every clone. Agents create fresh worktrees
+# constantly, so the cost compounds.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-large-files"
+require_git
+
+LIMIT_MB="${GOVERNANCE_MAX_FILE_SIZE_MB:-5}"
+LIMIT_BYTES=$((LIMIT_MB * 1024 * 1024))
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Portable byte-size for a file.
+file_size() {
+    # BSD stat (macOS)
+    stat -f%z "$1" 2>/dev/null && return 0
+    # GNU stat
+    stat -c%s "$1" 2>/dev/null && return 0
+    # Fallback
+    wc -c < "$1" | tr -d ' '
+}
+
+while IFS= read -r f; do
+    [[ -z "$f" || ! -f "$f" ]] && continue
+    size=$(file_size "$f")
+    [[ -z "$size" ]] && continue
+    if [[ "$size" -gt "$LIMIT_BYTES" ]]; then
+        hr=$(awk -v b="$size" 'BEGIN{ split("B KB MB GB", u); s=0; while (b>1024 && s<3) { b/=1024; s++ } printf "%.1f %s", b, u[s+1] }')
+        violation "$f — $hr (limit: ${LIMIT_MB} MB). Use Git LFS or host externally."
+    fi
+done < <(git ls-files)
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-merge-conflict-markers.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-merge-conflict-markers.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Rule: No tracked file contains a merge conflict marker.
+# Installed ALWAYS (not an opt-in menu item) — this rule has zero false positives
+# and prevents an entire category of broken builds.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-merge-conflict-markers"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Use git grep with -I to skip binary files. Match each marker at line-start.
+while IFS=: read -r file line_no _; do
+    [[ -z "$file" ]] && continue
+    # Skip this rule file — it contains the patterns as strings.
+    [[ "$file" == tests/governance/rules/no-merge-conflict-markers.sh ]] && continue
+    violation "$file:$line_no — merge conflict marker"
+done < <(git grep -InE '^(<<<<<<< |=======$|>>>>>>> )' 2>/dev/null || true)
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-orphan-todos.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-orphan-todos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Rule: Every TODO/FIXME must reference a tracker (#123 or ABC-123).
+# Orphan TODOs rot — a TODO without a ticket is a future bug with no owner.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-orphan-todos"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Pattern: TODO or FIXME, then anything up to 80 chars on the same line.
+# Accepted references on the same line: #123, ABC-123 (uppercase project key + number).
+while IFS=: read -r file line_no match; do
+    [[ -z "$file" ]] && continue
+    # Skip matches in this rule file itself (it mentions TODO).
+    [[ "$file" == tests/governance/rules/no-orphan-todos.sh ]] && continue
+    # Skip matches inside the constitution, which documents the rule.
+    [[ "$file" == CONSTITUTION.md ]] && continue
+    # Accept waiver: `# governance: allow-no-orphan-todos <reason>`
+    has_waiver "$file" "$line_no" "no-orphan-todos" && continue
+    # Accept a tracker reference on the same line.
+    if echo "$match" | grep -qE '(#[0-9]+|[A-Z][A-Z0-9]+-[0-9]+)'; then
+        continue
+    fi
+    violation "$file:$line_no — $(echo "$match" | sed 's/^[[:space:]]*//' | cut -c1-80)"
+done < <(git grep -nE '\b(TODO|FIXME)\b' -- \
+    ':!tests/governance/rules/no-orphan-todos.sh' \
+    ':!CONSTITUTION.md' 2>/dev/null || true)
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/no-secrets.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/no-secrets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Rule: No obvious secrets (keys, tokens, private keys) in tracked files.
+# This is a heuristic net — it will not catch everything. Pair it with a real
+# scanner (gitleaks, trufflehog) in CI for defense in depth.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Patterns intentionally conservative to limit false positives.
+# Each pattern: "<label>|<regex>"
+patterns=(
+    "AWS access key|AKIA[0-9A-Z]{16}"
+    "AWS secret key|aws_secret_access_key[[:space:]]*=[[:space:]]*['\"]?[A-Za-z0-9/+=]{40}"
+    "GCP service account|-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+    "GitHub token|gh[pousr]_[A-Za-z0-9]{36,}"
+    "Slack token|xox[baprs]-[A-Za-z0-9-]{10,}"
+    "Generic API key|api[_-]?key[[:space:]]*[:=][[:space:]]*['\"][A-Za-z0-9]{32,}['\"]"
+    "Stripe live key|sk_live_[A-Za-z0-9]{24,}"
+)
+
+# Exclude binaries, the rule file itself (contains regexes), the constitution,
+# and common lock files which sometimes contain base64 blobs.
+excludes=(
+    ":!tests/governance/rules/no-secrets.sh"
+    ":!CONSTITUTION.md"
+    ":!*.lock"
+    ":!*.lockfile"
+    ":!package-lock.json"
+    ":!yarn.lock"
+    ":!pnpm-lock.yaml"
+    ":!Cargo.lock"
+    ":!poetry.lock"
+    ":!Pipfile.lock"
+    ":!go.sum"
+)
+
+for entry in "${patterns[@]}"; do
+    label="${entry%%|*}"
+    pattern="${entry#*|}"
+    while IFS=: read -r file line_no _; do
+        [[ -z "$file" ]] && continue
+        has_waiver "$file" "$line_no" "no-secrets" && continue
+        violation "$file:$line_no — possible $label"
+    done < <(git grep -InE "$pattern" -- "${excludes[@]}" 2>/dev/null || true)
+done
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/readme-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/readme-exists.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Rule: README.md exists at repo root with at least a top-level heading and one paragraph.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "readme-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+FILE=""
+for candidate in "$ROOT/README.md" "$ROOT/README" "$ROOT/README.rst"; do
+    [[ -f "$candidate" ]] && { FILE="$candidate"; break; }
+done
+
+if [[ -z "$FILE" ]]; then
+    violation "no README.md / README / README.rst at repo root"
+    rule_end
+fi
+
+if ! grep -qE '^#[^#]' "$FILE" 2>/dev/null && ! grep -qE '^=+$' "$FILE" 2>/dev/null; then
+    violation "$FILE has no top-level heading"
+fi
+
+if [[ $(wc -w < "$FILE") -lt 30 ]]; then
+    violation "$FILE has fewer than 30 words — looks like a stub"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/security-md-exists.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/security-md-exists.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Rule: SECURITY.md exists and tells people how to report a vulnerability.
+# Accepts SECURITY.md at repo root, in docs/, or in .github/ (GitHub community
+# health file). Must contain a contact mechanism — an email address or URL.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "security-md-exists"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+FILE=""
+for candidate in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+    [[ -f "$ROOT/$candidate" ]] && { FILE="$ROOT/$candidate"; break; }
+done
+
+if [[ -z "$FILE" ]]; then
+    violation "no SECURITY.md (looked at: SECURITY.md, docs/SECURITY.md, .github/SECURITY.md)"
+    rule_end
+fi
+
+if [[ ! -s "$FILE" ]]; then
+    violation "$FILE exists but is empty"
+    rule_end
+fi
+
+# Needs at least one way to get hold of a human — email, URL, or hackerone/bugcrowd ref.
+if ! grep -qE '([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|https?://|hackerone|bugcrowd)' "$FILE"; then
+    violation "$FILE has no contact email, URL, or vulnerability-disclosure platform reference"
+fi
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/rules/workflows-hardened.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/workflows-hardened.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Rule: GitHub Actions workflows are hardened against supply-chain abuse.
+# Two sub-checks:
+#   1. Each workflow declares a `permissions:` block (top-level or per-job)
+#      to enforce least-privilege.
+#   2. Every third-party action (anything outside the actions/* and github/*
+#      namespaces) is pinned to a full 40-char commit SHA — not a moving tag.
+# Rationale: GitHub Security explicitly recommends both. Tag-pinning is the gap
+# the tj-actions/changed-files compromise exploited in 2025.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "workflows-hardened"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+shopt -s nullglob
+workflows=(.github/workflows/*.yml .github/workflows/*.yaml)
+shopt -u nullglob
+
+if [[ ${#workflows[@]} -eq 0 ]]; then
+    # No workflows is the domain of ci-workflow-exists; this rule is a no-op.
+    rule_end
+fi
+
+# Trusted namespaces where tag pinning is acceptable.
+allowlist_prefixes=(
+    "actions/"
+    "github/"
+)
+
+is_allowlisted() {
+    local action="$1"
+    for prefix in "${allowlist_prefixes[@]}"; do
+        [[ "$action" == "$prefix"* ]] && return 0
+    done
+    return 1
+}
+
+for wf in "${workflows[@]}"; do
+    # ── Sub-check 1: permissions block present somewhere ──
+    if ! grep -qE '^[[:space:]]*permissions:' "$wf"; then
+        violation "$wf — no 'permissions:' block (least-privilege hardening)"
+    fi
+
+    # ── Sub-check 2: third-party actions pinned to SHA ──
+    # Match lines like:  uses: owner/repo@ref   or   - uses: owner/repo/path@ref
+    # Skip local actions (./path) and docker actions (docker://...).
+    while IFS= read -r line; do
+        # Extract the "owner/repo...@ref" part.
+        ref_spec=$(echo "$line" | sed -nE 's/.*uses:[[:space:]]*([^[:space:]#]+).*/\1/p')
+        [[ -z "$ref_spec" ]] && continue
+        [[ "$ref_spec" == ./* ]] && continue
+        [[ "$ref_spec" == docker://* ]] && continue
+
+        action="${ref_spec%@*}"
+        ref="${ref_spec##*@}"
+
+        # If no @ present, the spec is malformed — still flag it.
+        if [[ "$action" == "$ref" ]]; then
+            violation "$wf — action '$ref_spec' has no version ref"
+            continue
+        fi
+
+        if is_allowlisted "$action"; then
+            continue
+        fi
+
+        # Require a full 40-char hex SHA.
+        if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+            violation "$wf — third-party action '$action@$ref' is not pinned to a commit SHA"
+        fi
+    done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:' "$wf" 2>/dev/null || true)
+done
+
+rule_end

--- a/governance-bootstrap/assets/tests-bash/run.sh
+++ b/governance-bootstrap/assets/tests-bash/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Governance test runner. Discovers every rule under ./rules/ and runs it.
+# Exits 0 if all rules pass, 1 if any rule fails.
+#
+# Usage:
+#   bash tests/governance/run.sh              # run all rules
+#   bash tests/governance/run.sh no-secrets   # run a single rule by name
+#
+# Environment:
+#   SKIP_GOVERNANCE=1   skip all rules (for emergency commits)
+
+set -u
+
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then
+    echo "⊘ governance skipped (SKIP_GOVERNANCE=1)"
+    exit 0
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RULES_DIR="$HERE/rules"
+
+if [[ ! -d "$RULES_DIR" ]]; then
+    echo "✗ no rules directory at $RULES_DIR"
+    echo "  Is this repo bootstrapped? Run the governance-bootstrap skill."
+    exit 1
+fi
+
+rule_files=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && rule_files+=("$f")
+done < <(find "$RULES_DIR" -maxdepth 1 -type f -name '*.sh' | sort)
+
+if [[ ${#rule_files[@]} -eq 0 ]]; then
+    echo "⊘ no governance rules defined in $RULES_DIR"
+    exit 0
+fi
+
+# Single-rule filter: `run.sh no-secrets` only runs no-secrets.sh.
+if [[ $# -gt 0 ]]; then
+    filter="$1"
+    filtered=()
+    for f in "${rule_files[@]}"; do
+        [[ "$(basename "$f" .sh)" == "$filter" ]] && filtered+=("$f")
+    done
+    if [[ ${#filtered[@]} -eq 0 ]]; then
+        echo "✗ no rule named '$filter' under $RULES_DIR"
+        exit 1
+    fi
+    rule_files=("${filtered[@]}")
+fi
+
+fail_count=0
+pass_count=0
+for rule in "${rule_files[@]}"; do
+    if bash "$rule"; then
+        pass_count=$((pass_count + 1))
+    else
+        fail_count=$((fail_count + 1))
+    fi
+done
+
+echo
+echo "────────────────────────────────────────"
+if [[ $fail_count -eq 0 ]]; then
+    echo "✓ governance: all $pass_count rule(s) passed"
+    exit 0
+fi
+echo "✗ governance: $fail_count rule(s) failed, $pass_count passed"
+echo
+echo "To bypass temporarily (CI will still enforce):"
+echo "    SKIP_GOVERNANCE=1 git commit ..."
+echo "    git commit --no-verify"
+exit 1

--- a/governance-bootstrap/evals/evals.json
+++ b/governance-bootstrap/evals/evals.json
@@ -1,0 +1,51 @@
+{
+  "skill_name": "governance-bootstrap",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're starting a new Python + TypeScript monorepo and I want to lock in some non-negotiables before the team grows. Can you set up governance for this repo? Pick a sensible default set of rules — I'll tell you what to drop.",
+      "expected_output": "A tests/governance/ directory with a runner and a tailored set of rule scripts, a pre-commit and commit-msg hook installed in .git/hooks/, a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at .github/workflows/governance.yml, and a short report listing which rules were enabled and why. The skill should have presented a menu via AskUserQuestion before acting — it should not have silently chosen the rule set.",
+      "files": ["evals/files/empty-polyglot-repo/"],
+      "assertions": [
+        "The skill detected both Python and TypeScript/JS before proposing rules (visible in its summary or in which rules it enabled)",
+        "tests/governance/run.sh exists and is executable",
+        "tests/governance/rules/ contains at least one rule script (.sh) per enabled category",
+        "tests/governance/lib.sh exists and defines rule_start, violation, rule_end, has_waiver",
+        ".git/hooks/pre-commit exists, is executable, and honors SKIP_GOVERNANCE=1",
+        ".git/hooks/commit-msg exists and rejects messages that don't match Conventional Commits (when that rule was enabled)",
+        "CONSTITUTION.md exists at the repo root with at least Principles, Invariants, and Evolution Log sections",
+        ".github/workflows/governance.yml exists and pins third-party actions by SHA (not by floating tag)",
+        "The .github/workflows/governance.yml file includes an explicit permissions block scoped to the minimum needed",
+        "The AskUserQuestion tool was invoked at least once during the run to present the rule menu",
+        "Running tests/governance/run.sh in the repo exits 0 on the seeded repo (no violations on a clean baseline)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Set up governance here — but this repo already has a tests/governance/ directory from a previous run. Don't clobber anything I've customized.",
+      "expected_output": "The skill detects the existing governance setup, refuses to overwrite customized files, and instead either reports what's already installed or suggests the governance-amend skill for incremental changes. It does not silently overwrite lib.sh, the runner, or any existing rule scripts.",
+      "files": ["evals/files/already-bootstrapped-repo/"],
+      "assertions": [
+        "The skill did NOT overwrite the pre-existing tests/governance/run.sh",
+        "The skill did NOT overwrite the pre-existing tests/governance/rules/*.sh files",
+        "The skill explicitly acknowledged the existing setup in its user-facing output (e.g., 'governance already bootstrapped' or similar)",
+        "The skill either exited cleanly or pointed the user to governance-amend for incremental changes",
+        "No new CONSTITUTION.md was written over an existing one"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Bootstrap governance for this repo. It's a Go service — keep the rule set tight, no stylistic stuff, and make sure security rules are included.",
+      "expected_output": "The Security category rules (no-secrets, dotenv-gitignored, security-md-exists, workflows-hardened) are enabled. Go-specific rules are chosen over Python/JS-specific ones. Stylistic rules are NOT enabled. The skill's summary explains which categories were included and which were deliberately dropped.",
+      "files": ["evals/files/go-service-repo/"],
+      "assertions": [
+        "tests/governance/rules/no-secrets.sh exists",
+        "tests/governance/rules/dotenv-gitignored.sh exists or was explicitly skipped with a reason (Go services often don't use .env)",
+        "tests/governance/rules/workflows-hardened.sh exists",
+        "No rule scripts targeting Python-only or JS-only patterns (e.g., no-pdb, no-console-log) were installed",
+        "The skill's summary explicitly names the Security category as enabled",
+        "tests/governance/run.sh exits 0 on the seeded clean Go repo"
+      ]
+    }
+  ]
+}

--- a/governance-bootstrap/evals/files/README.md
+++ b/governance-bootstrap/evals/files/README.md
@@ -1,0 +1,9 @@
+# Eval fixtures
+
+Each subdirectory is a seed repo state for one eval case. Before running an eval, copy the fixture into a fresh temp directory, run `git init && git add -A && git commit -m "seed"` inside it, and point the skill at that directory.
+
+- `empty-polyglot-repo/` — a minimal Python + TypeScript repo with no governance; eval case 1.
+- `already-bootstrapped-repo/` — a repo that already has `tests/governance/` from a prior run; eval case 2. The pre-existing files should carry a visible marker (e.g., a comment `# CUSTOMIZED`) so the grader can detect overwrites.
+- `go-service-repo/` — a minimal Go service with `go.mod`, `main.go`, and no governance; eval case 3.
+
+Fixtures are intentionally small — the eval checks the skill's *behavior*, not its ability to handle large repos.

--- a/governance-bootstrap/references/NATIVE_TESTS.md
+++ b/governance-bootstrap/references/NATIVE_TESTS.md
@@ -1,0 +1,168 @@
+# Native tests & alternative hook frameworks
+
+The bash rules in `tests/governance/rules/` are the baseline — they work in any repo without dependencies. This doc shows how to **also** run governance rules through the project's native test framework so they show up in the normal test report, and how to wire the pre-commit hook into frameworks the repo may already use.
+
+## When to add native tests
+
+Add native tests when:
+
+- The repo already runs `pytest` / `jest` / `go test` in CI — governance violations should appear in the same report.
+- A rule is easier to express in code than in bash (e.g. AST checks on Python imports, TypeScript type assertions).
+
+The bash rules stay either way. Native tests are additive, not a replacement.
+
+## pytest (Python)
+
+Create `tests/governance/test_governance.py`:
+
+```python
+import subprocess
+from pathlib import Path
+
+RULES_DIR = Path(__file__).parent / "rules"
+
+def _rules():
+    return sorted(p for p in RULES_DIR.glob("*.sh"))
+
+def test_rules_exist():
+    assert _rules(), "no governance rules defined"
+
+def test_each_rule(tmp_path, pytestconfig):
+    failures = []
+    for rule in _rules():
+        result = subprocess.run(["bash", str(rule)], capture_output=True, text=True)
+        if result.returncode != 0:
+            failures.append(f"{rule.name}:\n{result.stdout}{result.stderr}")
+    if failures:
+        raise AssertionError("\n\n".join(failures))
+```
+
+For AST-level rules, skip the bash wrapper and write a direct pytest test. Example — no wildcard imports:
+
+```python
+import ast
+from pathlib import Path
+
+def test_no_wildcard_imports():
+    offenders = []
+    for py in Path(".").rglob("*.py"):
+        if any(part.startswith(".") or part in {"node_modules", "venv", ".venv"} for part in py.parts):
+            continue
+        tree = ast.parse(py.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and any(a.name == "*" for a in node.names):
+                offenders.append(f"{py}:{node.lineno}")
+    assert not offenders, "wildcard imports: " + ", ".join(offenders)
+```
+
+## jest / vitest (Node)
+
+Create `tests/governance/governance.test.js`:
+
+```javascript
+const { execSync } = require('node:child_process');
+const { readdirSync } = require('node:fs');
+const { join } = require('node:path');
+
+const RULES_DIR = join(__dirname, 'rules');
+
+describe('governance rules', () => {
+  const rules = readdirSync(RULES_DIR).filter(f => f.endsWith('.sh'));
+
+  test('at least one rule is defined', () => {
+    expect(rules.length).toBeGreaterThan(0);
+  });
+
+  test.each(rules)('%s passes', (rule) => {
+    expect(() => {
+      execSync(`bash ${join(RULES_DIR, rule)}`, { stdio: 'pipe' });
+    }).not.toThrow();
+  });
+});
+```
+
+## go test (Go)
+
+Create `tests/governance/governance_test.go`:
+
+```go
+package governance_test
+
+import (
+    "os/exec"
+    "path/filepath"
+    "testing"
+)
+
+func TestGovernanceRules(t *testing.T) {
+    rules, err := filepath.Glob("rules/*.sh")
+    if err != nil || len(rules) == 0 {
+        t.Fatal("no governance rules defined")
+    }
+    for _, rule := range rules {
+        rule := rule
+        t.Run(filepath.Base(rule), func(t *testing.T) {
+            out, err := exec.Command("bash", rule).CombinedOutput()
+            if err != nil {
+                t.Fatalf("%s\n%s", err, out)
+            }
+        })
+    }
+}
+```
+
+## Alternative hook frameworks
+
+### husky
+
+If `package.json` has `husky` configured, don't write to `.git/hooks/pre-commit` directly. Instead:
+
+```bash
+npx husky add .husky/pre-commit "bash tests/governance/run.sh"
+```
+
+Add the `SKIP_GOVERNANCE` guard at the top of `.husky/pre-commit`:
+
+```bash
+#!/usr/bin/env bash
+. "$(dirname -- "$0")/_/husky.sh"
+
+[[ "${SKIP_GOVERNANCE:-0}" == "1" ]] && exit 0
+bash tests/governance/run.sh
+```
+
+### pre-commit framework (pre-commit.com)
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: governance
+        name: governance
+        entry: bash tests/governance/run.sh
+        language: system
+        pass_filenames: false
+        stages: [commit]
+```
+
+Users can skip with `SKIP=governance git commit ...` (the framework's native skip mechanism).
+
+### lefthook
+
+```yaml
+pre-commit:
+  commands:
+    governance:
+      run: bash tests/governance/run.sh
+      skip_empty: true
+```
+
+## Where to put complex rules
+
+- **Bash** — filesystem, grep, regex. Fast to add, portable.
+- **pytest / jest / go test** — AST inspection, type checks, cross-file reasoning.
+- **External tools in CI only** — `gitleaks`, `trufflehog`, `semgrep`, dependency scanners. Don't run these in the pre-commit hook (too slow); wire them into `.github/workflows/governance.yml` as additional steps.
+
+Layer them: fast rules on commit, heavier rules in CI. Both are enforcement, just at different cadences.

--- a/governance-bootstrap/references/RULES_CATALOG.md
+++ b/governance-bootstrap/references/RULES_CATALOG.md
@@ -1,0 +1,105 @@
+# Rules Catalog
+
+Every rule ships as a standalone bash script under `tests/governance/rules/`. Each script is independent — delete a `.sh` file to drop the rule; copy a new one to add one. The runner (`run.sh`) picks them up automatically.
+
+## Menu (default offer)
+
+The skill presents these via `AskUserQuestion` across two calls (five categories total).
+
+### Foundation
+| Rule | What it checks |
+|---|---|
+| `constitution-exists`  | `CONSTITUTION.md` exists at the repo root, non-empty, ≥ 10 lines. |
+| `readme-exists`        | `README.md` (or `README.rst`) exists with a heading and ≥ 30 words. |
+| `license-exists`       | `LICENSE` (or variants) exists at the repo root and is non-empty. |
+| `agents-md-exists`     | `AGENTS.md` at repo root, 30–250 lines, with ≥ 3 links to other docs. |
+
+### Security
+| Rule | What it checks |
+|---|---|
+| `no-secrets`           | Heuristic scan for AWS / GCP / GitHub / Slack / Stripe / generic API keys and private-key blocks. |
+| `dotenv-gitignored`    | `.env` is not tracked **and** is listed in `.gitignore`. |
+| `security-md-exists`   | `SECURITY.md` (root / `docs/` / `.github/`) exists and lists a contact email or URL. |
+| `workflows-hardened`   | Every `.github/workflows/*.yml` declares a `permissions:` block **and** pins third-party actions (anything outside `actions/*` and `github/*`) to a full 40-char commit SHA. |
+
+### System of record
+| Rule | What it checks |
+|---|---|
+| `architecture-doc-exists`       | `ARCHITECTURE.md` (root or `docs/`) exists, non-empty, ≥ 20 lines. |
+| `no-broken-internal-doc-links`  | Every markdown `[text](relative/path)` in tracked `.md` files resolves to an existing file. |
+| `doc-freshness`                 | Docs listed in `tests/governance/freshness.conf` carry `<!-- last-verified: YYYY-MM-DD -->` within 90 days (configurable). No-op if the config file is absent. |
+| `ci-workflow-exists`            | `.github/workflows/` contains at least one non-governance workflow. |
+
+### Commit hygiene
+| Rule | What it checks |
+|---|---|
+| `conventional-commits` | Commit subjects match `<type>(scope)?!?: subject`. Supported types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `revert`, `style`. Extend via `GOVERNANCE_CC_EXTRA_TYPES`. Installs a `commit-msg` git hook. |
+| `no-orphan-todos`      | Every `TODO` / `FIXME` on a line references `#123` or `ABC-123`. |
+
+### Quality
+| Rule | What it checks |
+|---|---|
+| `no-debug-statements`          | No `console.log`, `debugger`, `breakpoint()`, `import pdb`, `dbg!`, or `fmt.Println` left in source (tests excluded). |
+| `file-size-limit`              | No source file exceeds 500 lines. Override via `GOVERNANCE_FILE_SIZE_LIMIT`. |
+| `no-large-files`               | No tracked file exceeds 5 MB. Override via `GOVERNANCE_MAX_FILE_SIZE_MB`. |
+| `no-committed-build-artifacts` | Flags tracked `*.pyc`, `__pycache__/`, `*.class`, `*.o`, `node_modules/`, `dist/`, `build/`, `target/`, `out/`, `.DS_Store`, `Thumbs.db`, editor swap files. |
+
+### Always installed (not in the menu)
+| Rule | What it checks |
+|---|---|
+| `no-merge-conflict-markers` | No tracked file contains `<<<<<<<`, `=======`, or `>>>>>>>` at line-start. Zero false positives; always installed. |
+
+## Also available — copy on request
+
+Rules we've built but kept out of the default menu. The skill will install any of these if the user asks for them by name.
+
+| Rule | What it checks | Why it's not a default |
+|---|---|---|
+| `env-example-current` | Every key in a local `.env` is declared in `.env.example`. | Only helps teams that keep a `.env` locally; niche. |
+| `docs-dir-minimum`    | A configured list of required docs exists under `docs/`. | The list varies too much per project to default. *(Not yet shipped — write as needed via the template below.)* |
+| `no-curl-bash-pipe`   | No `curl … \| bash` or `curl … \| sh` in tracked scripts. | Real attack vector, but niche — opt-in. *(Not yet shipped.)* |
+| `no-http-urls-in-source` | Non-localhost `http://` URLs flagged in source. | High false-positive rate in docs and examples. *(Not yet shipped.)* |
+| `shell-scripts-safe` | All `*.sh` files have `set -e` / `set -u`. | Defensive but pedantic. *(Not yet shipped.)* |
+
+## In-source waivers
+
+Line-level rules respect a trailing comment: `governance: allow-<rule-name> <reason>`.
+
+```python
+api_key = "AKIA..."  # governance: allow-no-secrets INFRA-1247 — lab fixture
+```
+
+Waivers are visible in `git blame` and searchable by design. Only use them for documented, intentional exceptions.
+
+## Template for a new rule
+
+```bash
+#!/usr/bin/env bash
+# Rule: <one-line statement of the rule>
+# Rationale: <why it matters — link to an incident if possible>
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "<rule-name>"    # must match filename without .sh
+require_git
+
+# ── your check ───────────────────────────────────────────────
+# On every violation: call `violation "<file>:<line> — <message>"`
+# Support waivers:     has_waiver "$file" "$line_no" "<rule-name>" && continue
+# ─────────────────────────────────────────────────────────────
+
+rule_end
+```
+
+### Checklist for adding a new rule
+
+1. Drop the script into `tests/governance/rules/<rule-name>.sh`, `chmod +x`.
+2. Add an **Invariants** subsection in `CONSTITUTION.md` — Rule / Rationale / Enforced by / Exceptions.
+3. Append to the **Evolution Log** in `CONSTITUTION.md` with the PR link.
+4. Both changes land in the **same commit**.
+
+Every rule should be:
+
+- **Deterministic** — same repo state, same result.
+- **Fast** — every rule runs on every commit. Keep it under a second when possible.
+- **Specific** — a violation message should name the file, line, and reason. `"✗ bad code somewhere"` is worthless.
+- **Waivable when warranted** — if there are legitimate exceptions, support the `governance: allow-<rule>` waiver comment so they're auditable.


### PR DESCRIPTION
## Summary

Initial content for governance-kit — three Claude Code skills implementing a governance-driven development paradigm where invariants live in a versioned `CONSTITUTION.md` and are enforced by tests in `tests/governance/`.

- **governance-bootstrap** — detects the project's stack, presents a menu of 20 default rules (Foundation / Security / System-of-record / Commit hygiene / Quality), installs git hooks with a `SKIP_GOVERNANCE=1` escape hatch, writes a CI workflow with SHA-pinned actions + least-privilege permissions, and seeds `CONSTITUTION.md` from a template.
- **governance-amend** — adds/edits/removes a rule as a coordinated three-artifact amendment: the test script, an Invariants subsection in the constitution, and an Evolution Log entry. Refuses piecemeal application — that's the cardinal rule.
- **doc-gardener** — scans docs for staleness and opens remediation PRs. Two-tier classification separates low-risk stamp bumps (batched, ready-for-review) from drafted content updates (one PR per doc, opened as Draft). Unions an always-on baseline (`AGENTS.md`, `README.md`, `SECURITY.md`, `docs/**`, `plans/**`, `adrs/**`, etc.) with `freshness.conf` so it works out of the box; `CHANGELOG.md` and ADRs are explicitly skipped as historical records.

## Notable design choices

- **Polyglot detection in bootstrap.** The rule menu narrows based on `go.mod` / `package.json` / `pyproject.toml` / `Cargo.toml` / `pom.xml` presence, so Go repos don't get `no-pdb-breakpoints` and Python repos don't get `no-console-log`.
- **Bash 3.2 compatible.** macOS default shell — no `mapfile`, no iterative regex with `=~`, and `date -j -f` for ISO parsing. All 20 rule scripts plus the runner tested on 3.2.
- **In-source waivers.** Rules respect `governance: allow-<rule-name>` comments on the same line so one-off exceptions don't require editing the rule script.
- **Supply-chain hardening.** The seeded `governance.yml` workflow pins third-party actions by commit SHA, not floating tag, and declares an explicit `permissions:` block scoped to `contents: read`.
- **Gardener separation.** The `doc-freshness` rule (CI blocker) stays strictly opt-in via `freshness.conf` for predictability. The gardener (remediation helper) is the generous one with the baseline union.
- **agentskills.io spec.** Each skill has `SKILL.md` with YAML frontmatter (name/description), `assets/` for scaffolds, `references/` for on-demand docs, and `evals/evals.json` with prompt/expected_output/assertions test cases.

## Test plan

- [ ] Walk through `governance-bootstrap/SKILL.md` and confirm the 8-step flow reads cleanly end-to-end.
- [ ] Dry-run `governance-bootstrap` in a scratch polyglot repo; confirm hook install, rule selection menu, and `run.sh` exits 0 on the clean baseline.
- [ ] Run the `governance-amend` flow to add a new rule; confirm all three artifacts (test + invariant subsection + Evolution Log entry) are presented before application.
- [ ] Seed a repo with mixed-staleness docs, run `doc-gardener`, verify the baseline-union tracked-doc set and the bump-only vs. needs-update split.
- [ ] Spot-check each skill's `evals/evals.json` — prompts are realistic, assertions are verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)