### PR TITLE
test(evals): encode change-aware rule expectations

### DIFF
--- a/governance-amend/evals/evals.json
+++ b/governance-amend/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "We had an incident yesterday (INC-4117) — someone committed a private key file (*.pem) and we had to rotate half our credentials. Add a governance rule that blocks committing *.pem, *.key, and *.p12 files. Wire it into the constitution properly.",
-      "expected_output": "Three coordinated artifacts land together: (a) a new tests/governance/rules/<rule-name>.sh that blocks committing the listed key/cert extensions, (b) a new Invariants subsection in CONSTITUTION.md describing the rule and citing INC-4117, and (c) an Evolution Log entry with today's date summarizing the amendment. The rule is tested against a seeded repo with and without a .pem file. The skill does not commit the change without showing the three artifacts to the user.",
+      "expected_output": "Three coordinated artifacts land together: (a) a new tests/governance/rules/<rule-name>.sh that blocks committing the listed key/cert extensions, (b) a new Invariants subsection in CONSTITUTION.md describing the rule and citing INC-4117, and (c) an Evolution Log entry with today's date summarizing the amendment. The rule is tested against a seeded repo with and without a .pem file. Because the request is concrete, the skill may use its fast path, but it must still report the rule name, action type, smoke-test result, staged status, and suggested commit message.",
       "files": ["evals/files/seeded-repo/"],
       "assertions": [
         "A new rule script was created under tests/governance/rules/ with a name matching the invariant (e.g., no-key-material.sh)",
@@ -15,7 +15,7 @@
         "CONSTITUTION.md's Evolution Log gained a new entry dated today describing the amendment",
         "Running tests/governance/run.sh on a repo containing a staged *.pem file produces a violation referencing the new rule",
         "Running tests/governance/run.sh on a clean repo (no key files) exits 0 after the amendment",
-        "The skill presented the three artifacts (test, invariant section, evolution log entry) as a coordinated set before applying them — it did not apply them piecemeal"
+        "The skill reported the action type, smoke-test result, staged status, and suggested commit message in its final summary"
       ]
     },
     {
@@ -28,7 +28,8 @@
         "The new limit value (800) appears in the rule script or its env var default",
         "The CONSTITUTION.md invariant for file-size-limit references 800 (not 500)",
         "A new Evolution Log entry was added with today's date describing the limit change and citing the data-pipeline false-positive reason",
-        "No new rule script file was created"
+        "No new rule script file was created",
+        "The amendment summary reported that this was an update rather than a new rule"
       ]
     },
     {
@@ -42,6 +43,29 @@
         "A new Evolution Log entry dated today records the removal with the stated reason",
         "Running tests/governance/run.sh still exits 0 on the seeded repo after removal",
         "If the repo contains any references to the removed rule name (e.g., in a README or CI doc), the skill surfaced them to the user rather than silently leaving dangling references"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Can you run a governance health check and tell me if any of these rules look stale?",
+      "expected_output": "The skill recognizes that this is a health-check request, not a targeted amendment. It does not edit files, does not stage changes, and redirects the user to governance-gardener or answers directly.",
+      "files": ["evals/files/seeded-repo/"],
+      "assertions": [
+        "No files under tests/governance/rules/ or CONSTITUTION.md were modified",
+        "The skill explicitly identified the request as a review/health-check rather than an amendment request",
+        "The skill redirected to governance-gardener or answered directly without staging changes"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Our `plan-captured` rule says every substantive change must update a plan, but the script only checks that `plans/` exists and has one markdown file. Amend it so the enforcement actually matches that intent.",
+      "expected_output": "The skill treats the mismatch as rule drift and strengthens the rule instead of preserving the weak proxy. The amended rule should become change-set-aware, and the constitution text should be updated to match the stronger enforcement surface.",
+      "files": ["evals/files/seeded-repo/"],
+      "assertions": [
+        "The skill explicitly identifies the old check as a weak proxy for the stated policy",
+        "The amended script inspects staged or branch diffs rather than only repo-at-rest existence",
+        "The constitution rule text is updated so it matches the new enforcement shape",
+        "The skill does not preserve the old repo-exists check as if it were sufficient for the per-change policy"
       ]
     }
   ]

--- a/governance-bootstrap/evals/evals.json
+++ b/governance-bootstrap/evals/evals.json
@@ -4,19 +4,20 @@
     {
       "id": 1,
       "prompt": "We're starting a new Python + TypeScript monorepo and I want to lock in some non-negotiables before the team grows. Can you set up governance for this repo? Pick a sensible default set of rules — I'll tell you what to drop.",
-      "expected_output": "A tests/governance/ directory with a runner and a tailored set of rule scripts, a pre-commit and commit-msg hook installed in .git/hooks/, a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at .github/workflows/governance.yml, and a short report listing which rules were enabled and why. The skill should have presented a menu via AskUserQuestion before acting — it should not have silently chosen the rule set.",
+      "expected_output": "A tests/governance/ directory with a runner and a tailored set of rule scripts, tracked hooks installed via .githooks/ (or an explicitly preserved existing hook framework if one exists), a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at .github/workflows/governance.yml, and a short report listing the chosen preset, rules enabled, rules skipped, and assumptions. The skill should have surfaced a preset choice before acting — it should not have silently chosen the rule set.",
       "files": ["evals/files/empty-polyglot-repo/"],
       "assertions": [
         "The skill detected both Python and TypeScript/JS before proposing rules (visible in its summary or in which rules it enabled)",
         "tests/governance/run.sh exists and is executable",
         "tests/governance/rules/ contains at least one rule script (.sh) per enabled category",
         "tests/governance/lib.sh exists and defines rule_start, violation, rule_end, has_waiver",
-        ".git/hooks/pre-commit exists, is executable, and honors SKIP_GOVERNANCE=1",
-        ".git/hooks/commit-msg exists and rejects messages that don't match Conventional Commits (when that rule was enabled)",
+        ".githooks/pre-commit exists, is executable, and honors SKIP_GOVERNANCE=1 when the repo uses the default hook strategy",
+        ".githooks/commit-msg exists and rejects messages that don't match Conventional Commits when that rule was enabled under the default hook strategy",
         "CONSTITUTION.md exists at the repo root with at least Principles, Invariants, and Evolution Log sections",
         ".github/workflows/governance.yml exists and pins third-party actions by SHA (not by floating tag)",
         "The .github/workflows/governance.yml file includes an explicit permissions block scoped to the minimum needed",
-        "The AskUserQuestion tool was invoked at least once during the run to present the rule menu",
+        "The run asked the user to choose or confirm a starting preset, either with AskUserQuestion or concise free text",
+        "The summary includes an Assumptions field, even if it says none",
         "Running tests/governance/run.sh in the repo exits 0 on the seeded repo (no violations on a clean baseline)"
       ]
     },
@@ -43,8 +44,31 @@
         "tests/governance/rules/dotenv-gitignored.sh exists or was explicitly skipped with a reason (Go services often don't use .env)",
         "tests/governance/rules/workflows-hardened.sh exists",
         "No rule scripts targeting Python-only or JS-only patterns (e.g., no-pdb, no-console-log) were installed",
-        "The skill's summary explicitly names the Security category as enabled",
+        "The skill's summary explicitly names the Security category or an equivalent preset-derived rule set as enabled",
         "tests/governance/run.sh exits 0 on the seeded clean Go repo"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "This repo already has governance. Can you review whether the constitution is missing anything obvious? Do not rewrite or reinstall anything.",
+      "expected_output": "The skill does not bootstrap. It recognizes that the request is for review rather than installation, leaves files untouched, and either answers directly or points the user to governance-gardener/governance-amend as the better fit.",
+      "files": ["evals/files/already-bootstrapped-repo/"],
+      "assertions": [
+        "No governance files were rewritten",
+        "The skill explicitly recognized this as a review/explanation request rather than an installation request",
+        "The skill either answered directly or redirected to governance-gardener or governance-amend",
+        "The skill did not create new hook files, a new CONSTITUTION.md, or a replacement tests/governance/ runner"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Bootstrap governance here. One of the rules I want is: every substantive code change must update a plan file. Make sure the enforcement is real, not just 'plans directory exists'.",
+      "expected_output": "The skill recognizes that this requested rule is about each change set, not just repo state. It should either install a change-set-aware rule or clearly say the rule needs diff-aware enforcement. It must not present a mere plans-directory or file-count check as sufficient enforcement for that policy intent.",
+      "files": ["evals/files/empty-polyglot-repo/"],
+      "assertions": [
+        "The skill explicitly distinguishes repo-state rules from change-set-aware rules in its reasoning or summary",
+        "The resulting enforcement for the plan rule is diff-aware, or the skill explicitly says a repo-exists check would be a weak proxy and rejects it",
+        "The skill does not claim that the presence of plans/*.md alone is enough to enforce 'every substantive change updates a plan'"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- update bootstrap evals to reflect preset selection, .githooks usage, and stronger routing expectations
- update amend evals to reflect fast-path summaries, health-check routing, and weak-proxy rule drift fixes
- add explicit eval coverage for rejecting repo-state proxies when the real policy is change-set-aware

## Testing
- jq empty governance-bootstrap/evals/evals.json governance-amend/evals/evals.json
- commit hook (governance rules)
