### PR TITLE
docs(skills): require intent-matched rule enforcement

### DIFF
--- a/governance-amend/SKILL.md
+++ b/governance-amend/SKILL.md
@@ -71,7 +71,18 @@ Most requests will already give you most of this — extract what you can from t
 | **Check logic** | What the script actually inspects — files, patterns, paths, size thresholds, git state, etc. |
 | **Exceptions** | How approved deviations are documented. Default: no exceptions. Otherwise: waiver comment `governance: allow-<rule-name> <ticket>` or a named config file the rule reads. |
 
+Before you draft anything, write down an explicit **intent map** for yourself:
+
+| Field | What to capture |
+|---|---|
+| **Bad merge to block** | The concrete merge or omission this rule is meant to stop. |
+| **Policy surface** | `repo-state` or `change-set obligation`. |
+| **Enforcement surface** | Repo-at-rest scan, staged diff, or branch diff in CI. |
+| **Why this surface fits** | One sentence tying the check shape back to the bad merge. |
+
 If any field is ambiguous, **ask one question at a time** via `AskUserQuestion` or free text — don't dump a four-question form on the user. The most common blocker is "check logic" being too vague; iterate until you have something concrete enough to write bash that either passes or fails deterministically.
+
+If the user's rationale says "every substantive change must...", "this kind of change must also...", "reviewers keep missing intent/approval/metadata", or anything else that describes a missing companion artifact in a change set, classify it as a **change-set obligation** unless the user explicitly says otherwise.
 
 Use two operating modes:
 - **Fast path** — if the user's request already names a concrete rule, rationale, and check shape, draft the amendment directly, smoke-test it, and then show the result.
@@ -83,6 +94,8 @@ If structured question tools are unavailable, use short free-text questions inst
 - If `tests/governance/rules/<name>.sh` already exists → this is an **update**, not a new rule. Confirm with the user before overwriting, and treat the matching `CONSTITUTION.md` subsection as an update too (not a new insertion).
 - If `CONSTITUTION.md` already has a subsection whose header closely matches the proposed name → same thing, confirm.
 - If the user asked to **remove** a rule, confirm the matching script and invariant exist before you start deleting. Also grep for dangling references in docs or CI notes before finishing.
+
+Do not proceed until the intent map is coherent. A valid amendment needs a concrete bad merge, a policy surface, and a check shape that would actually fail that bad merge.
 
 ### Step 3 — Draft the test script
 
@@ -96,6 +109,11 @@ The script must:
 - Call `require_git` if it touches `git ls-files` / `git grep`.
 - On every violation: call `violation "<file>:<line> — <specific-message>"`. A rule without a location in the message is less useful — always include one if the check is per-file or per-line.
 - Honor in-source waivers via `has_waiver "$file" "$line_no" "<rule-name>"` wherever violations are line-level, *unless* the user explicitly said no exceptions.
+
+Choose the inspection surface to match the intent map:
+- `repo-state` rules inspect the tracked tree at rest (`git ls-files`, `git grep`, known paths).
+- `change-set obligation` rules inspect the staged diff locally and the branch diff in CI. Do not collapse these into existence checks just because existence checks are easier to write.
+- If you cannot enforce the intended surface mechanically, stop and tell the user the rule is not ready yet. Do not ship a knowingly weak proxy without calling it out and getting explicit buy-in.
 
 Syntax-check it: `bash -n tests/governance/rules/<name>.sh`. If it fails, fix and re-check. Do not put syntactically broken bash in front of the user.
 
@@ -112,6 +130,8 @@ Run `bash tests/governance/rules/<name>.sh` against the current repo and capture
 - **Any other exit code / crashes** — the rule has a bug. Back to Step 3.
 
 Never ship an amendment that crashes. Exit-1 is legitimate (that's a rule detecting a violation); exit-2+ or a stack trace is a broken rule.
+
+For `change-set obligation` rules, also smoke-test the failure mode itself whenever feasible. The minimum bar is to create or identify a representative changed-path scenario and verify the rule fails when the required companion artifact is missing, not just that it passes on the current tree. If you cannot exercise the missing-companion case safely in the repo, say so explicitly in the final summary.
 
 ### Step 5 — Edit CONSTITUTION.md
 
@@ -154,6 +174,7 @@ Print:
 - The rule name.
 - The action type: added, updated, or removed.
 - The three files changed (with paths).
+- The intent map: bad merge to block, policy surface, and chosen enforcement surface.
 - Smoke-test result: pass, fail-with-real-violation, or crashed-then-fixed.
 - Staged status: confirm the intended amendment files are staged and unrelated files are not.
 - A suggested commit message in Conventional Commits format: `feat(governance): add <rule-name> — <one-line summary>`
@@ -184,6 +205,8 @@ Every successful run should include:
 - **Preserve policy intent on updates.** Threshold tweaks and mechanical refinements should not silently rewrite the rationale.
 - **Strengthen weak proxies, do not preserve them by default.** If an existing rule claims to enforce per-change behavior but only checks repo-level existence or file shape, treat that mismatch as drift worth fixing, not a quirk to copy forward.
 - **Choose the check shape by failure mode.** Ask what bad merge this rule is meant to block. If the answer is "a future change that forgot to do X", the test should inspect the staged diff or branch diff rather than only the repo at rest.
+- **Name the policy surface explicitly.** Every amendment must classify the rule as `repo-state` or `change-set obligation` before any bash is written. If you cannot make that classification, you do not understand the rule yet.
+- **A passing smoke test is not enough for change-set rules.** If the rule is supposed to fail a missing companion artifact, prove that scenario fails or say why you could not exercise it. "It passes on the current repo" is not evidence that the right merge would be blocked.
 - **Respect existing formatting.** The constitution is a living document. Match the indent style, list marker, and heading level conventions already in the file. Don't rewrite prose the user has been tending to.
 - **State material assumptions explicitly.** If you inferred the rule name, summary line, or author handle, surface that in the summary.
 - **Don't commit.** The skill ends at `git add`, not `git commit`. The user's review is the final gate.

--- a/governance-amend/evals/evals.json
+++ b/governance-amend/evals/evals.json
@@ -55,6 +55,19 @@
         "The skill explicitly identified the request as a review/health-check rather than an amendment request",
         "The skill redirected to governance-gardener or answered directly without staging changes"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Add a rule called plan-captured. The goal is that every substantive change ships with an updated plan in plans/*.md so reviewers can see the intent, not just the diff.",
+      "expected_output": "The skill treats this as a change-set obligation, not a repo-state existence check. It creates or updates a rule that inspects the staged diff locally and the branch diff in CI so a substantive change without a companion plans/*.md update fails mechanically. The constitution entry says the rule blocks substantive changes landing without an updated plan, and the final summary explicitly names the bad merge, policy surface, and enforcement surface.",
+      "files": ["evals/files/seeded-repo/"],
+      "assertions": [
+        "The final summary explicitly classifies the rule as a change-set obligation or equivalent wording",
+        "The new or updated rule script inspects changed files (for example via git diff --cached or a branch-diff fallback) rather than only checking whether plans/*.md exists",
+        "The rule script can fail when substantive files change without a companion plans/*.md update",
+        "The CONSTITUTION.md invariant for plan-captured describes the blocked bad merge in per-change terms, not just repo structure",
+        "The summary includes the chosen enforcement surface and why it fits"
+      ]
     }
   ]
 }

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -142,6 +142,19 @@ If the user selects `doc-freshness`, also copy `assets/freshness.conf` to `tests
 
 If the user asks for rules that exist in `references/RULES_CATALOG.md` under "Also available" (e.g. `env-example-current`, `no-curl-bash-pipe`, `docs-dir-minimum`), copy those too — they are supported, just not in the default menu.
 
+Before you install any non-trivial or user-described rule, classify its policy surface:
+
+| Policy surface | Use when the intent is | Preferred enforcement shape |
+|---|---|---|
+| `repo-state` | "the repo must contain / must not contain X" | Existence, content, pattern, metric, or structural check over tracked files |
+| `change-set obligation` | "every substantive change must also do X" | Staged-diff check locally plus branch-diff check in CI |
+
+Ask this explicitly whenever the user requests a custom rule or a rule whose rationale sounds per-change:
+
+> What bad merge are we trying to block: a repo missing something at rest, or a substantive change landing without its required companion update?
+
+Do not accept a repo-exists proxy for a change-set obligation unless you explicitly tell the user it is only a weak approximation and they approve that tradeoff.
+
 ### Step 4 — Write the constitution
 
 Copy `assets/CONSTITUTION.template.md` to `<repo-root>/CONSTITUTION.md`. Then tailor it:
@@ -157,6 +170,7 @@ Copy `assets/CONSTITUTION.template.md` to `<repo-root>/CONSTITUTION.md`. Then ta
 
 Do not invent principles the user did not pick. It is better to ship a short constitution than a bloated one.
 If you had to infer anything material — stack, preset, or hook strategy — record it under `Assumptions:` in the final summary.
+If you install any custom or change-set-aware rule, make sure the invariant text says what merge it blocks, not just what file shape it checks.
 
 ### Step 4b — Inject the Compliance directive into AGENTS.md
 
@@ -252,6 +266,8 @@ Every successful run should leave the user with a summary that includes:
 - **State material assumptions explicitly.** If you had to infer the preset, stack, or hook strategy, surface that in the summary.
 - **Match the enforcement surface to the real intent.** If a rule is meant to govern each substantive change, do not implement it as a repo-exists or file-count check. Prefer change-set-aware enforcement where the hook/CI can actually fail the missing behavior.
 - **Reject weak proxies when they create false confidence.** A rule that says "every change must do X" but only checks "the repo contains one X somewhere" is a bad bootstrap output, not a partial success.
+- **Make the bad merge explicit before writing the rule.** For every custom or ambiguous rule, state the concrete failure mode in plain language, then choose the enforcement surface that would actually catch it.
+- **Spell intent into the invariant.** The constitution entry should encode the spirit of the rule in the Rule and Rationale lines, so future amendments do not mistake a companion-artifact obligation for a repo-exists check.
 - **No invented rules.** When writing the constitution, only include rules the user selected. Governance loses authority the moment it contains rules nobody signed off on.
 
 ## References

--- a/governance-bootstrap/evals/evals.json
+++ b/governance-bootstrap/evals/evals.json
@@ -60,6 +60,18 @@
         "The skill either answered directly or redirected to governance-gardener or governance-amend",
         "The skill did not create new hook files, a new CONSTITUTION.md, or a replacement tests/governance/ runner"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Bootstrap governance here and include a custom rule that says every substantive change must update a plan under plans/*.md so the reason for the change is preserved.",
+      "expected_output": "The skill identifies this custom rule as a change-set obligation and implements it accordingly instead of falling back to a repo-level existence check. The resulting constitution and rule script describe the blocked bad merge in per-change terms, and the summary makes the chosen enforcement surface explicit.",
+      "files": ["evals/files/empty-polyglot-repo/"],
+      "assertions": [
+        "The summary explicitly distinguishes the custom rule as a per-change or change-set-aware rule",
+        "The installed custom rule inspects the staged diff or branch diff rather than only checking whether plans/*.md exists",
+        "The CONSTITUTION.md invariant for the custom rule describes a substantive change landing without a companion plan update as the failure mode",
+        "The summary explains the chosen enforcement surface or why a weaker approximation was not used"
+      ]
     }
   ]
 }

--- a/plans/2026-04-22-refine-governance-skill-contracts.md
+++ b/plans/2026-04-22-refine-governance-skill-contracts.md
@@ -13,6 +13,8 @@ The work includes:
 - a preset-based bootstrap flow
 - a shared governance vocabulary and a canonical watched-scope model
 - expanded eval expectations for routing failures, output contracts, and gardener mode handling
+- explicit intent-mapping guidance so custom and amended rules are derived from the bad merge they must block, not from the easiest proxy to script
+- eval coverage for `plan-captured`-style companion-artifact rules so shallow repo-state implementations fail the contract
 
 ## Steps
 
@@ -20,9 +22,12 @@ The work includes:
 2. Patch the skill contracts to add negative-trigger examples, decision tables, stronger output requirements, and explicit assumption reporting.
 3. Add shared reference material for cross-skill terminology and gardener watched-scope resolution.
 4. Update eval expectations so the repo encodes the intended routing behavior instead of relying on prose alone.
-5. Run lightweight verification: JSON sanity for eval files and `bash tests/governance/run.sh`.
+5. Tighten bootstrap and amend authoring flow so rule intent, policy surface, and enforcement surface must be named explicitly before implementation.
+6. Add a regression-focused eval that rejects repo-exists proxies for per-change obligations such as `plan-captured`.
+7. Run lightweight verification: JSON sanity for eval files and `bash tests/governance/run.sh`.
 
 ## Notes
 
 - This is a retrospective capture. The change work started before this plan file was written.
 - The follow-up amendment to `plan-captured` should make this kind of miss mechanically catchable in the future instead of depending on memory.
+- This plan also covers the next tightening pass: making bootstrap/amend encode the spirit of a rule directly into the workflow so future amendments do not stop at a cursory interpretation.


### PR DESCRIPTION
## Summary
- require governance-amend to map rule intent to bad merge, policy surface, and enforcement surface before drafting checks
- require governance-bootstrap to classify custom rules by policy surface and reject weak repo-state proxies for per-change obligations
- add eval coverage for `plan-captured`-style companion-artifact rules and update the active plan entry

## Testing
- bash tests/governance/run.sh