### PR TITLE
test: eval-readiness helper + author evals and fixtures for all 3 skills

### DIFF
--- a/governance-amend/evals/files/repo-with-console-log-rule/CONSTITUTION.md
+++ b/governance-amend/evals/files/repo-with-console-log-rule/CONSTITUTION.md
@@ -1,0 +1,21 @@
+# CONSTITUTION
+
+## Compliance
+
+Agents and humans working in this repo must read and follow this document. Mechanical invariants are enforced by `tests/governance/run.sh`.
+
+## Principles
+
+- Keep logs structured, not printed.
+- Amendments land atomically: rule + invariant + evolution-log entry.
+
+## Invariants
+
+### no-console-log
+**Rule.** No `console.log` / `console.debug` calls in tracked `.ts` / `.tsx` / `.js` / `.jsx` files.
+**Enforced by.** `tests/governance/rules/no-console-log.sh`
+**Waivers.** `// governance: allow-no-console-log <TICKET>` on the offending line.
+
+## Evolution Log
+
+- 2025-10-20 — Initial bootstrap. Added `no-console-log` rule. Author: fixture-owner.

--- a/governance-amend/evals/files/repo-with-console-log-rule/README.md
+++ b/governance-amend/evals/files/repo-with-console-log-rule/README.md
@@ -1,0 +1,3 @@
+# repo-with-console-log-rule
+
+A bootstrapped repo that already has a `no-console-log` rule. Governance-amend eval case 3 asks the skill to remove the rule cleanly (script + invariant + evolution-log entry) AND surface the dangling reference to `no-console-log` that lives in `docs/LOGGING.md`.

--- a/governance-amend/evals/files/repo-with-console-log-rule/docs/LOGGING.md
+++ b/governance-amend/evals/files/repo-with-console-log-rule/docs/LOGGING.md
@@ -1,0 +1,3 @@
+# Logging
+
+We use pino for structured logging. See the `no-console-log` governance rule for the reason we block `console.log` in source files — if you ever need a printf debug, waive it inline with `// governance: allow-no-console-log <TICKET>` and remove the waiver before merging.

--- a/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/lib.sh
+++ b/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/lib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then echo "✓ $_RULE_NAME"; exit 0; fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘ not a git repo"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/rules/no-console-log.sh
+++ b/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/rules/no-console-log.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Rule: no console.log / console.debug in tracked JS/TS.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-console-log"
+require_git
+
+while IFS=: read -r file line _; do
+    [[ -z "$file" ]] && continue
+    if ! has_waiver "$file" "$line" "no-console-log"; then
+        violation "$file:$line"
+    fi
+done < <(git ls-files -z '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null \
+         | xargs -0 grep -nE 'console\.(log|debug)' 2>/dev/null || true)
+
+rule_end

--- a/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/run.sh
+++ b/governance-amend/evals/files/repo-with-console-log-rule/tests/governance/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘ skipped"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-amend/evals/files/repo-with-file-size-rule/CONSTITUTION.md
+++ b/governance-amend/evals/files/repo-with-file-size-rule/CONSTITUTION.md
@@ -1,0 +1,21 @@
+# CONSTITUTION
+
+## Compliance
+
+Agents and humans working in this repo must read and follow this document. Mechanical invariants are enforced by `tests/governance/run.sh`.
+
+## Principles
+
+- Keep files small and reviewable.
+- Amendments land atomically: rule + invariant + evolution-log entry.
+
+## Invariants
+
+### file-size-limit
+**Rule.** No single tracked source file may exceed 500 lines.
+**Enforced by.** `tests/governance/rules/file-size-limit.sh` (limit controlled by `GOVERNANCE_FILE_SIZE_LIMIT`, default 500).
+**Waivers.** Append `# governance: allow-file-size-limit <TICKET>` to the first line of the file.
+
+## Evolution Log
+
+- 2025-11-02 — Initial bootstrap. Added `file-size-limit` rule at 500 lines. Author: fixture-owner.

--- a/governance-amend/evals/files/repo-with-file-size-rule/README.md
+++ b/governance-amend/evals/files/repo-with-file-size-rule/README.md
@@ -1,0 +1,3 @@
+# repo-with-file-size-rule
+
+A bootstrapped repo that already has a `file-size-limit` rule with a 500-line default, used by governance-amend eval case 2. The eval expects the skill to raise the limit to 800 in place — not duplicate the rule — and record the change in the Evolution Log.

--- a/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/lib.sh
+++ b/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/lib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then echo "✓ $_RULE_NAME"; exit 0; fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘ not a git repo"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/rules/file-size-limit.sh
+++ b/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/rules/file-size-limit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Rule: no single tracked source file may exceed the limit.
+# Limit is controlled by GOVERNANCE_FILE_SIZE_LIMIT (default 500).
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "file-size-limit"
+require_git
+
+LIMIT="${GOVERNANCE_FILE_SIZE_LIMIT:-500}"
+
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    case "$f" in
+        *.md|*.lock|*.svg|*.json) continue ;;
+    esac
+    lines=$(wc -l < "$f" 2>/dev/null | tr -d ' ')
+    [[ -z "$lines" ]] && continue
+    if (( lines > LIMIT )); then
+        first="$(sed -n '1p' "$f")"
+        if [[ "$first" == *"governance: allow-file-size-limit"* ]]; then
+            continue
+        fi
+        violation "$f has $lines lines (> $LIMIT)"
+    fi
+done < <(git ls-files 2>/dev/null)
+
+rule_end

--- a/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/run.sh
+++ b/governance-amend/evals/files/repo-with-file-size-rule/tests/governance/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘ skipped"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-amend/evals/files/seeded-repo/CONSTITUTION.md
+++ b/governance-amend/evals/files/seeded-repo/CONSTITUTION.md
@@ -1,0 +1,22 @@
+# CONSTITUTION
+
+## Compliance
+
+Agents and humans working in this repo must read and follow this document. Mechanical invariants are enforced by `tests/governance/run.sh` (pre-commit hook and CI).
+
+## Principles
+
+- Keep changes small and reviewable.
+- Every Invariant has a matching test script in `tests/governance/rules/`.
+- Amendments land atomically: rule + invariant + evolution-log entry in one commit.
+
+## Invariants
+
+### no-secrets
+**Rule.** No credentials or private keys in tracked files.
+**Enforced by.** `tests/governance/rules/no-secrets.sh`
+**Waivers.** `# governance: allow-no-secrets <TICKET>` on the offending line.
+
+## Evolution Log
+
+- 2026-01-15 — Initial bootstrap. Seeded with `no-secrets` rule. Author: fixture-owner.

--- a/governance-amend/evals/files/seeded-repo/README.md
+++ b/governance-amend/evals/files/seeded-repo/README.md
@@ -1,0 +1,3 @@
+# seeded-repo
+
+A minimal bootstrapped repo for governance-amend eval case 1. Contains a CONSTITUTION.md with Principles/Invariants/Evolution Log and a tiny tests/governance/ scaffold. The eval expects the skill to add a new `no-key-material` rule atomically across all three artifacts.

--- a/governance-amend/evals/files/seeded-repo/tests/governance/lib.sh
+++ b/governance-amend/evals/files/seeded-repo/tests/governance/lib.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then
+        echo "✓ $_RULE_NAME"; exit 0
+    fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘ not a git repo"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-amend/evals/files/seeded-repo/tests/governance/rules/no-secrets.sh
+++ b/governance-amend/evals/files/seeded-repo/tests/governance/rules/no-secrets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Rule: reject committed credentials and private keys.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+require_git
+while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    violation "$hit"
+done < <(git ls-files -z | xargs -0 grep -InE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null || true)
+rule_end

--- a/governance-amend/evals/files/seeded-repo/tests/governance/run.sh
+++ b/governance-amend/evals/files/seeded-repo/tests/governance/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Governance test runner. Discovers every rule under ./rules/ and runs it.
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘ skipped"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-bootstrap/evals/files/already-bootstrapped-repo/CONSTITUTION.md
+++ b/governance-bootstrap/evals/files/already-bootstrapped-repo/CONSTITUTION.md
@@ -1,0 +1,21 @@
+<!-- CUSTOMIZED by the fixture owner — overwriting loses their edits. -->
+# CONSTITUTION
+
+## Compliance
+
+Agents and humans working in this repo must read and follow this document.
+
+## Principles
+
+- Keep changes small and reviewable.
+- Every rule has a matching test script.
+
+## Invariants
+
+### no-secrets
+**Rule.** No credentials or private keys in tracked files.
+**Enforced by.** tests/governance/rules/no-secrets.sh
+
+## Evolution Log
+
+- 2025-12-01 — Initial hand-rolled bootstrap. Author: fixture-owner.

--- a/governance-bootstrap/evals/files/already-bootstrapped-repo/README.md
+++ b/governance-bootstrap/evals/files/already-bootstrapped-repo/README.md
@@ -1,0 +1,3 @@
+# already-bootstrapped-repo
+
+A repo that already has `tests/governance/` from a prior bootstrap run. The `# CUSTOMIZED` marker in `lib.sh` and the custom rule script signal files the user has hand-edited. The skill must NOT overwrite these; it should detect the prior setup and point the user at governance-amend.

--- a/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/lib.sh
+++ b/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/lib.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# CUSTOMIZED — do not overwrite. Includes an extra helper used by this repo's rules.
+set -u
+
+_RULE_NAME=""
+_VIOLATION_COUNT=0
+_VIOLATIONS=()
+
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()   { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then
+        echo "OK $_RULE_NAME"; exit 0
+    fi
+    echo "FAIL $_RULE_NAME ($_VIOLATION_COUNT)"
+    for v in "${_VIOLATIONS[@]}"; do echo "  $v"; done
+    exit 1
+}
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+
+# Local helper added by the fixture owner.
+fixture_custom_helper() { echo "custom"; }

--- a/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/rules/no-secrets.sh
+++ b/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/rules/no-secrets.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CUSTOMIZED — hand-tuned secret patterns for this repo. Do not overwrite.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+matches=$(git ls-files -z | xargs -0 grep -InE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null || true)
+[[ -n "$matches" ]] && violation "$matches"
+rule_end

--- a/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/run.sh
+++ b/governance-bootstrap/evals/files/already-bootstrapped-repo/tests/governance/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# CUSTOMIZED runner — the fixture owner edited this. Do not overwrite.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+for rule in "$HERE"/rules/*.sh; do
+    bash "$rule" || exit 1
+done
+echo "governance: all custom rules passed"

--- a/governance-bootstrap/evals/files/empty-polyglot-repo/README.md
+++ b/governance-bootstrap/evals/files/empty-polyglot-repo/README.md
@@ -1,0 +1,3 @@
+# empty-polyglot-repo
+
+A minimal Python + TypeScript repo fixture for the governance-bootstrap skill. Contains no governance scaffolding — the skill should detect both languages and propose a tailored rule set via `AskUserQuestion` before doing anything.

--- a/governance-bootstrap/evals/files/empty-polyglot-repo/package.json
+++ b/governance-bootstrap/evals/files/empty-polyglot-repo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture-polyglot",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "test": "echo 'no tests yet'"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/governance-bootstrap/evals/files/empty-polyglot-repo/pyproject.toml
+++ b/governance-bootstrap/evals/files/empty-polyglot-repo/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "fixture-polyglot"
+version = "0.0.1"
+description = "Fixture repo for governance-bootstrap eval case 1."
+requires-python = ">=3.11"

--- a/governance-bootstrap/evals/files/empty-polyglot-repo/src/index.ts
+++ b/governance-bootstrap/evals/files/empty-polyglot-repo/src/index.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return `hello, ${name}`;
+}

--- a/governance-bootstrap/evals/files/empty-polyglot-repo/src/main.py
+++ b/governance-bootstrap/evals/files/empty-polyglot-repo/src/main.py
@@ -1,0 +1,6 @@
+def greet(name: str) -> str:
+    return f"hello, {name}"
+
+
+if __name__ == "__main__":
+    print(greet("world"))

--- a/governance-bootstrap/evals/files/go-service-repo/README.md
+++ b/governance-bootstrap/evals/files/go-service-repo/README.md
@@ -1,0 +1,3 @@
+# go-service-repo
+
+Minimal Go service fixture for the governance-bootstrap skill. No governance scaffolding yet. The skill should pick Go-appropriate rules and include the Security category.

--- a/governance-bootstrap/evals/files/go-service-repo/go.mod
+++ b/governance-bootstrap/evals/files/go-service-repo/go.mod
@@ -1,0 +1,3 @@
+module example.com/fixture-go-service
+
+go 1.22

--- a/governance-bootstrap/evals/files/go-service-repo/main.go
+++ b/governance-bootstrap/evals/files/go-service-repo/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello from fixture go service")
+}

--- a/governance-gardener/evals/evals.json
+++ b/governance-gardener/evals/evals.json
@@ -1,0 +1,66 @@
+{
+  "skill_name": "governance-gardener",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run the governance gardener on this repo. I want a health report — don't open any PRs yet, I'll look at the report first.",
+      "expected_output": "The skill runs all three axes (Alignment, Friction, Consistency), writes a single report file at governance-health/YYYY-MM-DD.md with a Summary traffic-light table, per-axis sections with signal IDs and evidence, an Actionable queue, and (if a prior report exists) a Trend section. The report carries the <!-- governance: allow-plan-captured --> marker at the top. The skill then invokes AskUserQuestion with four options and defaults to option (4) — nothing. No branches or PRs are created.",
+      "files": ["evals/files/governed-repo-with-drift/"],
+      "assertions": [
+        "A file governance-health/<today>.md was created",
+        "The report contains sections for Alignment, Friction, and Consistency",
+        "At least one finding includes a signal ID (e.g., A1, A3, F2, C1) and concrete evidence (commit SHAs, file paths with line numbers, or counts)",
+        "Every finding carries a confidence tag of high, medium, or low",
+        "The report's first non-empty line contains <!-- governance: allow-plan-captured -->",
+        "The skill invoked AskUserQuestion offering bump-stamps / draft doc updates / both / nothing",
+        "The default option presented was option (4) — Nothing (review the report first)",
+        "No branches matching 'governance-gardener/*' were created",
+        "No PRs were opened",
+        "The working tree is clean after the run apart from the new report file"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Run the gardener. I've got some uncommitted changes staged but just go ahead — I need the report for a meeting.",
+      "expected_output": "The skill detects the dirty working tree in preflight and refuses to run. It tells the user to commit or stash first and does not produce a report, create branches, or open PRs. It holds the rule even under pressure — the rationale (never entangle gardener output with unrelated user work) still applies.",
+      "files": ["evals/files/dirty-tree-repo/"],
+      "assertions": [
+        "The skill detected uncommitted changes or untracked files in the preflight step",
+        "The skill explicitly refused to proceed and told the user to commit or stash",
+        "No governance-health/ report file was created",
+        "No branches were created",
+        "No PRs were opened",
+        "The skill did not cave to the 'just go ahead' pressure — it held the rule because mixing gardener output with unrelated changes is never right"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Run the governance gardener please.",
+      "expected_output": "The skill's preflight detects that CONSTITUTION.md and/or tests/governance/ are missing, concludes there is nothing to garden, points the user at the governance-bootstrap skill, and exits without writing a report or creating branches.",
+      "files": ["evals/files/ungoverned-repo/"],
+      "assertions": [
+        "The skill detected the absence of CONSTITUTION.md or tests/governance/",
+        "The skill recommended running governance-bootstrap first",
+        "No governance-health/ file was created",
+        "No branches or PRs were created",
+        "The skill exited cleanly — it did not error out or half-run the axes against a non-governance repo"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Garden the governance. After you show me the report, go ahead and open the bump-stamps PR if there are any docs that only need their last-verified line touched.",
+      "expected_output": "The skill produces the health report. After AskUserQuestion, the user's answer routes to the bump-stamps follow-up. Exactly one branch named governance-gardener/stamp-bumps-<YYYY-MM-DD> is created; its diff contains only <!-- last-verified: ... --> line edits — no prose changes. The PR is opened as ready-for-review (not draft). The skill does NOT open any draft doc-update PRs, does NOT edit CONSTITUTION.md, and does NOT write new rule scripts.",
+      "files": ["evals/files/governed-repo-bump-eligible/"],
+      "assertions": [
+        "The health report was written to governance-health/<today>.md before any PR was opened",
+        "Exactly one branch named 'governance-gardener/stamp-bumps-<YYYY-MM-DD>' was created",
+        "The bump-stamps branch diff contains only changes to <!-- last-verified: --> lines — no prose edits",
+        "The bump-stamps PR was opened as ready-for-review (not draft)",
+        "No edits were made to CONSTITUTION.md",
+        "No new files were added under tests/governance/rules/",
+        "No draft doc-update PRs were opened (the user only asked for bump-stamps)",
+        "Rule-shaped candidates surfaced in the report handed off to governance-amend rather than being amended in place"
+      ]
+    }
+  ]
+}

--- a/governance-gardener/evals/files/README.md
+++ b/governance-gardener/evals/files/README.md
@@ -1,0 +1,10 @@
+# Eval fixtures
+
+Each subdirectory is a seed repo state for one gardener eval case. Before running an eval, copy the fixture into a fresh temp directory, run `git init && git add -A && git commit -m "seed"` inside it, and point the skill at that directory.
+
+- `governed-repo-with-drift/` — a bootstrapped repo with obvious Alignment/Friction/Consistency signals seeded in (aspirational rule, stale stamp with drift, dead-rule candidate). Eval case 1.
+- `dirty-tree-repo/` — a bootstrapped repo plus an uncommitted file (`UNCOMMITTED.md`). Delete the file and re-seed if you need a clean variant. Eval case 2.
+- `ungoverned-repo/` — a bare repo with just a README.md and no governance scaffolding. Eval case 3.
+- `governed-repo-bump-eligible/` — a bootstrapped repo with one doc whose `last-verified` stamp has expired but whose watched paths are unchanged, making it bump-only. Eval case 4.
+
+Fixtures are intentionally minimal — the eval checks the skill's *behavior* on well-understood seed states, not its ability to handle large repos.

--- a/governance-gardener/evals/files/dirty-tree-repo/CONSTITUTION.md
+++ b/governance-gardener/evals/files/dirty-tree-repo/CONSTITUTION.md
@@ -1,0 +1,16 @@
+# CONSTITUTION
+
+## Compliance
+Agents and humans follow this document. Mechanical invariants in `tests/governance/run.sh`.
+
+## Principles
+- Governance artifacts stay in sync with the code.
+
+## Invariants
+
+### no-secrets
+**Rule.** No credentials or private keys in tracked files.
+**Enforced by.** `tests/governance/rules/no-secrets.sh`
+
+## Evolution Log
+- 2026-02-01 — Bootstrap. Author: fixture-owner.

--- a/governance-gardener/evals/files/dirty-tree-repo/README.md
+++ b/governance-gardener/evals/files/dirty-tree-repo/README.md
@@ -1,0 +1,9 @@
+# dirty-tree-repo
+
+Bootstrapped repo. Gardener eval case 2 — the skill must refuse to run on a dirty tree.
+
+**Seed steps for the grader:**
+1. Copy this fixture to a fresh directory.
+2. `git init && git add -A && git commit -m "seed"`
+3. Create the dirty state: `echo 'wip' >> UNCOMMITTED.md`
+4. Do NOT commit — the skill is supposed to see uncommitted work.

--- a/governance-gardener/evals/files/dirty-tree-repo/UNCOMMITTED.md
+++ b/governance-gardener/evals/files/dirty-tree-repo/UNCOMMITTED.md
@@ -1,0 +1,3 @@
+# Scratch
+
+The grader appends to this file after the seed commit to create a dirty working tree.

--- a/governance-gardener/evals/files/dirty-tree-repo/tests/governance/lib.sh
+++ b/governance-gardener/evals/files/dirty-tree-repo/tests/governance/lib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then echo "✓ $_RULE_NAME"; exit 0; fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-gardener/evals/files/dirty-tree-repo/tests/governance/rules/no-secrets.sh
+++ b/governance-gardener/evals/files/dirty-tree-repo/tests/governance/rules/no-secrets.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+require_git
+while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    violation "$hit"
+done < <(git ls-files -z | xargs -0 grep -InE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null || true)
+rule_end

--- a/governance-gardener/evals/files/dirty-tree-repo/tests/governance/run.sh
+++ b/governance-gardener/evals/files/dirty-tree-repo/tests/governance/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/CONSTITUTION.md
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/CONSTITUTION.md
@@ -1,0 +1,16 @@
+# CONSTITUTION
+
+## Compliance
+Agents and humans follow this document. Mechanical invariants in `tests/governance/run.sh`.
+
+## Principles
+- Docs are stamped with a `last-verified` line and watched paths.
+
+## Invariants
+
+### no-secrets
+**Rule.** No credentials or private keys in tracked files.
+**Enforced by.** `tests/governance/rules/no-secrets.sh`
+
+## Evolution Log
+- 2025-08-15 — Bootstrap with no-secrets.

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/README.md
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/README.md
@@ -1,0 +1,7 @@
+# governed-repo-bump-eligible
+
+A bootstrapped repo with one doc whose `last-verified` stamp has expired but whose watched paths have not changed since the stamp — the gardener should classify it as **bump-only** (signal A4), and when the user opts in to the bump-stamps follow-up, open a single batched stamp-only PR.
+
+**Seed steps for the grader:**
+1. Copy fixture; `git init && git add -A && git commit -m "seed"`.
+2. Do NOT edit `src/api.ts` — the watched path must stay untouched relative to the stamp date, so the drift check returns "unchanged".

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/docs/API.md
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/docs/API.md
@@ -1,0 +1,6 @@
+<!-- last-verified: 2024-06-01 -->
+<!-- gardener-watches: src/api.ts -->
+
+# API
+
+The public HTTP API is defined in `src/api.ts`. Each exported function corresponds to one endpoint.

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/src/api.ts
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/src/api.ts
@@ -1,0 +1,7 @@
+export function getHealth(): { ok: boolean } {
+  return { ok: true };
+}
+
+export function getVersion(): { version: string } {
+  return { version: "0.1.0" };
+}

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/freshness.conf
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/freshness.conf
@@ -1,0 +1,2 @@
+# path<TAB>freshness_days<TAB>watched_paths
+docs/API.md	90	src/api.ts

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/lib.sh
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/lib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then echo "✓ $_RULE_NAME"; exit 0; fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/rules/no-secrets.sh
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/rules/no-secrets.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+require_git
+while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    violation "$hit"
+done < <(git ls-files -z | xargs -0 grep -InE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null || true)
+rule_end

--- a/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/run.sh
+++ b/governance-gardener/evals/files/governed-repo-bump-eligible/tests/governance/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-gardener/evals/files/governed-repo-with-drift/CONSTITUTION.md
+++ b/governance-gardener/evals/files/governed-repo-with-drift/CONSTITUTION.md
@@ -1,0 +1,21 @@
+# CONSTITUTION
+
+## Compliance
+Agents and humans follow this document. Mechanical invariants are enforced by `tests/governance/run.sh`.
+
+## Principles
+- Governance artifacts stay in sync with the code.
+
+## Invariants
+
+### no-secrets
+**Rule.** Tracked files should not contain credentials or private keys.
+**Enforced by.** `tests/governance/rules/no-secrets.sh`
+
+### agents-md-exists
+**Rule.** AGENTS.md exists at the repo root.
+**Enforced by.** `tests/governance/rules/agents-md-exists.sh`
+
+## Evolution Log
+- 2025-09-10 — Bootstrap with no-secrets.
+- 2025-10-02 — Added agents-md-exists invariant (test script to follow — NOTE: never landed).

--- a/governance-gardener/evals/files/governed-repo-with-drift/README.md
+++ b/governance-gardener/evals/files/governed-repo-with-drift/README.md
@@ -1,0 +1,12 @@
+# governed-repo-with-drift
+
+A bootstrapped repo seeded with known drift across all three axes. Gardener eval case 1 — the skill should produce a health report surfacing these findings:
+
+- **Alignment A1 (aspirational rule):** `CONSTITUTION.md` names `agents-md-exists` as an Invariant, but no `tests/governance/rules/agents-md-exists.sh` script exists.
+- **Alignment A3 (doc drift):** `docs/ARCHITECTURE.md` has a `<!-- last-verified: 2024-01-01 -->` stamp; the watched path `src/server.ts` was edited after the stamp (seeded with a recent commit).
+- **Consistency C2 (test without rule):** `tests/governance/rules/no-console-log.sh` exists on disk but is not named in any Invariants entry.
+- **Consistency C5 (hedge language):** the `no-secrets` Invariant's Rule line contains "should" — Invariants should be hard rules.
+
+**Seed steps for the grader:**
+1. Copy fixture; `git init && git add -A && git commit -m "seed"`.
+2. To make the A3 signal fire, amend `src/server.ts` and commit — e.g. `echo '// bump' >> src/server.ts && git commit -am "touch server"`. The `last-verified` stamp in `docs/ARCHITECTURE.md` predates this commit.

--- a/governance-gardener/evals/files/governed-repo-with-drift/docs/ARCHITECTURE.md
+++ b/governance-gardener/evals/files/governed-repo-with-drift/docs/ARCHITECTURE.md
@@ -1,0 +1,6 @@
+<!-- last-verified: 2024-01-01 -->
+<!-- gardener-watches: src/server.ts, src/db.ts -->
+
+# Architecture
+
+The server in `src/server.ts` handles HTTP requests, and `src/db.ts` wraps a sqlite connection pool. Both modules are the source of truth for this document — when their shape changes, this doc needs a refresh.

--- a/governance-gardener/evals/files/governed-repo-with-drift/src/db.ts
+++ b/governance-gardener/evals/files/governed-repo-with-drift/src/db.ts
@@ -1,0 +1,5 @@
+export function createPool() {
+  return {
+    query: async (_sql: string) => ({ rows: [] }),
+  };
+}

--- a/governance-gardener/evals/files/governed-repo-with-drift/src/server.ts
+++ b/governance-gardener/evals/files/governed-repo-with-drift/src/server.ts
@@ -1,0 +1,7 @@
+import { createPool } from "./db";
+
+export async function main() {
+  const pool = createPool();
+  await pool.query("SELECT 1");
+  return "ok";
+}

--- a/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/freshness.conf
+++ b/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/freshness.conf
@@ -1,0 +1,2 @@
+# path<TAB>freshness_days<TAB>watched_paths (comma-separated)
+docs/ARCHITECTURE.md	90	src/server.ts,src/db.ts

--- a/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/lib.sh
+++ b/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/lib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+_RULE_NAME=""; _VIOLATION_COUNT=0; _VIOLATIONS=()
+rule_start() { _RULE_NAME="$1"; _VIOLATION_COUNT=0; _VIOLATIONS=(); }
+violation()  { _VIOLATION_COUNT=$((_VIOLATION_COUNT + 1)); _VIOLATIONS+=("$1"); }
+rule_end() {
+    if [[ $_VIOLATION_COUNT -eq 0 ]]; then echo "✓ $_RULE_NAME"; exit 0; fi
+    echo "✗ $_RULE_NAME ($_VIOLATION_COUNT violation(s))"
+    for v in "${_VIOLATIONS[@]}"; do echo "    $v"; done
+    exit 1
+}
+require_git() { git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "⊘"; exit 0; }; }
+has_waiver() { sed -n "${2}p" "$1" | grep -q "governance: allow-${3}"; }
+tracked_files() { if [[ $# -eq 0 ]]; then git ls-files; else git ls-files "$@"; fi; }

--- a/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/rules/no-console-log.sh
+++ b/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/rules/no-console-log.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Orphan: this script exists on disk but is NOT named in any CONSTITUTION Invariants
+# entry. The gardener should flag it under Consistency C2 (test without rule).
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-console-log"
+require_git
+while IFS=: read -r file line _; do
+    [[ -z "$file" ]] && continue
+    violation "$file:$line"
+done < <(git ls-files -z '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null \
+         | xargs -0 grep -nE 'console\.(log|debug)' 2>/dev/null || true)
+rule_end

--- a/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/rules/no-secrets.sh
+++ b/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/rules/no-secrets.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "no-secrets"
+require_git
+while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    violation "$hit"
+done < <(git ls-files -z | xargs -0 grep -InE 'AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null || true)
+rule_end

--- a/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/run.sh
+++ b/governance-gardener/evals/files/governed-repo-with-drift/tests/governance/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+if [[ "${SKIP_GOVERNANCE:-0}" == "1" ]]; then echo "⊘"; exit 0; fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+for rule in "$HERE"/rules/*.sh; do
+    [[ -f "$rule" ]] || continue
+    bash "$rule" || failed=1
+done
+[[ $failed -eq 0 ]] || exit 1
+echo "governance: all rules passed"

--- a/governance-gardener/evals/files/ungoverned-repo/README.md
+++ b/governance-gardener/evals/files/ungoverned-repo/README.md
@@ -1,0 +1,3 @@
+# ungoverned-repo
+
+A bare repo with no CONSTITUTION.md and no `tests/governance/`. Gardener eval case 3 — the skill should tell the user to run governance-bootstrap first and exit cleanly.

--- a/governance-gardener/evals/files/ungoverned-repo/src/app.ts
+++ b/governance-gardener/evals/files/ungoverned-repo/src/app.ts
@@ -1,0 +1,3 @@
+export function ok(): string {
+  return "ok";
+}

--- a/plans/2026-04-22-author-skill-evals.md
+++ b/plans/2026-04-22-author-skill-evals.md
@@ -1,0 +1,25 @@
+# Author evals for all three skills
+
+## Goal
+
+Bring eval coverage to parity across the three skills so `scripts/eval-report.sh` reports ready for each. Before this change: `governance-bootstrap` and `governance-amend` had `evals.json` specs but no seeded fixture directories (only placeholder READMEs), and `governance-gardener` had no eval spec at all.
+
+## Steps
+
+1. **Author `governance-gardener/evals/evals.json`** — four cases mirroring the shape of the other two skills' specs (prompt, expected_output, assertions, fixture path). Cases cover: (1) happy-path health report with AskUserQuestion defaulting to "nothing", (2) dirty-tree refusal, (3) ungoverned-repo exit with bootstrap recommendation, (4) user opts into bump-stamps follow-up.
+2. **Seed `governance-bootstrap/evals/files/`** with three fixtures: `empty-polyglot-repo/` (package.json + pyproject.toml + tiny src), `already-bootstrapped-repo/` (pre-existing governance with `# CUSTOMIZED` markers so graders detect overwrites), `go-service-repo/` (go.mod + main.go).
+3. **Seed `governance-amend/evals/files/`** with three fixtures: `seeded-repo/` (baseline bootstrapped), `repo-with-file-size-rule/` (adds `file-size-limit.sh` at 500 lines), `repo-with-console-log-rule/` (adds `no-console-log.sh` plus `docs/LOGGING.md` referencing the rule by name so the skill must surface a dangling reference on removal).
+4. **Seed `governance-gardener/evals/files/`** with four fixtures: `governed-repo-with-drift/` (seeded A1/A3/C2/C5 signals), `dirty-tree-repo/` (bootstrapped + instructions to create an uncommitted file after seed), `ungoverned-repo/` (bare repo), `governed-repo-bump-eligible/` (stale stamp with unchanged watched paths).
+5. **Verify** — run `bash scripts/eval-report.sh` and expect all three skills to flip from `fixtures-incomplete` / `missing` to `ready` with exit 0. Run `bash tests/governance/run.sh` to confirm the repo's governance suite still passes.
+
+## Non-goals
+
+- Executing the evals. They are LLM-graded behavioral checks; executing them requires spinning up a Claude Code session per case against the seeded fixture, which a human runs. `scripts/eval-report.sh` only reports *readiness*, not pass/fail.
+- Reorganizing the three skills under a top-level `skills/` directory. The user deferred that suggestion to a later change so this PR stays focused.
+
+## Design notes
+
+- Fixtures are intentionally minimal: just enough files to exercise the scenario, not production-sized. Each fixture's README tells the grader how to seed (`git init && git add -A && git commit -m seed`) and any case-specific post-seed step (e.g., dirty-tree requires appending to `UNCOMMITTED.md` after the seed commit).
+- The `already-bootstrapped-repo/` fixture embeds visible `# CUSTOMIZED` comment markers in its `lib.sh` / `run.sh` / `rules/no-secrets.sh` so the grader can assert the bootstrap skill did not overwrite hand-edited files.
+- Gardener fixture `governed-repo-with-drift/` seeds multiple axes at once (A1 aspirational rule, A3 doc drift with an annotation, C2 test-without-rule orphan, C5 hedge language in the `no-secrets` invariant). The health report should surface at least one per axis.
+- `governed-repo-bump-eligible/` carries a `last-verified: 2024-06-01` stamp that has clearly expired against a 90-day freshness window, but the watched path (`src/api.ts`) is unchanged since the stamp — so the signal is A4 (bump-only), not A3 (drift).

--- a/scripts/eval-report.sh
+++ b/scripts/eval-report.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Produces a coverage/readiness report for the skill evals in this repo.
+#
+# Evals are behavioral (prompt + expected_output + assertions) and are graded by
+# an LLM, so this script does not execute them. It inspects each skill's
+# evals/evals.json and reports: case counts, assertion counts, and whether the
+# referenced fixture directories exist and contain more than a placeholder.
+#
+# Usage:
+#   bash scripts/eval-report.sh              # markdown report to stdout
+#   bash scripts/eval-report.sh --out FILE   # also write report to FILE
+#   bash scripts/eval-report.sh --json       # machine-readable JSON summary
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS=(governance-bootstrap governance-amend governance-gardener)
+
+OUT=""
+FORMAT="md"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        --json) FORMAT="json"; shift ;;
+        -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required" >&2
+    exit 2
+fi
+
+# Collect results into parallel arrays (bash 3.2 compatible).
+names=()
+statuses=()
+case_counts=()
+assertion_counts=()
+fixture_missing=()
+fixture_placeholder=()
+issues=()
+
+overall_ready=1
+
+for skill in "${SKILLS[@]}"; do
+    spec="$ROOT/$skill/evals/evals.json"
+    names+=("$skill")
+
+    if [[ ! -f "$spec" ]]; then
+        statuses+=("missing")
+        case_counts+=(0)
+        assertion_counts+=(0)
+        fixture_missing+=(0)
+        fixture_placeholder+=(0)
+        issues+=("no evals/evals.json")
+        overall_ready=0
+        continue
+    fi
+
+    if ! jq -e . "$spec" >/dev/null 2>&1; then
+        statuses+=("invalid-json")
+        case_counts+=(0)
+        assertion_counts+=(0)
+        fixture_missing+=(0)
+        fixture_placeholder+=(0)
+        issues+=("evals.json is not valid JSON")
+        overall_ready=0
+        continue
+    fi
+
+    n_cases=$(jq '.evals | length' "$spec")
+    n_assert=$(jq '[.evals[].assertions | length] | add // 0' "$spec")
+
+    miss=0
+    place=0
+    skill_issues=""
+    while IFS= read -r rel; do
+        [[ -z "$rel" ]] && continue
+        path="$ROOT/$skill/$rel"
+        if [[ ! -e "$path" ]]; then
+            miss=$((miss + 1))
+            skill_issues+="missing fixture: $rel; "
+        elif [[ -d "$path" ]]; then
+            # Placeholder = directory contains only a README.md (no seeded repo).
+            entries=$(find "$path" -mindepth 1 -maxdepth 1 ! -name README.md | head -n 1)
+            if [[ -z "$entries" ]]; then
+                place=$((place + 1))
+                skill_issues+="fixture is placeholder only: $rel; "
+            fi
+        fi
+    done < <(jq -r '.evals[].files[]?' "$spec")
+
+    fixture_missing+=("$miss")
+    fixture_placeholder+=("$place")
+    case_counts+=("$n_cases")
+    assertion_counts+=("$n_assert")
+
+    if [[ $miss -gt 0 || $place -gt 0 ]]; then
+        statuses+=("fixtures-incomplete")
+        overall_ready=0
+    else
+        statuses+=("ready")
+    fi
+    issues+=("${skill_issues%% ; }")
+done
+
+emit_md() {
+    printf '# Skill evals report\n\n'
+    printf '_Generated %s_\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '| Skill | Status | Cases | Assertions | Missing fixtures | Placeholder fixtures |\n'
+    printf '|---|---|---:|---:|---:|---:|\n'
+    for i in "${!names[@]}"; do
+        printf '| %s | %s | %s | %s | %s | %s |\n' \
+            "${names[$i]}" "${statuses[$i]}" "${case_counts[$i]}" \
+            "${assertion_counts[$i]}" "${fixture_missing[$i]}" "${fixture_placeholder[$i]}"
+    done
+    printf '\n## Notes\n\n'
+    for i in "${!names[@]}"; do
+        if [[ -n "${issues[$i]}" ]]; then
+            printf -- '- **%s**: %s\n' "${names[$i]}" "${issues[$i]}"
+        fi
+    done
+    printf '\n## How to run the evals\n\n'
+    printf 'Evals are LLM-graded behavioral checks, not unit tests. For each case in '
+    printf 'a skill'\''s `evals.json`:\n\n'
+    printf '1. Copy the fixture under `<skill>/evals/files/<fixture>/` into a fresh temp dir and `git init` it.\n'
+    printf '2. Start a Claude Code session scoped to that dir with the skill installed.\n'
+    printf '3. Paste the `prompt` field verbatim.\n'
+    printf '4. Compare the resulting state against `expected_output` and each item in `assertions`.\n\n'
+    if [[ $overall_ready -eq 1 ]]; then
+        printf '**All skills have complete eval specs and fixtures.**\n'
+    else
+        printf '**Some skills are not eval-ready** — see the Notes section.\n'
+    fi
+}
+
+emit_json() {
+    local first=1
+    printf '{"generated_at":"%s","skills":[' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    for i in "${!names[@]}"; do
+        [[ $first -eq 0 ]] && printf ','
+        first=0
+        printf '{"name":"%s","status":"%s","cases":%s,"assertions":%s,"missing_fixtures":%s,"placeholder_fixtures":%s,"notes":%s}' \
+            "${names[$i]}" "${statuses[$i]}" "${case_counts[$i]}" \
+            "${assertion_counts[$i]}" "${fixture_missing[$i]}" "${fixture_placeholder[$i]}" \
+            "$(printf '%s' "${issues[$i]}" | jq -Rs .)"
+    done
+    printf '],"ready":%s}\n' "$([[ $overall_ready -eq 1 ]] && echo true || echo false)"
+}
+
+if [[ "$FORMAT" == "json" ]]; then
+    if [[ -n "$OUT" ]]; then emit_json | tee "$OUT"; else emit_json; fi
+else
+    if [[ -n "$OUT" ]]; then emit_md | tee "$OUT"; else emit_md; fi
+fi
+
+[[ $overall_ready -eq 1 ]]


### PR DESCRIPTION
## Summary
Consolidated eval-related changes in a single PR:

1. **`scripts/eval-report.sh`** — helper that validates each skill's `evals/evals.json` and reports case/assertion counts plus missing-or-placeholder fixture dirs. Markdown output by default; `--json` for machine-readable; `--out FILE` to tee. Exits non-zero if any skill is not eval-ready.
2. **`governance-gardener/evals/evals.json`** — 4 cases / 29 assertions covering health-report happy path, dirty-tree refusal, ungoverned-repo exit, and bump-stamps follow-up.
3. **Seeded fixture directories** across all three skills' `evals/files/` trees so graders have real seed repos to run each eval against.

## Fixtures added
- **governance-bootstrap** — `empty-polyglot-repo/`, `already-bootstrapped-repo/` (with `# CUSTOMIZED` markers), `go-service-repo/`.
- **governance-amend** — `seeded-repo/`, `repo-with-file-size-rule/`, `repo-with-console-log-rule/` (includes `docs/LOGGING.md` that references the rule by name so the skill must surface dangling-reference warnings on removal).
- **governance-gardener** — `governed-repo-with-drift/` (seeds A1/A3/C2/C5 signals), `dirty-tree-repo/`, `ungoverned-repo/`, `governed-repo-bump-eligible/`.

Each fixture's `README.md` documents any post-seed step the grader needs (e.g., the dirty-tree case asks the grader to append a line to `UNCOMMITTED.md` after `git init && git add -A && git commit -m seed`).

Plan: [plans/2026-04-22-author-skill-evals.md](plans/2026-04-22-author-skill-evals.md).

## Report after merge
```
| Skill                | Status | Cases | Assertions |
|----------------------|--------|------:|-----------:|
| governance-bootstrap | ready  |     3 |         22 |
| governance-amend     | ready  |     3 |         19 |
| governance-gardener  | ready  |     4 |         29 |
```

## Test plan
- [x] `bash scripts/eval-report.sh` — all three skills report `ready`, exit 0.
- [x] `bash scripts/eval-report.sh --json | jq .` — valid JSON, `ready: true`.
- [x] `bash tests/governance/run.sh` — all 13 rules pass.
- [ ] Manually run one eval case end-to-end against the new fixtures (future follow-up — requires a Claude Code session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)