### PR TITLE
docs(skills): tighten governance skill instructions

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -97,10 +97,10 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 
 ### plan-captured
 
-- **Rule**: The repo maintains a `plans/` directory with at least one tracked `.md` file, and every `plans/*.md` has a top-level `# ` heading, a `## Goal` section, and a `## Steps` section.
+- **Rule**: The repo maintains a `plans/` directory with at least one tracked `.md` file, every `plans/*.md` has a top-level `# ` heading, a `## Goal` section, and a `## Steps` section, and every substantive tracked change outside `plans/` or `governance-health/` adds or modifies at least one `plans/*.md` file in the same change set.
 - **Rationale**: The diff shows *what* changed; the plan shows *why it took this shape*. Without the plan on disk, reviewers and future agents reconstruct intent from code and get it wrong.
 - **Enforced by**: `tests/governance/rules/plan-captured.sh`
-- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-captured` (bare or inside an HTML comment) anywhere in the file exempts that plan.
+- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-captured` (bare or inside an HTML comment) anywhere in the file exempts that plan from the structure check. Changes limited to `plans/` or `governance-health/` are exempt from the same-change requirement.
 
 ### issues-tracked
 
@@ -132,6 +132,7 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 - 2026-04-22 — @srikanth — Add `issues-tracked`: require `QUALITY.md` with Open + Resolved sections so bugs live in the system of record, not Slack.
 - 2026-04-22 — @srikanth — Add **Compliance** section: explicit directive that humans, agents, and automation must satisfy every principle, guideline, and invariant — not just the mechanically enforced ones. Mirrored into the bootstrap template.
 - 2026-04-22 — @srikanth — Add `hooks-configured`: move local hook scripts to tracked `.githooks/` and require `core.hooksPath=.githooks`, so a fresh clone gets the same local enforcement as every other contributor. Bootstrap skill updated to install hooks under `.githooks/` (not `.git/hooks/`).
+- 2026-04-22 — @srikanth — Strengthen `plan-captured`: require substantive tracked changes to touch `plans/*.md` in the same change set, so missing plans fail mechanically instead of relying on repo memory.
 
 ## Escape hatches
 

--- a/GOVERNANCE_VOCABULARY.md
+++ b/GOVERNANCE_VOCABULARY.md
@@ -1,0 +1,73 @@
+<!-- last-verified: 2026-04-22 -->
+
+# Governance Vocabulary
+
+Shared terms used by `governance-bootstrap`, `governance-amend`, and `governance-gardener`.
+
+## Core terms
+
+### rule
+
+A concrete requirement or prohibition that can be checked mechanically. In this repo, a rule belongs in `CONSTITUTION.md` only if there is an executable check for it.
+
+### invariant
+
+A rule as recorded in the `## Invariants` section of `CONSTITUTION.md`. Each invariant names the rule, rationale, enforcing test, and exceptions.
+
+### principle
+
+A non-mechanical guideline that still governs the repo, but depends on judgment rather than a pass/fail script.
+
+### waiver
+
+An explicitly documented exception to a rule. Waivers are local and intentional; they are not silent escapes. Typical forms are inline comments such as `governance: allow-<rule-name> <reason>` or named config files the rule reads.
+
+### evolution log
+
+The append-only history in `CONSTITUTION.md` recording governance changes. It explains when a rule changed and why.
+
+### system of record
+
+The tracked files that define how the repo works now. In this project that usually means `CONSTITUTION.md`, `AGENTS.md`, docs, rule scripts, and any tracked config the governance suite relies on.
+
+### drift
+
+Misalignment between two things that should agree. Common examples:
+
+- constitution drift: the invariant and the enforcing test no longer match
+- doc drift: a doc's `last-verified` stamp is older than the code it describes
+- evolution-log drift: a logged amendment was not made atomically with its test change
+
+### signal
+
+A gardener finding pattern such as `A3`, `F2`, or `C5`. Signals are evidence-backed observations, not automatic amendments.
+
+### watched scope
+
+The file set a doc or rule is considered responsible for. The gardener uses watched scopes to decide whether a doc has drifted or whether a rule is dormant. Canonical resolution lives in [governance-gardener/references/WATCH_SCOPES.md](governance-gardener/references/WATCH_SCOPES.md).
+
+## Execution terms
+
+### bootstrap
+
+Initial installation of the governance kit into a repo that does not yet have it, or an explicit augment/overwrite operation requested by the user.
+
+### amend
+
+A targeted change to an existing governance installation: add, modify, or remove a specific rule while keeping the constitution and enforcing test in sync.
+
+### gardener
+
+A periodic health check over an existing governance installation. The gardener writes a report and may optionally open follow-up PRs after user review.
+
+### report-only mode
+
+Gardener mode that writes the health report but does not create branches or PRs. Dirty working trees are acceptable here.
+
+### follow-up mode
+
+Gardener mode that may create branches or PRs after the report is written. Requires a clean working tree.
+
+### material assumption
+
+An inference that changes behavior in a way the user may care about. Examples: choosing a stack in a polyglot repo, choosing `.githooks/` over another hook framework, selecting the `standard` preset without explicit user confirmation, or inferring watched scope from sibling directories. Skills should label these explicitly as assumptions in their summaries.

--- a/governance-amend/SKILL.md
+++ b/governance-amend/SKILL.md
@@ -182,6 +182,8 @@ Every successful run should include:
 - **Iterate on the check when it is ambiguous.** A staged half-baked rule is worse than no rule — if the rule shape is unclear, slow down and clarify before staging.
 - **Never invent rationale.** If the user didn't give a reason, ask. "Because it's best practice" is not a rationale — governance derives authority from *named* incidents and *real* constraints. A rule without one is a speed bump nobody respects.
 - **Preserve policy intent on updates.** Threshold tweaks and mechanical refinements should not silently rewrite the rationale.
+- **Strengthen weak proxies, do not preserve them by default.** If an existing rule claims to enforce per-change behavior but only checks repo-level existence or file shape, treat that mismatch as drift worth fixing, not a quirk to copy forward.
+- **Choose the check shape by failure mode.** Ask what bad merge this rule is meant to block. If the answer is "a future change that forgot to do X", the test should inspect the staged diff or branch diff rather than only the repo at rest.
 - **Respect existing formatting.** The constitution is a living document. Match the indent style, list marker, and heading level conventions already in the file. Don't rewrite prose the user has been tending to.
 - **State material assumptions explicitly.** If you inferred the rule name, summary line, or author handle, surface that in the summary.
 - **Don't commit.** The skill ends at `git add`, not `git commit`. The user's review is the final gate.

--- a/governance-amend/SKILL.md
+++ b/governance-amend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: governance-amend
-description: Amends an existing governance-kit setup — adds a new rule (or modifies an existing one) atomically across three artifacts that must land in the same commit: a new test script under tests/governance/rules/, a new Invariants subsection in CONSTITUTION.md, and an entry in the Evolution Log. Enforces the cardinal rule of governance-driven development — a rule and its enforcing test evolve together. Use when the user says "add a governance rule", "add a new invariant", "amend the constitution", "add a rule to CONSTITUTION.md", "update governance", or "evolve governance".
+description: Amends an existing governance-kit setup by adding or modifying a specific governance rule atomically across the enforcing test and the constitution's invariant/log entries. Use when the repo already has governance-kit installed and the user wants a concrete rule change such as "add a governance rule", "add a new invariant", "amend the constitution", or "modify rule X". Do not use for initial setup; use governance-bootstrap for that. Do not use for general health reviews; use governance-gardener for that.
 license: MIT
 metadata:
   author: governance-kit
@@ -14,13 +14,13 @@ The `governance-bootstrap` skill sets up the system of record. **This skill evol
 
 Governance-driven development's cardinal rule: *the constitution and the enforcing tests evolve together, in one commit.* This skill makes obeying that rule cheap and makes breaking it harder than following it.
 
-Every amendment this skill produces is three artifacts, staged atomically:
+Every amendment this skill produces is three logical changes, staged atomically:
 
 1. A new (or updated) test script at `tests/governance/rules/<rule-name>.sh`.
 2. A new **Invariants** subsection in `CONSTITUTION.md`.
 3. A new entry in the `CONSTITUTION.md` **Evolution Log**.
 
-The skill does **not** commit. The user reviews and commits. But the three files are staged together and the skill refuses to finish with a partial amendment on disk.
+The skill does **not** commit. The user reviews and commits. But the amendment is staged together and the skill refuses to finish with a partial amendment on disk.
 
 ---
 
@@ -52,6 +52,12 @@ Most requests will already give you most of this — extract what you can from t
 
 If any field is ambiguous, **ask one question at a time** via `AskUserQuestion` or free text — don't dump a four-question form on the user. The most common blocker is "check logic" being too vague; iterate until you have something concrete enough to write bash that either passes or fails deterministically.
 
+Use two operating modes:
+- **Fast path** — if the user's request already names a concrete rule, rationale, and check shape, draft the amendment directly, smoke-test it, and then show the result.
+- **Interactive path** — if rule scope, rationale, or check logic is ambiguous, ask one concise question at a time until the rule is concrete enough to implement safely.
+
+If structured question tools are unavailable, use short free-text questions instead of stopping.
+
 **Check for collisions before you proceed:**
 - If `tests/governance/rules/<name>.sh` already exists → this is an **update**, not a new rule. Confirm with the user before overwriting, and treat the matching `CONSTITUTION.md` subsection as an update too (not a new insertion).
 - If `CONSTITUTION.md` already has a subsection whose header closely matches the proposed name → same thing, confirm.
@@ -69,9 +75,11 @@ The script must:
 - On every violation: call `violation "<file>:<line> — <specific-message>"`. A rule without a location in the message is less useful — always include one if the check is per-file or per-line.
 - Honor in-source waivers via `has_waiver "$file" "$line_no" "<rule-name>"` wherever violations are line-level, *unless* the user explicitly said no exceptions.
 
-**Before showing the draft to the user**, syntax-check it: `bash -n tests/governance/rules/<name>.sh`. If it fails, fix and re-check. Do not put syntactically broken bash in front of the user.
+Syntax-check it: `bash -n tests/governance/rules/<name>.sh`. If it fails, fix and re-check. Do not put syntactically broken bash in front of the user.
 
-Show the draft. Ask whether it's the check they want. Iterate. When the user signs off, write it to disk.
+On the **interactive path**, show the draft and ask whether it's the check they want. Iterate. When the user signs off, write it to disk.
+
+On the **fast path**, write the script once it passes syntax check, then show the user the resulting rule and any smoke-test output. Do not stop for approval unless the smoke test reveals ambiguity or the rule would require waivers or repo fixes the user did not ask for.
 
 ### Step 4 — Smoke-test the script
 
@@ -130,8 +138,8 @@ Print:
 ## Key design rules
 
 - **Three artifacts or nothing.** If you can only produce two of the three (e.g., the script is ambiguous and can't be written yet), stop and report. Do not edit `CONSTITUTION.md` for a rule whose test doesn't exist yet, and do not write a test whose invariant isn't in the constitution. That is exactly the drift this skill is built to prevent.
-
-- **Iterate on the check before staging.** The user should see the script, approve it, and see it pass a smoke test *before* anything is staged. A staged half-baked rule is worse than no rule — it invites a quick commit to "clean up git status" and ships broken governance.
+- **Fast path when the request is concrete.** Do not force an approval loop for an obvious, well-specified amendment.
+- **Iterate on the check when it is ambiguous.** A staged half-baked rule is worse than no rule — if the rule shape is unclear, slow down and clarify before staging.
 
 - **Never invent rationale.** If the user didn't give a reason, ask. "Because it's best practice" is not a rationale — governance derives authority from *named* incidents and *real* constraints. A rule without one is a speed bump nobody respects.
 

--- a/governance-amend/SKILL.md
+++ b/governance-amend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: governance-amend
-description: Amends an existing governance-kit setup by adding or modifying a specific governance rule atomically across the enforcing test and the constitution's invariant/log entries. Use when the repo already has governance-kit installed and the user wants a concrete rule change such as "add a governance rule", "add a new invariant", "amend the constitution", or "modify rule X". Do not use for initial setup; use governance-bootstrap for that. Do not use for general health reviews; use governance-gardener for that.
+description: Amends an existing governance-kit setup by adding, modifying, or removing a specific governance rule atomically across the enforcing test and the constitution's invariant/log entries. Use when the repo already has governance-kit installed and the user wants a concrete rule change such as "add a governance rule", "add a new invariant", "amend the constitution", "modify rule X", or "remove rule Y". Do not use for initial setup; use governance-bootstrap for that. Do not use for general health reviews; use governance-gardener for that.
 license: MIT
 metadata:
   author: governance-kit
@@ -21,6 +21,27 @@ Every amendment this skill produces is three logical changes, staged atomically:
 3. A new entry in the `CONSTITUTION.md` **Evolution Log**.
 
 The skill does **not** commit. The user reviews and commits. But the amendment is staged together and the skill refuses to finish with a partial amendment on disk.
+
+## Negative triggers
+
+Do **not** use this skill for these requests:
+
+- "Set up governance for this repo" — use `governance-bootstrap`.
+- "Run a governance health check" or "find dead rules" — use `governance-gardener`.
+- "Explain what this constitution means" — answer directly; do not amend anything.
+- "Review whether these rules are good" — answer directly or use `governance-gardener`.
+
+## Interaction policy
+
+| Situation | Action |
+|---|---|
+| Governance kit is missing | Stop and tell the user to run `governance-bootstrap` first. |
+| User asks for a general review or health check | Do not amend. Redirect to `governance-gardener`. |
+| Request names a concrete rule, rationale, and check shape | Use the fast path. |
+| Request is missing rationale or check logic | Ask one concise question at a time until it is implementable. |
+| Request updates an existing rule | Preserve the existing rationale unless the user explicitly changes the policy intent. |
+| Request removes a rule | Remove the test and invariant together, add an evolution-log entry, and surface dangling references. |
+| Structured question tools are unavailable | Use short free-text questions instead of stopping. |
 
 ---
 
@@ -61,6 +82,7 @@ If structured question tools are unavailable, use short free-text questions inst
 **Check for collisions before you proceed:**
 - If `tests/governance/rules/<name>.sh` already exists → this is an **update**, not a new rule. Confirm with the user before overwriting, and treat the matching `CONSTITUTION.md` subsection as an update too (not a new insertion).
 - If `CONSTITUTION.md` already has a subsection whose header closely matches the proposed name → same thing, confirm.
+- If the user asked to **remove** a rule, confirm the matching script and invariant exist before you start deleting. Also grep for dangling references in docs or CI notes before finishing.
 
 ### Step 3 — Draft the test script
 
@@ -108,6 +130,8 @@ Two edits, both in the same file:
 
 Preserve everything else in the file verbatim. Use `Edit`, not `Write`.
 
+If this is an **update** to an existing rule, preserve the original rationale unless the user explicitly changes the underlying policy intent. Threshold changes and mechanical refinements normally keep the existing rationale and only update the rule text, exceptions, or enforcement details.
+
 **(b) Append an Evolution Log entry** in the format the file already uses (check the existing entries — the format is per-project). Default template:
 
 ```markdown
@@ -118,7 +142,7 @@ Use today's date from the session environment (not a placeholder).
 
 ### Step 6 — Stage the three artifacts
 
-`git add tests/governance/rules/<rule-name>.sh CONSTITUTION.md`
+Use `git add -A tests/governance/rules/<rule-name>.sh CONSTITUTION.md` so removals are staged correctly too.
 
 Then run `git status` to confirm the three changes are staged and nothing else unrelated is picked up. If other unstaged changes exist, leave them unstaged — they're not part of this amendment.
 
@@ -128,10 +152,26 @@ Then run `git status` to confirm the three changes are staged and nothing else u
 
 Print:
 - The rule name.
+- The action type: added, updated, or removed.
 - The three files changed (with paths).
+- Smoke-test result: pass, fail-with-real-violation, or crashed-then-fixed.
+- Staged status: confirm the intended amendment files are staged and unrelated files are not.
 - A suggested commit message in Conventional Commits format: `feat(governance): add <rule-name> — <one-line summary>`
 - How to test locally: `bash tests/governance/run.sh <rule-name>`
+- Assumptions made. If none, say `Assumptions: none`.
 - A reminder that the pre-commit hook and CI workflow already pick up the new rule — no hook reinstall needed.
+
+## Required final output
+
+Every successful run should include:
+
+- `Rule:` name
+- `Action:` added, updated, or removed
+- `Files changed:` list
+- `Smoke test:` result
+- `Staged:` yes/no summary
+- `Assumptions:` any material assumptions, or `none`
+- `Suggested commit:` conventional-commit subject
 
 ---
 
@@ -140,15 +180,15 @@ Print:
 - **Three artifacts or nothing.** If you can only produce two of the three (e.g., the script is ambiguous and can't be written yet), stop and report. Do not edit `CONSTITUTION.md` for a rule whose test doesn't exist yet, and do not write a test whose invariant isn't in the constitution. That is exactly the drift this skill is built to prevent.
 - **Fast path when the request is concrete.** Do not force an approval loop for an obvious, well-specified amendment.
 - **Iterate on the check when it is ambiguous.** A staged half-baked rule is worse than no rule — if the rule shape is unclear, slow down and clarify before staging.
-
 - **Never invent rationale.** If the user didn't give a reason, ask. "Because it's best practice" is not a rationale — governance derives authority from *named* incidents and *real* constraints. A rule without one is a speed bump nobody respects.
-
+- **Preserve policy intent on updates.** Threshold tweaks and mechanical refinements should not silently rewrite the rationale.
 - **Respect existing formatting.** The constitution is a living document. Match the indent style, list marker, and heading level conventions already in the file. Don't rewrite prose the user has been tending to.
-
+- **State material assumptions explicitly.** If you inferred the rule name, summary line, or author handle, surface that in the summary.
 - **Don't commit.** The skill ends at `git add`, not `git commit`. The user's review is the final gate.
 
 ## References
 
+- `../GOVERNANCE_VOCABULARY.md` — shared terms used across the three governance skills.
 - `assets/rule.template.sh` — the starter shape for a new rule script.
 - `assets/invariant-section.template.md` — the shape for the Invariants subsection.
 - `references/RULE_AUTHORING.md` — patterns and anti-patterns for writing good governance checks.

--- a/governance-amend/evals/evals.json
+++ b/governance-amend/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "We had an incident yesterday (INC-4117) — someone committed a private key file (*.pem) and we had to rotate half our credentials. Add a governance rule that blocks committing *.pem, *.key, and *.p12 files. Wire it into the constitution properly.",
-      "expected_output": "Three coordinated artifacts land together: (a) a new tests/governance/rules/<rule-name>.sh that blocks committing the listed key/cert extensions, (b) a new Invariants subsection in CONSTITUTION.md describing the rule and citing INC-4117, and (c) an Evolution Log entry with today's date summarizing the amendment. The rule is tested against a seeded repo with and without a .pem file. The skill does not commit the change without showing the three artifacts to the user.",
+      "expected_output": "Three coordinated artifacts land together: (a) a new tests/governance/rules/<rule-name>.sh that blocks committing the listed key/cert extensions, (b) a new Invariants subsection in CONSTITUTION.md describing the rule and citing INC-4117, and (c) an Evolution Log entry with today's date summarizing the amendment. The rule is tested against a seeded repo with and without a .pem file. Because the request is concrete, the skill may use its fast path, but it must still report the rule name, action type, smoke-test result, staged status, and suggested commit message.",
       "files": ["evals/files/seeded-repo/"],
       "assertions": [
         "A new rule script was created under tests/governance/rules/ with a name matching the invariant (e.g., no-key-material.sh)",
@@ -15,7 +15,7 @@
         "CONSTITUTION.md's Evolution Log gained a new entry dated today describing the amendment",
         "Running tests/governance/run.sh on a repo containing a staged *.pem file produces a violation referencing the new rule",
         "Running tests/governance/run.sh on a clean repo (no key files) exits 0 after the amendment",
-        "The skill presented the three artifacts (test, invariant section, evolution log entry) as a coordinated set before applying them — it did not apply them piecemeal"
+        "The skill reported the action type, smoke-test result, staged status, and suggested commit message in its final summary"
       ]
     },
     {
@@ -28,7 +28,8 @@
         "The new limit value (800) appears in the rule script or its env var default",
         "The CONSTITUTION.md invariant for file-size-limit references 800 (not 500)",
         "A new Evolution Log entry was added with today's date describing the limit change and citing the data-pipeline false-positive reason",
-        "No new rule script file was created"
+        "No new rule script file was created",
+        "The amendment summary reported that this was an update rather than a new rule"
       ]
     },
     {
@@ -42,6 +43,17 @@
         "A new Evolution Log entry dated today records the removal with the stated reason",
         "Running tests/governance/run.sh still exits 0 on the seeded repo after removal",
         "If the repo contains any references to the removed rule name (e.g., in a README or CI doc), the skill surfaced them to the user rather than silently leaving dangling references"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Can you run a governance health check and tell me if any of these rules look stale?",
+      "expected_output": "The skill recognizes that this is a health-check request, not a targeted amendment. It does not edit files, does not stage changes, and redirects the user to governance-gardener or answers directly.",
+      "files": ["evals/files/seeded-repo/"],
+      "assertions": [
+        "No files under tests/governance/rules/ or CONSTITUTION.md were modified",
+        "The skill explicitly identified the request as a review/health-check rather than an amendment request",
+        "The skill redirected to governance-gardener or answered directly without staging changes"
       ]
     }
   ]

--- a/governance-amend/evals/files/README.md
+++ b/governance-amend/evals/files/README.md
@@ -5,5 +5,6 @@ Each subdirectory is a seed repo state for one eval case. Before running, copy t
 - `seeded-repo/` — a repo that has already run `governance-bootstrap` (has `tests/governance/`, `CONSTITUTION.md`, hooks). No key-material rule yet. For eval 1.
 - `repo-with-file-size-rule/` — seeded repo with `tests/governance/rules/file-size-limit.sh` at the default 500-line limit. For eval 2.
 - `repo-with-console-log-rule/` — seeded repo with `tests/governance/rules/no-console-log.sh` enabled and documented in CONSTITUTION.md. For eval 3.
+- `seeded-repo/` also backs the negative-routing eval where amend should refuse a general health-check request and redirect to gardener; eval case 4.
 
 All three share the same scaffolding; they differ only in which rules are pre-installed and what the constitution records.

--- a/governance-amend/references/RULE_AUTHORING.md
+++ b/governance-amend/references/RULE_AUTHORING.md
@@ -22,6 +22,8 @@ The constitution is only as strong as the rules inside it. A bad rule — one th
 
 **Rules that lie.** A check that claims to enforce X but actually enforces a weak proxy for X is worse than no check — it creates false confidence. If you can only enforce an approximation, say so in the rationale, and name the gap.
 
+**Repo-state checks for change-set obligations.** If the real intent is "every substantive change must do X", a check that only proves "the repo has one X file somewhere" is not governance, it's theater. Prefer inspecting the staged diff in hooks and the branch diff in CI.
+
 **Checks that double as documentation.** If a rule's failure message is "see docs/SECURITY.md for why this matters", fine — but the message must *first* say what's wrong and where. Never make the developer read documentation to understand which line failed.
 
 **Non-idempotent logic.** A rule that modifies the repo while checking is a bug. Governance reads; remediation writes. Keep them separate. (If the rule needs writable scratch space, use `mktemp -d`.)
@@ -30,11 +32,34 @@ The constitution is only as strong as the rules inside it. A bad rule — one th
 
 ## Patterns by rule class
 
+### Change-set-aware checks
+
+Use these when the rule is about what must accompany a given substantive change, not just what must exist in the repo.
+
+Good fits:
+
+- every substantive change must update a plan
+- code changes affecting auth must update a specific doc or test suite
+- changes under a sensitive path must touch an approval or metadata file
+
+Implementation guidance:
+
+- In pre-commit or local runs, inspect `git diff --cached --name-only`.
+- In CI or branch validation, inspect the merge-base diff against the default branch.
+- Exempt non-substantive paths explicitly, rather than pretending they never happen.
+- Report the missing companion artifact and a few example changed files so the failure is obvious.
+
+Bad fit:
+
+- "repo contains at least one plan file" when the real intent is "this change must add or update a plan"
+- "QUALITY.md exists" when the real intent is "newly discovered issues must be recorded before merge"
+
 ### Existence / content checks (`*-exists`)
 
 - Check at the repo root, or in a small known set of locations (`X.md`, `docs/X.md`, `.github/X.md`).
 - Validate a minimum size or a minimum content signal (e.g., "contains an email address").
 - Fail fast on the first missing condition — no reason to keep checking if the file is absent.
+- Use this class only when repo-level presence is the true policy intent. If the real intent is per-change compliance, do not hide behind an existence check.
 
 ### Pattern-scan checks (`no-*`)
 
@@ -66,6 +91,47 @@ done < <(ls)
 ```
 
 Wrong on five axes: no rationale, non-specific rule statement, uses `ls` (includes gitignored files and directories), violation message has no location, pattern is meaningless.
+
+Another common anti-pattern:
+
+Bad rule statement:
+
+> Every substantive change must update `plans/`.
+
+Bad implementation:
+
+```bash
+[[ -d plans ]] || violation "plans/ missing"
+git ls-files -- 'plans/*.md' | grep -q . || violation "no plan files"
+```
+
+Why it's bad: it proves only that the repo once had a plan file. It does not fail the exact thing the rule claims to prevent: a new substantive change landing without a plan update.
+
+Better implementation shape:
+
+```bash
+changed_files=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    changed_files+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACMRD -- 2>/dev/null || true)
+
+plan_touched=0
+substantive=0
+for f in "${changed_files[@]}"; do
+    case "$f" in
+        plans/*.md) plan_touched=1 ;;
+        governance-health/*) ;;
+        *) substantive=1 ;;
+    esac
+done
+
+if [[ $substantive -eq 1 && $plan_touched -eq 0 ]]; then
+    violation "substantive change set has no accompanying plan update"
+fi
+```
+
+Now the check matches the policy claim.
 
 Good:
 

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -18,6 +18,26 @@ This skill sets up **governance-driven development** in the current repository:
 
 Governance evolves: new rules get added to `CONSTITUTION.md` *and* to `tests/governance/` together. The constitution without the tests is just a wishlist.
 
+## Negative triggers
+
+Do **not** use this skill for these requests:
+
+- "Review our constitution" or "is this governance any good?" — answer the question directly or use `governance-gardener`.
+- "Add one new rule" or "change the file-size limit" — use `governance-amend`.
+- "Run a governance health check" or "find dead rules" — use `governance-gardener`.
+- "What does this invariant mean?" — explain the current setup; do not bootstrap.
+
+## Interaction policy
+
+| Situation | Action |
+|---|---|
+| Repo is not a git repo | Stop and tell the user bootstrap requires git. |
+| Repo already has governance artifacts and the user asked for setup | Continue in augment/overwrite mode; default to augment. |
+| Repo already has governance artifacts and the user asked for review, explanation, or one targeted change | Do not bootstrap. Answer directly or redirect to `governance-amend` / `governance-gardener`. |
+| Multiple plausible primary stacks exist | Ask once. If no answer is available, fall back to bash-first generic setup and label it as an assumption. |
+| Hook framework is unclear | Infer from tracked files. If still unclear, assume `.githooks/` and label that as an assumption. |
+| Structured question tools are unavailable | Ask concise free-text questions, then proceed with defaults if the user does not provide more detail. |
+
 ---
 
 ## Activation flow
@@ -59,9 +79,22 @@ Multiple markers → pick the one the user points to. If unclear, ask once.
 
 **Default** for every stack: also install the universal **bash** test runner from `assets/tests-bash/`. Bash tests are language-agnostic (grep/find/wc based) and work anywhere. The native test runner is a second, stack-idiomatic copy that lets governance rules integrate with the project's normal test command. The user picks in Step 3 whether to install native tests, bash tests, or both.
 
-### Step 3 — Offer the rule menu
+### Step 3 — Choose a preset, then customize
 
-The rule catalog is five categories, presented across **two `AskUserQuestion` calls** (the tool caps at four questions per call). Use `multiSelect: true` for every question. If structured question tools are unavailable, ask concise free-text questions in the same category order and proceed with the user's answers. "Other" appears automatically — if the user picks it and describes a rule, generate a new `.sh` file under `tests/governance/rules/` following the template in `references/RULES_CATALOG.md` and add a matching Invariants subsection to `CONSTITUTION.md`.
+Before presenting the full rule menu, ask the user for a starting preset. The preset is a starting point, not a lock-in. The user can always add or remove rules in the next step.
+
+Preset choices:
+
+| Preset | Intent | Default starting rules |
+|---|---|---|
+| `minimal` | Smallest credible governance baseline | `constitution-exists`, `no-secrets`, `dotenv-gitignored`, `workflows-hardened`, `no-broken-internal-doc-links`, `no-large-files`, `no-committed-build-artifacts`, `no-merge-conflict-markers`, and `hooks-configured` when using `.githooks/` |
+| `standard` | Recommended default for most repos | `minimal` plus `agents-md-exists`, `conventional-commits`, `doc-freshness` |
+| `strict` | Broad governance coverage for teams that want more structure | `standard` plus `readme-exists`, `security-md-exists`, `architecture-doc-exists`, `ci-workflow-exists`, `no-orphan-todos`, `file-size-limit`, `no-debug-statements` |
+| `custom` | Start from a blank slate | no preselected rules beyond the always-installed set |
+
+Use `standard` as the recommended preset. If the user does not answer and you must proceed, assume `standard` and label it in the final summary as a material assumption.
+
+After the preset choice, present the rule catalog across **two `AskUserQuestion` calls** (the tool caps at four questions per call). Use `multiSelect: true` for every question. If structured question tools are unavailable, ask concise free-text questions in the same category order and proceed with the user's answers. "Other" appears automatically — if the user picks it and describes a rule, generate a new `.sh` file under `tests/governance/rules/` following the template in `references/RULES_CATALOG.md` and add a matching Invariants subsection to `CONSTITUTION.md`.
 
 **Always installed — do not put in the menu:**
 - `no-merge-conflict-markers` — no `<<<<<<<` / `=======` / `>>>>>>>` in any tracked file. Zero false positives, zero config. Install unconditionally.
@@ -123,6 +156,7 @@ Copy `assets/CONSTITUTION.template.md` to `<repo-root>/CONSTITUTION.md`. Then ta
 - Leave the **Evolution Log** section with a template entry and a note that each amendment needs a commit.
 
 Do not invent principles the user did not pick. It is better to ship a short constitution than a bloated one.
+If you had to infer anything material — stack, preset, or hook strategy — record it under `Assumptions:` in the final summary.
 
 ### Step 4b — Inject the Compliance directive into AGENTS.md
 
@@ -183,13 +217,28 @@ Copy `assets/governance.yml` to `.github/workflows/governance.yml`. Adjust the t
 ### Step 8 — Report to the user
 
 Print a concise summary:
+- Preset chosen and whether it was explicit or assumed.
+- Hook strategy chosen (`.githooks/`, husky, or `pre-commit`).
 - Stack detected.
 - Rules installed (with file paths).
+- Rules deliberately skipped (with reasons) when that matters.
 - How to run locally: `bash tests/governance/run.sh`.
 - How to skip the hook: `SKIP_GOVERNANCE=1 git commit ...` or `git commit --no-verify`.
+- Assumptions made. If none, say `Assumptions: none`.
 - Reminder: **constitution amendments must land with their test.** Point to `references/RULES_CATALOG.md` for the template.
 
 Do **not** commit the new files. Leave that to the user — the first commit of their governance system should be intentional, and the pre-commit hook is now active.
+
+## Required final output
+
+Every successful run should leave the user with a summary that includes:
+
+- `Preset:` chosen preset and whether it was explicit or assumed.
+- `Hook strategy:` `.githooks/`, husky, or `pre-commit`.
+- `Rules installed:` file-backed list or grouped summary.
+- `Rules skipped:` only when the omission is meaningful.
+- `Assumptions:` any material assumptions, or `none`.
+- `Next command:` `bash tests/governance/run.sh`
 
 ---
 
@@ -199,9 +248,12 @@ Do **not** commit the new files. Leave that to the user — the first commit of 
 - **Escape hatches are a feature, not a bug.** `SKIP_GOVERNANCE=1` exists because governance that blocks emergency hotfixes will get ripped out. CI enforces the rule even when the hook is skipped, which is the right layering.
 - **Bash-first, native as enhancement.** Bash tests work in any repo, in any CI, without install steps. Native tests (pytest etc.) are nicer DX but add friction. Default to bash; offer native.
 - **Respect the repo's existing hook framework.** `.githooks/` is the default only when no tracked hook framework already exists. Do not force repos off husky or `pre-commit`.
+- **Start with a preset, then let the user customize.** Presets reduce setup fatigue; the category menu keeps the result intentional.
+- **State material assumptions explicitly.** If you had to infer the preset, stack, or hook strategy, surface that in the summary.
 - **No invented rules.** When writing the constitution, only include rules the user selected. Governance loses authority the moment it contains rules nobody signed off on.
 
 ## References
 
+- `../GOVERNANCE_VOCABULARY.md` — shared terms used across the three governance skills.
 - `references/RULES_CATALOG.md` — full list of ready-made rules with descriptions, and the template for adding new ones.
 - `references/NATIVE_TESTS.md` — how to port bash rules to pytest / jest / go test, and husky / pre-commit-framework snippets.

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -250,6 +250,8 @@ Every successful run should leave the user with a summary that includes:
 - **Respect the repo's existing hook framework.** `.githooks/` is the default only when no tracked hook framework already exists. Do not force repos off husky or `pre-commit`.
 - **Start with a preset, then let the user customize.** Presets reduce setup fatigue; the category menu keeps the result intentional.
 - **State material assumptions explicitly.** If you had to infer the preset, stack, or hook strategy, surface that in the summary.
+- **Match the enforcement surface to the real intent.** If a rule is meant to govern each substantive change, do not implement it as a repo-exists or file-count check. Prefer change-set-aware enforcement where the hook/CI can actually fail the missing behavior.
+- **Reject weak proxies when they create false confidence.** A rule that says "every change must do X" but only checks "the repo contains one X somewhere" is a bad bootstrap output, not a partial success.
 - **No invented rules.** When writing the constitution, only include rules the user selected. Governance loses authority the moment it contains rules nobody signed off on.
 
 ## References

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: governance-bootstrap
-description: Bootstraps governance-driven development in a repository — scaffolds a CONSTITUTION.md, a test suite under tests/governance/ that enforces the constitution, pre-commit and commit-msg hooks (skippable), and a GitHub Actions workflow. Offers a menu of ready-made rules across five categories (Foundation, Security, System of record, Commit hygiene, Quality) including Conventional Commits, secret scanning, .env hygiene, GitHub Actions hardening, AGENTS.md / ARCHITECTURE.md / SECURITY.md checks, broken-link detection, doc freshness, and merge-conflict-marker detection. Use when the user wants to set up governance, add a constitution, enforce invariants, install conventional commits, harden workflows, or when they say "bootstrap governance", "set up governance tests", "governance-driven development", or reference a constitution document.
+description: Bootstraps governance-driven development in a repository that does not yet have the kit installed — scaffolds an initial CONSTITUTION.md, a test suite under tests/governance/ that enforces it, tracked git hooks, and a GitHub Actions workflow. Offers a menu of ready-made rules across five categories (Foundation, Security, System of record, Commit hygiene, Quality) including Conventional Commits, secret scanning, .env hygiene, GitHub Actions hardening, AGENTS.md / ARCHITECTURE.md / SECURITY.md checks, broken-link detection, doc freshness, and merge-conflict-marker detection. Use when the user wants initial governance setup, says "bootstrap governance", "set up governance tests", or wants to install this governance kit into a repo. Do not use for amending an existing rule set; use governance-amend for that.
 license: MIT
 metadata:
   author: governance-kit
@@ -37,6 +37,12 @@ If this is not a git repo, stop and tell the user — governance-bootstrap requi
 
 If artifacts already exist, report what's there and ask whether to **augment** (add missing pieces, preserve existing) or **overwrite** (fresh start). Default to augment.
 
+Also detect hook strategy before you offer or install hook-related rules:
+- If `.husky/` exists, `package.json` references husky, or `.pre-commit-config.yaml` exists, treat the repo as using an existing hook framework.
+- Otherwise, use the repo-local `.githooks/` strategy described below.
+
+This choice affects whether `hooks-configured` is installed. Do not present `.githooks/` as universal if the repo already has a tracked hook framework.
+
 ### Step 2 — Classify the project stack
 
 Pick exactly one primary stack from the markers:
@@ -55,11 +61,11 @@ Multiple markers → pick the one the user points to. If unclear, ask once.
 
 ### Step 3 — Offer the rule menu
 
-The rule catalog is five categories, presented across **two `AskUserQuestion` calls** (the tool caps at four questions per call). Use `multiSelect: true` for every question. "Other" appears automatically — if the user picks it and describes a rule, generate a new `.sh` file under `tests/governance/rules/` following the template in `references/RULES_CATALOG.md` and add a matching Invariants subsection to `CONSTITUTION.md`.
+The rule catalog is five categories, presented across **two `AskUserQuestion` calls** (the tool caps at four questions per call). Use `multiSelect: true` for every question. If structured question tools are unavailable, ask concise free-text questions in the same category order and proceed with the user's answers. "Other" appears automatically — if the user picks it and describes a rule, generate a new `.sh` file under `tests/governance/rules/` following the template in `references/RULES_CATALOG.md` and add a matching Invariants subsection to `CONSTITUTION.md`.
 
 **Always installed — do not put in the menu:**
 - `no-merge-conflict-markers` — no `<<<<<<<` / `=======` / `>>>>>>>` in any tracked file. Zero false positives, zero config. Install unconditionally.
-- `hooks-configured` — `.githooks/pre-commit` (and `.githooks/commit-msg`, if `conventional-commits` is installed) are tracked and executable, and `core.hooksPath` is set to `.githooks`. The meta-rule that makes every other local rule actually run; install unconditionally.
+- `hooks-configured` — `.githooks/pre-commit` (and `.githooks/commit-msg`, if `conventional-commits` is installed) are tracked and executable, and `core.hooksPath` is set to `.githooks`. Install this only when the repo is using the `.githooks/` strategy. If the repo uses husky or `pre-commit`, skip this rule entirely.
 
 **First `AskUserQuestion` call — four questions:**
 
@@ -95,7 +101,7 @@ The rule catalog is five categories, presented across **two `AskUserQuestion` ca
 - `no-large-files` — No tracked file exceeds 5 MB (configurable). *(Recommended)*
 - `no-committed-build-artifacts` — No `__pycache__`, `*.pyc`, `node_modules/`, `dist/`, `build/`, `target/`, `out/`, `.DS_Store` etc. are tracked. *(Recommended)*
 
-For each selected rule, copy `assets/tests-bash/rules/<rule>.sh` into `tests/governance/rules/` in the target repo. Also copy `assets/tests-bash/rules/no-merge-conflict-markers.sh` regardless of what the user picked.
+For each selected rule, copy `assets/tests-bash/rules/<rule>.sh` into `tests/governance/rules/` in the target repo. Also copy `assets/tests-bash/rules/no-merge-conflict-markers.sh` regardless of what the user picked. Copy `assets/tests-bash/rules/hooks-configured.sh` only when using the `.githooks/` strategy.
 
 If the user selects `conventional-commits`, remember that `commit-msg` will also be installed in Step 6.
 
@@ -142,9 +148,13 @@ Copy `assets/tests-bash/lib.sh` to `tests/governance/lib.sh` — shared helpers 
 
 If the user wants **native** tests in addition to bash, read `references/NATIVE_TESTS.md` for the port pattern for their stack (pytest / jest / go test). Generate the native test file(s) inline — do not invent a separate `run.sh` for the native side; the project's existing test runner (`pytest tests/governance`, `npx jest tests/governance`, `go test ./tests/governance/...`) is the entrypoint.
 
-### Step 6 — Install the git hooks (tracked, via `.githooks/`)
+### Step 6 — Install the git hooks
 
-Hook scripts live in a **tracked** directory `.githooks/` — not in `.git/hooks/`, which is per-clone and untracked. This way every contributor's clone gets the same hooks, and the `hooks-configured` rule (always installed) catches anyone whose `core.hooksPath` is unset.
+Choose one path based on the hook strategy detected in Step 1.
+
+**Path A — repo-local `.githooks/`**
+
+Hook scripts live in a **tracked** directory `.githooks/` — not in `.git/hooks/`, which is per-clone and untracked. This way every contributor's clone gets the same hooks, and the `hooks-configured` rule catches anyone whose `core.hooksPath` is unset.
 
 Do this:
 
@@ -153,11 +163,18 @@ Do this:
    - Runs `tests/governance/run.sh` (bash mode) and/or the native command (if native tests are installed — detect and run both if present).
    - On failure, prints the failing rule, the `SKIP_GOVERNANCE=1 git commit` escape hatch, and `git commit --no-verify` as the nuclear option.
 2. **If, and only if, the user selected `conventional-commits`**, also copy `assets/githooks/commit-msg` to `.githooks/commit-msg` and `chmod +x` it. Honors the same escape hatches.
-3. Also install `assets/tests-bash/rules/hooks-configured.sh` to `tests/governance/rules/hooks-configured.sh` (this happens automatically because `hooks-configured` is in the always-installed list above; the reminder is here so the hook + rule stay co-located in your mental model).
+3. Also install `assets/tests-bash/rules/hooks-configured.sh` to `tests/governance/rules/hooks-configured.sh`.
 4. Run `git config core.hooksPath .githooks` in the target repo. **Tell the user explicitly** that this config is per-clone — every other contributor must run the same command after their first clone. The `hooks-configured` rule will surface that requirement on every commit until they do.
 5. **Do not** create files under `.git/hooks/`. If `.git/hooks/pre-commit` (or `commit-msg`) already exists from a previous bootstrap or another tool, ask the user before deleting — it could be a husky or pre-commit.com hook (see the framework branch below).
 
-If the project uses `husky` or the `pre-commit` framework, *do not* set `core.hooksPath` and do not copy into `.githooks/` — those frameworks already have their own tracked hook-config mechanism. Instead, add a hook entry to the existing config (ask the user which framework they use). See `references/NATIVE_TESTS.md` for the husky / pre-commit.com snippets. In that case, also tell the user the `hooks-configured` rule should be removed (`rm tests/governance/rules/hooks-configured.sh`) since it asserts the `.githooks/` convention specifically.
+**Path B — existing hook framework**
+
+If the project uses `husky` or the `pre-commit` framework, *do not* set `core.hooksPath` and do not copy into `.githooks/` — those frameworks already have their own tracked hook-config mechanism. Instead, add a hook entry to the existing config (ask the user which framework they use, or infer it from the files you found). See `references/NATIVE_TESTS.md` for the husky / pre-commit.com snippets.
+
+In this path:
+- Do not install `hooks-configured.sh`.
+- Do not describe `hooks-configured` as part of the constitution.
+- Tell the user explicitly that the repo is using its existing tracked hook framework instead of `.githooks/`.
 
 ### Step 7 — Install the CI workflow
 
@@ -181,6 +198,7 @@ Do **not** commit the new files. Leave that to the user — the first commit of 
 - **The constitution and the tests evolve together.** Never add a rule to the constitution without a test. Never add a test without a rule. If the user asks to add one in isolation, push back and do both.
 - **Escape hatches are a feature, not a bug.** `SKIP_GOVERNANCE=1` exists because governance that blocks emergency hotfixes will get ripped out. CI enforces the rule even when the hook is skipped, which is the right layering.
 - **Bash-first, native as enhancement.** Bash tests work in any repo, in any CI, without install steps. Native tests (pytest etc.) are nicer DX but add friction. Default to bash; offer native.
+- **Respect the repo's existing hook framework.** `.githooks/` is the default only when no tracked hook framework already exists. Do not force repos off husky or `pre-commit`.
 - **No invented rules.** When writing the constitution, only include rules the user selected. Governance loses authority the moment it contains rules nobody signed off on.
 
 ## References

--- a/governance-bootstrap/evals/evals.json
+++ b/governance-bootstrap/evals/evals.json
@@ -4,19 +4,21 @@
     {
       "id": 1,
       "prompt": "We're starting a new Python + TypeScript monorepo and I want to lock in some non-negotiables before the team grows. Can you set up governance for this repo? Pick a sensible default set of rules — I'll tell you what to drop.",
-      "expected_output": "A tests/governance/ directory with a runner and a tailored set of rule scripts, a pre-commit and commit-msg hook installed in .git/hooks/, a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at .github/workflows/governance.yml, and a short report listing which rules were enabled and why. The skill should have presented a menu via AskUserQuestion before acting — it should not have silently chosen the rule set.",
+      "expected_output": "A tests/governance/ directory with a runner and a tailored set of rule scripts, tracked hooks installed via .githooks/ (or an explicitly preserved existing hook framework if one exists), a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at .github/workflows/governance.yml, and a short report listing the chosen preset, rules enabled, rules skipped, and assumptions. The skill should have surfaced a preset choice before acting — it should not have silently chosen the rule set.",
       "files": ["evals/files/empty-polyglot-repo/"],
       "assertions": [
         "The skill detected both Python and TypeScript/JS before proposing rules (visible in its summary or in which rules it enabled)",
+        "The skill surfaced a preset choice or clearly stated the assumed preset before installing rules",
         "tests/governance/run.sh exists and is executable",
         "tests/governance/rules/ contains at least one rule script (.sh) per enabled category",
         "tests/governance/lib.sh exists and defines rule_start, violation, rule_end, has_waiver",
-        ".git/hooks/pre-commit exists, is executable, and honors SKIP_GOVERNANCE=1",
-        ".git/hooks/commit-msg exists and rejects messages that don't match Conventional Commits (when that rule was enabled)",
+        ".githooks/pre-commit exists, is executable, and honors SKIP_GOVERNANCE=1 when the repo uses the default hook strategy",
+        ".githooks/commit-msg exists and rejects messages that don't match Conventional Commits when that rule was enabled under the default hook strategy",
         "CONSTITUTION.md exists at the repo root with at least Principles, Invariants, and Evolution Log sections",
         ".github/workflows/governance.yml exists and pins third-party actions by SHA (not by floating tag)",
         "The .github/workflows/governance.yml file includes an explicit permissions block scoped to the minimum needed",
-        "The AskUserQuestion tool was invoked at least once during the run to present the rule menu",
+        "The run asked the user to choose or confirm a starting preset, either with AskUserQuestion or concise free text",
+        "The summary includes an Assumptions field, even if it says none",
         "Running tests/governance/run.sh in the repo exits 0 on the seeded repo (no violations on a clean baseline)"
       ]
     },
@@ -43,8 +45,20 @@
         "tests/governance/rules/dotenv-gitignored.sh exists or was explicitly skipped with a reason (Go services often don't use .env)",
         "tests/governance/rules/workflows-hardened.sh exists",
         "No rule scripts targeting Python-only or JS-only patterns (e.g., no-pdb, no-console-log) were installed",
-        "The skill's summary explicitly names the Security category as enabled",
+        "The skill's summary explicitly names the Security category or an equivalent preset-derived rule set as enabled",
         "tests/governance/run.sh exits 0 on the seeded clean Go repo"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "This repo already has governance. Can you review whether the constitution is missing anything obvious? Do not rewrite or reinstall anything.",
+      "expected_output": "The skill does not bootstrap. It recognizes that the request is for review rather than installation, leaves files untouched, and either answers directly or points the user to governance-gardener/governance-amend as the better fit.",
+      "files": ["evals/files/already-bootstrapped-repo/"],
+      "assertions": [
+        "No governance files were rewritten",
+        "The skill explicitly recognized this as a review/explanation request rather than an installation request",
+        "The skill either answered directly or redirected to governance-gardener or governance-amend",
+        "The skill did not create new hook files, a new CONSTITUTION.md, or a replacement tests/governance/ runner"
       ]
     }
   ]

--- a/governance-bootstrap/evals/files/README.md
+++ b/governance-bootstrap/evals/files/README.md
@@ -5,5 +5,6 @@ Each subdirectory is a seed repo state for one eval case. Before running an eval
 - `empty-polyglot-repo/` — a minimal Python + TypeScript repo with no governance; eval case 1.
 - `already-bootstrapped-repo/` — a repo that already has `tests/governance/` from a prior run; eval case 2. The pre-existing files should carry a visible marker (e.g., a comment `# CUSTOMIZED`) so the grader can detect overwrites.
 - `go-service-repo/` — a minimal Go service with `go.mod`, `main.go`, and no governance; eval case 3.
+- `already-bootstrapped-repo/` also backs the negative-routing eval where bootstrap should decline to reinstall and instead answer or redirect; eval case 4.
 
 Fixtures are intentionally small — the eval checks the skill's *behavior*, not its ability to handle large repos.

--- a/governance-bootstrap/references/RULES_CATALOG.md
+++ b/governance-bootstrap/references/RULES_CATALOG.md
@@ -104,3 +104,17 @@ Every rule should be:
 - **Fast** — every rule runs on every commit. Keep it under a second when possible.
 - **Specific** — a violation message should name the file, line, and reason. `"✗ bad code somewhere"` is worthless.
 - **Waivable when warranted** — if there are legitimate exceptions, support the `governance: allow-<rule>` waiver comment so they're auditable.
+- **Matched to the real policy surface** — if the policy is about each substantive change, prefer a change-set-aware check over a repo-exists proxy.
+
+## Authoring guardrail
+
+Before you ship a new rule, ask this explicitly:
+
+> Is this rule about the state of the repository, or about what each change set must carry?
+
+Use:
+
+- **repo-state checks** for things like `README.md exists`, `SECURITY.md exists`, `workflows pin actions`
+- **change-set-aware checks** for things like `this change must update a plan`, `this sensitive code change must update a doc`, or `this path change must touch an approval file`
+
+If you pick a repo-state check for a change-set obligation, the rule will create false confidence. Do not do that.

--- a/governance-gardener/SKILL.md
+++ b/governance-gardener/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: governance-gardener
-description: Walks the repo's governance surface and produces a Governance Health Report — a dated markdown file that flags misalignment between CONSTITUTION.md, the code, and git history. Three axes — Alignment (rules vs. code — blind spots, invisible norms, doc drift), Friction (rules vs. history — dead rules, escape-hatch usage, recurring fixes), Consistency (governance vs. governance — three-legged drift, orphans, hedge language). The report is the product; follow-up actions (doc stamp bumps, drafted doc updates) are opt-in after review. Never auto-amends the constitution. Pairs with governance-bootstrap (which seeds rules) and governance-amend (which edits them). Use when the user says "garden the governance", "governance health check", "run the gardener", "check for blind spots", "find dead rules", or when debugging why the governance tooling feels noisy or out of date. Also designed for /loop or a scheduled task.
+description: Walks the repo's governance surface and produces a Governance Health Report — a dated markdown file that flags misalignment between CONSTITUTION.md, the code, and git history. Three axes — Alignment (rules vs. code — blind spots, invisible norms, doc drift), Friction (rules vs. history — dead rules, escape-hatch usage, recurring fixes), Consistency (governance vs. governance — three-legged drift, orphans, hedge language). The report is the product; follow-up actions (doc stamp bumps, drafted doc updates) are opt-in after review. Never auto-amends the constitution. Use when the user asks for a governance health check, wants to find blind spots or dead rules, or wants to understand why the governance system feels noisy or stale. Do not use for initial installation or a known one-rule amendment.
 license: MIT
 metadata:
   author: governance-kit
@@ -37,7 +37,10 @@ Full signal catalog with thresholds and evidence requirements: [references/SIGNA
 From the repo root:
 
 1. Confirm this is a git repo (`git rev-parse --show-toplevel`). If not, stop.
-2. Confirm the working tree is clean. If dirty, stop and tell the user to commit or stash — the gardener writes a report file and optionally opens branches, and must not entangle its output with unrelated work.
+2. Decide mode based on the user's request:
+   - **Report-only mode** — if the user asked only for analysis, a health check, or a report, a dirty tree is acceptable.
+   - **Follow-up mode** — if the run may open branches or PRs, require a clean tree.
+   If the tree is dirty and follow-up mode is required, stop and tell the user to commit or stash first.
 3. Confirm `CONSTITUTION.md` and `tests/governance/` exist. If not, suggest running `governance-bootstrap` first and exit.
 4. Note prior runs: `ls governance-health/*.md 2>/dev/null`. The most recent one, if any, feeds the **Trend** section.
 
@@ -67,8 +70,8 @@ Run each signal. Collect findings as structured records: `{axis, signal, severit
 - `A4` Bump-eligible — tracked doc whose `last-verified` has expired but watched paths are unchanged (low-risk follow-up available).
 
 **Friction signals** — SIGNAL_CATALOG.md §Friction:
-- `F1` Escape-hatch cluster — commits using `--no-verify` or `SKIP_GOVERNANCE=1` in the window. Groups by affected rule when inferable.
-- `F2` Dead rule — rule test whose watched paths haven't changed in ≥2× the window AND whose test script hasn't been edited since the rule was added.
+- `F1` Escape-hatch cluster — commits using `--no-verify` or `SKIP_GOVERNANCE=1` in the window. Group by affected rule only when the evidence is direct; otherwise report at repo level and lower confidence.
+- `F2` Dead rule — rule test whose watched paths haven't changed in ≥2× the window AND whose test script hasn't been edited since the rule was added. If a rule has no credible watched-path approximation, skip this signal for that rule instead of guessing.
 - `F3` Recurring-fix cluster — commit-subject clusters (`fix style`, `fix typo`, `fix lint`) with ≥ `MIN_EVIDENCE` occurrences not covered by an existing rule.
 - `F4` Revert cluster — `git log --grep=^Revert` with ≥2 hits on the same path.
 
@@ -78,7 +81,7 @@ Run each signal. Collect findings as structured records: `{axis, signal, severit
 - `C3` Evolution-log drift — a log entry whose commit touched neither `CONSTITUTION.md` nor `tests/governance/`.
 - `C4` Orphaned freshness entry — a path in `freshness.conf` that doesn't exist on disk.
 - `C5` Hedge language — an Invariants **Rule** line containing `should`, `generally`, `usually`, `typically`, `try to`. Invariants are hard rules; hedges belong in Principles.
-- `C6` Redundant rule — two rule scripts whose `grep`/`awk` patterns overlap by ≥80%. Flag for dedup.
+- `C6` Redundant rule — two rule scripts whose checks appear materially overlapping. Only surface this when the overlap is obvious from the script bodies or shared helper calls; if overlap is merely heuristic, mark confidence low or suppress it.
 
 ### Step 4 — Render the report
 
@@ -110,6 +113,8 @@ Report written to governance-health/<date>.md. What next?
 
 Default is **(4)** on the first run in a session: the user should see the report before the skill starts opening PRs. Autonomous invocations (`/loop`, scheduled tasks) also default to (4) — they produce the report and exit.
 
+If structured question tools are unavailable, ask the same question in concise free text and default to "review the report first" unless the user clearly asked for follow-up actions in the same request.
+
 If the user picks an action, delegate to the follow-up flows in [references/FOLLOWUP_ACTIONS.md](references/FOLLOWUP_ACTIONS.md). The gardener never auto-amends `CONSTITUTION.md` or `tests/governance/rules/` — rule-shaped candidates always hand off to `governance-amend`.
 
 ### Step 6 — Exit cleanly
@@ -128,8 +133,9 @@ Do not loop or recurse.
 - **Every finding carries evidence.** Commit SHAs, file paths with line numbers, occurrence counts. A finding without evidence is a guess — drop it or mark its confidence as `low`.
 - **Never auto-amend.** The gardener does not edit `CONSTITUTION.md` or write new rule scripts. Candidates are proposed; `governance-amend` does the editing.
 - **Never auto-merge.** Even the low-risk bump-stamps PR requires a human click.
-- **Refuse to run on a dirty tree.** The skill writes a report file and (if the user opts in) creates branches. Mixing with unrelated user work is never right.
+- **Separate report-only mode from follow-up mode.** Analysis can run on a dirty tree; branch-creating follow-up actions cannot.
 - **Confidence is mandatory.** Every finding is tagged `high | medium | low`. Readers calibrate their attention by it; hiding uncertainty wastes the reviewer's time.
+- **Prefer suppression to fake precision.** If a signal cannot tie its claim to concrete evidence, omit it or downgrade confidence rather than over-claiming.
 - **Diffable across runs.** Report files stay in `governance-health/`. Run N+1 can compare against run N. If you move or rewrite old reports, you lose the trend signal.
 
 ## When NOT to use this skill

--- a/governance-gardener/SKILL.md
+++ b/governance-gardener/SKILL.md
@@ -18,6 +18,26 @@ Every run produces a single markdown file: `governance-health/YYYY-MM-DD.md`. Th
 
 This matters. Anchoring on "open PRs" narrows the skill to doc-drift-shaped problems. Anchoring on "produce a health report" lets blind spots, dead rules, escape-hatch friction, and doc drift sit on equal footing, with equal accountability to evidence.
 
+## Negative triggers
+
+Do **not** use this skill for these requests:
+
+- "Set up governance here" — use `governance-bootstrap`.
+- "Add one rule" or "remove rule X" — use `governance-amend`.
+- "Explain this constitution to me" — answer directly.
+- "Just check whether the hooks are installed" — answer directly; do not generate a health report.
+
+## Interaction policy
+
+| Situation | Action |
+|---|---|
+| Governance kit is missing | Stop and redirect to `governance-bootstrap`. |
+| User asked for a known one-rule change | Do not garden. Redirect to `governance-amend`. |
+| User asked only for a report or health check | Use report-only mode; dirty trees are acceptable. |
+| User asked for report plus follow-up branches/PRs | Use follow-up mode; require a clean tree before branch creation. |
+| Signal cannot produce concrete evidence | Suppress it or downgrade confidence; do not bluff precision. |
+| Structured question tools are unavailable | Ask concise free-text follow-up and default to review-first. |
+
 ## What the report covers
 
 Three axes. Each axis compares governance artifacts against a different source of truth.
@@ -29,6 +49,7 @@ Three axes. Each axis compares governance artifacts against a different source o
 | **Consistency** | governance itself | Three-legged drift (rule↔test↔log), orphans in `freshness.conf`, hedge language in Invariants, redundant rules. |
 
 Full signal catalog with thresholds and evidence requirements: [references/SIGNAL_CATALOG.md](references/SIGNAL_CATALOG.md).
+Shared terms, including "signal", "drift", and "watched scope", live in [../GOVERNANCE_VOCABULARY.md](../GOVERNANCE_VOCABULARY.md).
 
 ## Activation flow
 
@@ -57,11 +78,11 @@ Parse these once; every axis reuses them:
 - **Tests** — list `tests/governance/rules/*.sh`.
 - **Evolution Log** — parse `## Evolution Log` entries (date, author, summary, linked PR if present).
 - **Freshness config** — `tests/governance/freshness.conf` if present.
-- **Tracked doc set** — the baseline globs + freshness.conf (see [references/WATCH_ANNOTATIONS.md](references/WATCH_ANNOTATIONS.md) for the baseline).
+- **Tracked doc set** — the baseline globs + freshness.conf (see [references/WATCH_SCOPES.md](references/WATCH_SCOPES.md) for the canonical watched-scope model).
 
 ### Step 3 — Walk the three axes
 
-Run each signal. Collect findings as structured records: `{axis, signal, severity, title, evidence, suggested_action}`. Severity is `info | watch | action`.
+Run each signal. Collect findings as structured records: `{axis, signal, severity, confidence, stability, title, evidence, suggested_action}`. Severity is `info | watch | action`. Stability is `stable | experimental | opt-in`.
 
 **Alignment signals** — see SIGNAL_CATALOG.md §Alignment:
 - `A1` Aspirational rule — Invariants row with no matching test script on disk.
@@ -88,7 +109,7 @@ Run each signal. Collect findings as structured records: `{axis, signal, severit
 Write to `governance-health/YYYY-MM-DD.md` using [assets/health-report.template.md](assets/health-report.template.md). Sections:
 
 1. **Summary** — traffic-light table per axis with the worst signal called out.
-2. **Alignment / Friction / Consistency** — one section per axis, findings grouped by severity. Every finding names: signal ID, title, evidence (commit SHAs, file paths with line numbers, counts), suggested action, confidence.
+2. **Alignment / Friction / Consistency** — one section per axis, findings grouped by severity. Every finding names: signal ID, title, evidence (commit SHAs, file paths with line numbers, counts), suggested action, confidence, and stability.
 3. **Actionable queue** — the short list of things the user can do right now. Each item is a shell command or a pointer to another skill:
    - `governance-gardener --bump-stamps` (low-risk, batched PR).
    - `governance-gardener --draft-doc-updates` (draft PRs per doc).
@@ -123,9 +144,21 @@ Print a one-screen summary:
 - Path to the report.
 - Count of findings by axis and severity.
 - The follow-up the user chose (if any) and the PR URLs it produced.
+- Assumptions made. If none, say `Assumptions: none`.
 - What to run next: `governance-amend <name>` for each action-severity rule candidate.
 
 Do not loop or recurse.
+
+## Required final output
+
+Every successful run should leave the user with:
+
+- `Report:` path
+- `Mode:` report-only or follow-up
+- `Findings:` counts by axis and severity
+- `Follow-up:` action taken or `review first`
+- `Assumptions:` any material assumptions, or `none`
+- `Next:` candidate `governance-amend` commands when relevant
 
 ## Key design rules
 
@@ -135,7 +168,9 @@ Do not loop or recurse.
 - **Never auto-merge.** Even the low-risk bump-stamps PR requires a human click.
 - **Separate report-only mode from follow-up mode.** Analysis can run on a dirty tree; branch-creating follow-up actions cannot.
 - **Confidence is mandatory.** Every finding is tagged `high | medium | low`. Readers calibrate their attention by it; hiding uncertainty wastes the reviewer's time.
+- **Signal stability is mandatory.** Experimental or opt-in signals should be labeled as such so the reader knows how hard to lean on them.
 - **Prefer suppression to fake precision.** If a signal cannot tie its claim to concrete evidence, omit it or downgrade confidence rather than over-claiming.
+- **State material assumptions explicitly.** Inferred watched scopes and inferred rule groupings should be surfaced as assumptions when they materially shaped the report.
 - **Diffable across runs.** Report files stay in `governance-health/`. Run N+1 can compare against run N. If you move or rewrite old reports, you lose the trend signal.
 
 ## When NOT to use this skill
@@ -147,6 +182,7 @@ Do not loop or recurse.
 ## References
 
 - [references/SIGNAL_CATALOG.md](references/SIGNAL_CATALOG.md) — every signal, its threshold, and what evidence it requires.
+- [references/WATCH_SCOPES.md](references/WATCH_SCOPES.md) — canonical watched-scope resolution for docs and rules.
 - [references/WATCH_ANNOTATIONS.md](references/WATCH_ANNOTATIONS.md) — the `<!-- gardener-watches: ... -->` annotation format for doc-drift detection.
 - [references/FOLLOWUP_ACTIONS.md](references/FOLLOWUP_ACTIONS.md) — how `--bump-stamps` and `--draft-doc-updates` are executed after the user opts in.
 - [assets/health-report.template.md](assets/health-report.template.md) — the report skeleton.

--- a/governance-gardener/assets/health-report.template.md
+++ b/governance-gardener/assets/health-report.template.md
@@ -42,6 +42,7 @@ _Scan not run (set `GARDENER_NORM_SCAN=1` to enable)._
 - **`docs/example.md`** — stamp 2025-11-01 (172 days old); 4 commits on watched paths since.
   - Evidence: `git log --since=2025-11-01 -- <watches>` → `abc1234`, `def5678`, `9012345`, `6789abc`.
   - Confidence: high.
+  - Stability: stable.
   - Suggested: `governance-gardener --draft-doc-updates` will open a draft PR with a proposed edit.
 
 ### A4 · Bump-eligible
@@ -50,6 +51,7 @@ _Scan not run (set `GARDENER_NORM_SCAN=1` to enable)._
 - **`docs/stable.md`** — stamp 2025-10-15, 189 days old; watched paths unchanged.
   - Evidence: `git log --since=2025-10-15 -- <watches>` → empty.
   - Confidence: high.
+  - Stability: stable.
   - Suggested: `governance-gardener --bump-stamps`.
 
 ---
@@ -72,6 +74,7 @@ _No findings._
 - **"fix typo" cluster** — 7 commits in the last 180 days, no rule named.
   - Evidence: `abc1234`, `def5678`, … (see full list in collapsed block below)
   - Confidence: medium — could be a spellcheck rule, could be natural churn.
+  - Stability: experimental.
   - Suggested: consider `governance-amend spellcheck-docs` or similar.
 
 ### F4 · Revert cluster
@@ -103,6 +106,7 @@ _No findings._
 - **`agents-md-exists`** — rule says "generally 30–250 lines".
   - Evidence: CONSTITUTION.md:37.
   - Confidence: high — "generally" is a hedge in a hard rule.
+  - Stability: stable.
   - Suggested: tighten the wording or move to Principles; run `governance-amend agents-md-exists`.
 
 ### C6 · Redundant rule

--- a/governance-gardener/evals/evals.json
+++ b/governance-gardener/evals/evals.json
@@ -4,13 +4,14 @@
     {
       "id": 1,
       "prompt": "Run the governance gardener on this repo. I want a health report — don't open any PRs yet, I'll look at the report first.",
-      "expected_output": "The skill runs all three axes (Alignment, Friction, Consistency), writes a single report file at governance-health/YYYY-MM-DD.md with a Summary traffic-light table, per-axis sections with signal IDs and evidence, an Actionable queue, and (if a prior report exists) a Trend section. The report carries the <!-- governance: allow-plan-captured --> marker at the top. The skill then invokes AskUserQuestion with four options and defaults to option (4) — nothing. No branches or PRs are created.",
+      "expected_output": "The skill runs all three axes (Alignment, Friction, Consistency), writes a single report file at governance-health/YYYY-MM-DD.md with a Summary traffic-light table, per-axis sections with signal IDs and evidence, an Actionable queue, and (if a prior report exists) a Trend section. The report carries the <!-- governance: allow-plan-captured --> marker at the top. Findings include both confidence and stability tags. The skill then invokes AskUserQuestion with four options and defaults to option (4) — nothing. No branches or PRs are created.",
       "files": ["evals/files/governed-repo-with-drift/"],
       "assertions": [
         "A file governance-health/<today>.md was created",
         "The report contains sections for Alignment, Friction, and Consistency",
         "At least one finding includes a signal ID (e.g., A1, A3, F2, C1) and concrete evidence (commit SHAs, file paths with line numbers, or counts)",
         "Every finding carries a confidence tag of high, medium, or low",
+        "Any surfaced finding also carries a stability tag such as stable, experimental, or opt-in",
         "The report's first non-empty line contains <!-- governance: allow-plan-captured -->",
         "The skill invoked AskUserQuestion offering bump-stamps / draft doc updates / both / nothing",
         "The default option presented was option (4) — Nothing (review the report first)",
@@ -21,16 +22,15 @@
     },
     {
       "id": 2,
-      "prompt": "Run the gardener. I've got some uncommitted changes staged but just go ahead — I need the report for a meeting.",
-      "expected_output": "The skill detects the dirty working tree in preflight and refuses to run. It tells the user to commit or stash first and does not produce a report, create branches, or open PRs. It holds the rule even under pressure — the rationale (never entangle gardener output with unrelated user work) still applies.",
+      "prompt": "Run the gardener, and if there are any obvious follow-up actions, go ahead and open the relevant PRs too. I've got some uncommitted changes staged but just go ahead.",
+      "expected_output": "The skill detects the dirty working tree in preflight and refuses follow-up mode. It tells the user to commit or stash first and does not produce follow-up branches or PRs. It may explain that report-only mode would be acceptable, but it must not proceed into branch-creating work on a dirty tree.",
       "files": ["evals/files/dirty-tree-repo/"],
       "assertions": [
         "The skill detected uncommitted changes or untracked files in the preflight step",
-        "The skill explicitly refused to proceed and told the user to commit or stash",
-        "No governance-health/ report file was created",
+        "The skill explicitly refused follow-up mode and told the user to commit or stash before any branch-creating work",
         "No branches were created",
         "No PRs were opened",
-        "The skill did not cave to the 'just go ahead' pressure — it held the rule because mixing gardener output with unrelated changes is never right"
+        "The skill did not cave to the 'just go ahead' pressure — it held the clean-tree requirement for branch-creating work"
       ]
     },
     {
@@ -60,6 +60,30 @@
         "No new files were added under tests/governance/rules/",
         "No draft doc-update PRs were opened (the user only asked for bump-stamps)",
         "Rule-shaped candidates surfaced in the report handed off to governance-amend rather than being amended in place"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Run the governance gardener on this repo. I only need the report for a meeting, so don't open any PRs or branches.",
+      "expected_output": "The skill uses report-only mode. If the tree is dirty, that is acceptable because no branch-creating follow-up work was requested. The run writes the report and stops at review-first.",
+      "files": ["evals/files/dirty-tree-repo/"],
+      "assertions": [
+        "The skill treated the request as report-only mode",
+        "A governance-health/<today>.md report was written even though the fixture represents a dirty-tree scenario",
+        "No branches were created",
+        "No PRs were opened",
+        "The final summary explicitly identified the run as report-only mode"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Please add a new governance rule requiring SECURITY.md to exist.",
+      "expected_output": "The skill recognizes that this is a known one-rule amendment request rather than a health-check request. It does not write a governance-health report and redirects the user to governance-amend.",
+      "files": ["evals/files/governed-repo-with-drift/"],
+      "assertions": [
+        "No governance-health/ report was written",
+        "The skill explicitly identified the request as a one-rule amendment request",
+        "The skill redirected to governance-amend instead of generating a report"
       ]
     }
   ]

--- a/governance-gardener/evals/files/README.md
+++ b/governance-gardener/evals/files/README.md
@@ -3,8 +3,9 @@
 Each subdirectory is a seed repo state for one gardener eval case. Before running an eval, copy the fixture into a fresh temp directory, run `git init && git add -A && git commit -m "seed"` inside it, and point the skill at that directory.
 
 - `governed-repo-with-drift/` — a bootstrapped repo with obvious Alignment/Friction/Consistency signals seeded in (aspirational rule, stale stamp with drift, dead-rule candidate). Eval case 1.
-- `dirty-tree-repo/` — a bootstrapped repo plus an uncommitted file (`UNCOMMITTED.md`). Delete the file and re-seed if you need a clean variant. Eval case 2.
+- `dirty-tree-repo/` — a bootstrapped repo plus an uncommitted file (`UNCOMMITTED.md`). Delete the file and re-seed if you need a clean variant. It backs both the follow-up-mode refusal eval and the report-only-on-dirty-tree eval; eval cases 2 and 5.
 - `ungoverned-repo/` — a bare repo with just a README.md and no governance scaffolding. Eval case 3.
 - `governed-repo-bump-eligible/` — a bootstrapped repo with one doc whose `last-verified` stamp has expired but whose watched paths are unchanged, making it bump-only. Eval case 4.
+- `governed-repo-with-drift/` also backs the negative-routing eval where gardener should redirect a one-rule amendment request to governance-amend; eval case 6.
 
 Fixtures are intentionally minimal — the eval checks the skill's *behavior* on well-understood seed states, not its ability to handle large repos.

--- a/governance-gardener/references/SIGNAL_CATALOG.md
+++ b/governance-gardener/references/SIGNAL_CATALOG.md
@@ -14,6 +14,12 @@ Confidence levels (independent of severity):
 - **`medium`** — the signal is statistical (cluster size crossed threshold).
 - **`low`** — the signal is heuristic (pattern-match on naming or commit subjects).
 
+Stability levels:
+
+- **`stable`** — deterministic enough to trust as a default report signal.
+- **`experimental`** — useful, but more inference-heavy; include only with clear evidence.
+- **`opt-in`** — noisy enough that it should run only when explicitly enabled.
+
 ---
 
 ## §Alignment — governance vs. code
@@ -26,7 +32,7 @@ Confidence levels (independent of severity):
 
 **Threshold:** none — one missing test is enough.
 
-**Severity:** `action`. **Confidence:** `high`.
+**Severity:** `action`. **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -45,7 +51,7 @@ Built-in patterns scanned (extend in `references/NORM_PATTERNS.md` if you add mo
 
 **Threshold:** ≥80% match rate AND ≥5 files in the sample AND no existing Invariants rule mentions the pattern.
 
-**Severity:** `watch`. **Confidence:** `medium`.
+**Severity:** `watch`. **Confidence:** `medium`. **Stability:** `opt-in`.
 
 ---
 
@@ -53,13 +59,13 @@ Built-in patterns scanned (extend in `references/NORM_PATTERNS.md` if you add mo
 
 **Checks:** for each tracked doc with a `<!-- last-verified: YYYY-MM-DD -->` stamp older than `GARDENER_FRESHNESS_DAYS` (default 90), run `git log --since=<stamp> -- <watch-paths>`. If the log has commits, the watched code drifted since the stamp.
 
-Watch-set resolution order: explicit `<!-- gardener-watches: ... -->` annotation, then inference (fenced code blocks, inline path refs, directory sibling), then well-known-file defaults. See [WATCH_ANNOTATIONS.md](WATCH_ANNOTATIONS.md).
+Watch-set resolution order is canonicalized in [WATCH_SCOPES.md](WATCH_SCOPES.md). Use explicit annotations when possible.
 
 **Evidence:** doc path, stamp date, list of commit SHAs on watched paths.
 
 **Threshold:** ≥1 commit on a watched path since the stamp.
 
-**Severity:** `action`. **Confidence:** `high` if explicit annotation, `medium` if inferred.
+**Severity:** `action`. **Confidence:** `high` if explicit annotation, `medium` if inferred. **Stability:** `stable`.
 
 ---
 
@@ -71,7 +77,7 @@ Watch-set resolution order: explicit `<!-- gardener-watches: ... -->` annotation
 
 **Threshold:** stamp age > `GARDENER_FRESHNESS_DAYS` AND watched-path log is empty.
 
-**Severity:** `info` (follow-up available). **Confidence:** `high`.
+**Severity:** `info` (follow-up available). **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -84,7 +90,7 @@ Watch-set resolution order: explicit `<!-- gardener-watches: ... -->` annotation
 - Commits with `SKIP_GOVERNANCE=1` in the reflog / author note / commit trailer (if surfaced by the user's workflow).
 - Commits that `--no-verify` is inferable from: CI run for that commit's PR ran governance and failed, but the commit was merged anyway. (Requires `gh` + CI logs; otherwise skip.)
 
-Group by the rule that would have fired. If grouping isn't inferable, emit one cluster titled "unknown rule".
+Group by the rule that would have fired only when the evidence is direct. If grouping isn't inferable, emit one repo-level cluster titled "unknown rule" and lower confidence.
 
 **Evidence:** list of commit SHAs, grouped by rule. Count per group.
 
@@ -92,7 +98,7 @@ Group by the rule that would have fired. If grouping isn't inferable, emit one c
 
 **Severity:** `watch` at 3–5, `action` at >5 in a single cluster.
 
-**Confidence:** `high` when grouping is known, `medium` when it's unknown.
+**Confidence:** `high` when grouping is known, `medium` when it's unknown. **Stability:** `experimental`.
 
 **Interpretation:** a loud F1 cluster usually means a rule is wrong, not that the team is undisciplined. Investigate the rule before investigating the people.
 
@@ -102,17 +108,17 @@ Group by the rule that would have fired. If grouping isn't inferable, emit one c
 
 **Checks:** for each `tests/governance/rules/*.sh`:
 
-1. Determine its watched scope — grep the script for path literals.
+1. Determine its watched scope using [WATCH_SCOPES.md](WATCH_SCOPES.md).
 2. Run `git log --since=<2× window>` on those paths.
 3. Run `git log -- <test-script-path>` to see when the test was last edited.
 
-A rule is *dead* if its watched scope has had no activity in 2× the window AND the test script itself hasn't been edited since the rule was added (i.e., it's frozen).
+A rule is *dead* if its watched scope has had no activity in 2× the window AND the test script itself hasn't been edited since the rule was added (i.e., it's frozen). If no credible watched scope can be resolved, skip this signal for that rule.
 
 **Evidence:** rule name, last activity date on watched paths, last edit date of the test script.
 
 **Threshold:** watched-path quiet period ≥ 2× `GARDENER_WINDOW_DAYS`.
 
-**Severity:** `watch`. **Confidence:** `low` — dead rules might be dormant, not dead; surface them for human judgment, don't recommend deletion automatically.
+**Severity:** `watch`. **Confidence:** `low` — dead rules might be dormant, not dead; surface them for human judgment, don't recommend deletion automatically. **Stability:** `experimental`.
 
 ---
 
@@ -131,7 +137,7 @@ Drop clusters that match an existing Invariants rule (e.g., "fix conventional-co
 
 **Threshold:** ≥ `GARDENER_MIN_EVIDENCE` commits per cluster.
 
-**Severity:** `watch`. **Confidence:** `medium`.
+**Severity:** `watch`. **Confidence:** `medium`. **Stability:** `experimental`.
 
 **Interpretation:** a recurring-fix cluster usually means either (a) a rule is missing or (b) automation is missing. Both are valid amendments — either a new `tests/governance/rules/<name>.sh` or a pre-commit formatter/linter.
 
@@ -145,7 +151,7 @@ Drop clusters that match an existing Invariants rule (e.g., "fix conventional-co
 
 **Threshold:** ≥2 reverts on the same path.
 
-**Severity:** `watch`. **Confidence:** `high`.
+**Severity:** `watch`. **Confidence:** `high`. **Stability:** `stable`.
 
 **Interpretation:** the path is unstable. Could be a missing test, a missing rule, or a deeper design issue. Not necessarily a governance amendment — sometimes the right fix is in the code, not the rules.
 
@@ -161,7 +167,7 @@ These are mechanical lints. They have no thresholds — any violation is surface
 
 **Evidence:** rule name, line number, expected path.
 
-**Severity:** `action`. **Confidence:** `high`.
+**Severity:** `action`. **Confidence:** `high`. **Stability:** `stable`.
 
 Overlaps with A1 — A1 is the symptom ("your rule is aspirational"), C1 is the lint ("the three-legged invariant broke"). Same evidence, surfaced under both axes because the reader looking for alignment issues and the reader looking for consistency issues are different.
 
@@ -173,7 +179,7 @@ Overlaps with A1 — A1 is the symptom ("your rule is aspirational"), C1 is the 
 
 **Evidence:** script path, derived rule name.
 
-**Severity:** `action`. **Confidence:** `high`.
+**Severity:** `action`. **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -188,7 +194,7 @@ Entries that don't reference a PR or SHA are skipped (can't verify).
 
 **Evidence:** log line, referenced commit SHA, files touched.
 
-**Severity:** `watch`. **Confidence:** `high`.
+**Severity:** `watch`. **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -198,7 +204,7 @@ Entries that don't reference a PR or SHA are skipped (can't verify).
 
 **Evidence:** missing path, line number in the config.
 
-**Severity:** `action`. **Confidence:** `high`.
+**Severity:** `action`. **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -210,7 +216,7 @@ Exception: the word "should" is allowed when followed directly by "not" or "neve
 
 **Evidence:** rule name, line number, matched token.
 
-**Severity:** `watch`. **Confidence:** `high`.
+**Severity:** `watch`. **Confidence:** `high`. **Stability:** `stable`.
 
 ---
 
@@ -220,7 +226,7 @@ Exception: the word "should" is allowed when followed directly by "not" or "neve
 
 **Evidence:** both rule names, overlap ratio, shared tokens (top 5).
 
-**Severity:** `watch`. **Confidence:** `low` — pattern overlap is not the same as semantic overlap; this is a starting point for human review.
+**Severity:** `watch`. **Confidence:** `low` — pattern overlap is not the same as semantic overlap; this is a starting point for human review. **Stability:** `experimental`.
 
 ---
 

--- a/governance-gardener/references/WATCH_ANNOTATIONS.md
+++ b/governance-gardener/references/WATCH_ANNOTATIONS.md
@@ -1,5 +1,7 @@
 # Watch annotations
 
+This file defines the annotation syntax. The canonical watched-scope resolution model lives in [WATCH_SCOPES.md](WATCH_SCOPES.md).
+
 When the `governance-gardener` checks doc drift (signals A3 and A4), it needs to know *which code* each doc is describing. The most reliable way to tell it: an explicit annotation in the doc.
 
 ## Syntax
@@ -101,7 +103,7 @@ If a doc has no `gardener-watches` annotation, the gardener tries in order:
 | `CONSTITUTION.md` | `tests/governance/rules/`, `tests/governance/lib.sh` |
 | `CONTRIBUTING.md` | `.github/`, `tests/` (if present) |
 
-Inference is best-effort. Docs that matter should have explicit annotations — it's one line, it's permanent, it makes the gardener's findings predictable.
+Inference is best-effort. Docs that matter should have explicit annotations — it's one line, it's permanent, it makes the gardener's findings predictable. Confidence and resolution order are defined in [WATCH_SCOPES.md](WATCH_SCOPES.md).
 
 ## Unwatched-stale
 

--- a/governance-gardener/references/WATCH_SCOPES.md
+++ b/governance-gardener/references/WATCH_SCOPES.md
@@ -1,0 +1,49 @@
+# Watch scopes
+
+Canonical resolution model for the gardener's "watched scope" concept.
+
+The gardener uses watched scopes in two places:
+
+- **doc drift** — what code or docs a markdown doc is describing
+- **rule dormancy** — what files or paths a governance rule is meaningfully watching
+
+When a watched scope is explicit, trust it. When it is inferred, lower confidence and say so.
+
+## Resolution order
+
+### For docs
+
+Resolve watched scope in this order:
+
+1. Explicit `<!-- gardener-watches: ... -->` annotations
+2. `tests/governance/freshness.conf` entries, if the doc is opt-ed in there
+3. File references in fenced code blocks or inline code
+4. Well-known defaults for docs like `README.md`, `SECURITY.md`, `CONSTITUTION.md`
+5. Directory-sibling inference as a last resort
+
+Canonical annotation syntax and examples live in [WATCH_ANNOTATIONS.md](WATCH_ANNOTATIONS.md).
+
+### For rule scripts
+
+Resolve watched scope in this order:
+
+1. An explicit comment near the top of the rule script:
+   `# gardener-watches: src/, docs/api.md`
+2. Path literals or globs embedded in the script
+3. A named config file the script reads
+4. The repo-wide governance surface if the rule is clearly global
+
+If none of the above yields a credible scope, do **not** guess. Skip scope-dependent signals like `F2` for that rule.
+
+## Confidence guidance
+
+- **high** — explicit annotation or explicit config entry
+- **medium** — path literals or well-known defaults
+- **low** — sibling inference or broad repo-level approximation
+
+## Scope hygiene
+
+- Prefer narrow, durable paths over broad directories.
+- Include tests when the doc or rule describes externally observable behavior.
+- Avoid generated files and vendor trees.
+- If a doc or rule keeps surfacing low-confidence findings, add an explicit watched scope instead of tuning thresholds forever.

--- a/plans/2026-04-22-refine-governance-skill-contracts.md
+++ b/plans/2026-04-22-refine-governance-skill-contracts.md
@@ -1,0 +1,28 @@
+# 2026-04-22 - Refine governance skill contracts
+
+Retrospective plan for the follow-up work that tightened the three governance skills after the initial PR was already in flight. This was originally missed during execution and is being captured now so the repo history still records why the change took this shape.
+
+## Goal
+
+Strengthen the governance skill layer so it is less model-dependent and less likely to misfire, while keeping the three skills clearly separated by responsibility.
+
+The work includes:
+
+- tighter trigger boundaries for `governance-bootstrap`, `governance-amend`, and `governance-gardener`
+- more mechanical execution contracts and required final-output shapes
+- a preset-based bootstrap flow
+- a shared governance vocabulary and a canonical watched-scope model
+- expanded eval expectations for routing failures, output contracts, and gardener mode handling
+
+## Steps
+
+1. Review the three `SKILL.md` files and supporting references for ambiguity, overlap, and heuristic behavior that was not clearly labeled.
+2. Patch the skill contracts to add negative-trigger examples, decision tables, stronger output requirements, and explicit assumption reporting.
+3. Add shared reference material for cross-skill terminology and gardener watched-scope resolution.
+4. Update eval expectations so the repo encodes the intended routing behavior instead of relying on prose alone.
+5. Run lightweight verification: JSON sanity for eval files and `bash tests/governance/run.sh`.
+
+## Notes
+
+- This is a retrospective capture. The change work started before this plan file was written.
+- The follow-up amendment to `plan-captured` should make this kind of miss mechanically catchable in the future instead of depending on memory.

--- a/tests/governance/rules/plan-captured.sh
+++ b/tests/governance/rules/plan-captured.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Rule: The repo maintains plans/ — each plan doc captures the plan an agent
-# (or human) executed, with a title, Goal, and Steps section.
+# (or human) executed, with a title, Goal, and Steps section. Substantive
+# tracked changes must add or modify at least one plans/*.md file in the same
+# change set.
 # Rationale: The diff shows what changed; the plan shows why the change took
 # this shape. Without it, reviewers and future agents reconstruct intent from
 # code, and get it wrong.
@@ -40,5 +42,64 @@ for f in "${plan_files[@]}"; do
     grep -qE '^## Goal'   "$f" || violation "$f — missing '## Goal' section"
     grep -qE '^## Steps'  "$f" || violation "$f — missing '## Steps' section"
 done
+
+# Require a plan touch for substantive tracked changes in the same change set.
+# Resolution order:
+#   1. Pre-commit / local staging context: use the staged diff.
+#   2. CI / committed branch context: diff merge-base..HEAD against the default branch.
+# Changes limited to plans/ and governance-health/ are exempt from the same-change check.
+changed_files=()
+if ! git diff --cached --quiet --ignore-submodules -- 2>/dev/null; then
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        changed_files+=("$f")
+    done < <(git diff --cached --name-only --diff-filter=ACMRD -- 2>/dev/null || true)
+else
+    base=""
+    for candidate in origin/main origin/master main master; do
+        if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+            mb=$(git merge-base HEAD "$candidate" 2>/dev/null || echo "")
+            if [[ -n "$mb" && "$mb" != "$(git rev-parse HEAD)" ]]; then
+                base="$mb"
+                break
+            fi
+        fi
+    done
+
+    if [[ -n "$base" ]]; then
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            changed_files+=("$f")
+        done < <(git diff --name-only --diff-filter=ACMRD "$base..HEAD" -- 2>/dev/null || true)
+    fi
+fi
+
+if [[ ${#changed_files[@]} -gt 0 ]]; then
+    substantive_files=()
+    plan_touched=0
+
+    for f in "${changed_files[@]}"; do
+        case "$f" in
+            plans/*.md)
+                plan_touched=1
+                ;;
+            governance-health/*)
+                ;;
+            *)
+                substantive_files+=("$f")
+                ;;
+        esac
+    done
+
+    if [[ ${#substantive_files[@]} -gt 0 && $plan_touched -eq 0 ]]; then
+        violation "substantive change set touches tracked files outside plans/ but no plans/*.md file was added or modified"
+        for f in "${substantive_files[@]:0:5}"; do
+            violation "missing plan touch for change: $f"
+        done
+        if [[ ${#substantive_files[@]} -gt 5 ]]; then
+            violation "...and $((${#substantive_files[@]} - 5)) more file(s)"
+        fi
+    fi
+fi
 
 rule_end


### PR DESCRIPTION
## Summary
- tighten the trigger descriptions so bootstrap, amend, and gardener are less likely to misfire
- resolve the bootstrap hook-strategy contradiction by making .githooks conditional on existing hook frameworks
- add tool-availability fallbacks, a fast path for governance-amend, and more conservative gardener heuristics

## Testing
- git commit hook (governance rules)
