### PR TITLE
[codex] require issue-linked commit subjects

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -27,10 +27,10 @@ if ! bash "$RULE" "$1"; then
 ✗ Commit message blocked by governance.
 
 Conventional Commits format:
-    <type>(<optional-scope>)!?: <subject>
+    <type>(<optional-scope>)!?: <subject> (#123)
 
 Types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
-Example: fix(auth): reject tokens with empty 'sub' claim
+Example: fix(auth): reject tokens with empty 'sub' claim (#123)
 
 Bypass (CI will still enforce on PR):
     SKIP_GOVERNANCE=1 git commit ...

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -69,8 +69,8 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 
 ### conventional-commits
 
-- **Rule**: Commit messages match `<type>(scope)?!?: subject` per the Conventional Commits spec.
-- **Rationale**: A parseable commit log feeds changelog generation, semver decisions, and future rule enforcement.
+- **Rule**: Commit messages match `<type>(scope)?!?: subject (#123)` per the Conventional Commits spec, with a trailing GitHub issue reference in parentheses.
+- **Rationale**: A parseable commit log feeds changelog generation, semver decisions, and future rule enforcement; the linked GitHub issue keeps every commit tied to a durable discussion or work item.
 - **Enforced by**: `tests/governance/rules/conventional-commits.sh` (checks history) and `.githooks/commit-msg` (checks the pending commit).
 - **Exceptions**: Merge commits and revert commits are exempt.
 
@@ -133,6 +133,7 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 - 2026-04-22 — @srikanth — Add **Compliance** section: explicit directive that humans, agents, and automation must satisfy every principle, guideline, and invariant — not just the mechanically enforced ones. Mirrored into the bootstrap template.
 - 2026-04-22 — @srikanth — Add `hooks-configured`: move local hook scripts to tracked `.githooks/` and require `core.hooksPath=.githooks`, so a fresh clone gets the same local enforcement as every other contributor. Bootstrap skill updated to install hooks under `.githooks/` (not `.git/hooks/`).
 - 2026-04-22 — @srikanth — Strengthen `plan-captured`: require substantive tracked changes to touch `plans/*.md` in the same change set, so missing plans fail mechanically instead of relying on repo memory.
+- 2026-04-22 — @srikanth — Strengthen `conventional-commits`: require a trailing GitHub issue suffix like `(#123)` so every commit is traceable to a durable work item.
 
 ## Escape hatches
 

--- a/governance-bootstrap/SKILL.md
+++ b/governance-bootstrap/SKILL.md
@@ -121,7 +121,7 @@ After the preset choice, present the rule catalog across **two `AskUserQuestion`
 - `ci-workflow-exists` — At least one non-governance workflow exists under `.github/workflows/`.
 
 **Q4 — "Which commit-hygiene rules should the constitution enforce?"** (header: `CommitHygiene`)
-- `conventional-commits` — Commit messages match `<type>(scope)?!?: subject`. *(Recommended — installs a `commit-msg` hook)*
+- `conventional-commits` — Commit messages match `<type>(scope)?!?: subject (#123)`. *(Recommended — installs a `commit-msg` hook)*
 - `no-orphan-todos` — Every `TODO` / `FIXME` references `#123` or `ABC-123`.
 
 *(This question has only 2 options; that's valid. Do not pad with filler.)*

--- a/governance-bootstrap/assets/githooks/commit-msg
+++ b/governance-bootstrap/assets/githooks/commit-msg
@@ -27,10 +27,10 @@ if ! bash "$RULE" "$1"; then
 ✗ Commit message blocked by governance.
 
 Conventional Commits format:
-    <type>(<optional-scope>)!?: <subject>
+    <type>(<optional-scope>)!?: <subject> (#123)
 
 Types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
-Example: fix(auth): reject tokens with empty 'sub' claim
+Example: fix(auth): reject tokens with empty 'sub' claim (#123)
 
 Bypass (CI will still enforce on PR):
     SKIP_GOVERNANCE=1 git commit ...

--- a/governance-bootstrap/assets/tests-bash/rules/conventional-commits.sh
+++ b/governance-bootstrap/assets/tests-bash/rules/conventional-commits.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Rule: Commit messages follow Conventional Commits.
-#   <type>(<optional-scope>)!?: <subject>
+# Rule: Commit messages follow Conventional Commits and end with a GitHub issue suffix.
+#   <type>(<optional-scope>)!?: <subject> (#123)
 # Allowed types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
 # Extend via GOVERNANCE_CC_EXTRA_TYPES="foo bar baz".
 #
@@ -20,8 +20,8 @@ EXTRA_TYPES="${GOVERNANCE_CC_EXTRA_TYPES:-}"
 ALL_TYPES="$DEFAULT_TYPES $EXTRA_TYPES"
 # Build an alternation for the regex.
 types_alt=$(echo "$ALL_TYPES" | tr -s ' ' '|' | sed 's/^|//;s/|$//')
-# Conventional Commits header regex (first line only).
-HEADER_RE="^(${types_alt})(\([^)]+\))?!?: .+"
+# Conventional Commits header regex (first line only) plus a required GitHub issue suffix.
+HEADER_RE="^(${types_alt})(\([^)]+\))?!?: .+ \(#[1-9][0-9]*\)$"
 
 validate_subject() {
     local subject="$1"
@@ -34,7 +34,7 @@ validate_subject() {
     [[ "$subject" == fixup!\ * || "$subject" == squash!\ * || "$subject" == amend!\ * ]] && return 0
 
     if [[ ! "$subject" =~ $HEADER_RE ]]; then
-        violation "$label — '$subject' does not match Conventional Commits (<type>(scope)?: <subject>)"
+        violation "$label — '$subject' does not match Conventional Commits with an issue suffix (<type>(scope)?: <subject> (#123))"
         return 1
     fi
     # Subject ≤ 100 chars keeps PR titles and log output readable.

--- a/governance-bootstrap/references/RULES_CATALOG.md
+++ b/governance-bootstrap/references/RULES_CATALOG.md
@@ -33,7 +33,7 @@ The skill presents these via `AskUserQuestion` across two calls (five categories
 ### Commit hygiene
 | Rule | What it checks |
 |---|---|
-| `conventional-commits` | Commit subjects match `<type>(scope)?!?: subject`. Supported types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `revert`, `style`. Extend via `GOVERNANCE_CC_EXTRA_TYPES`. Installs a `commit-msg` git hook. |
+| `conventional-commits` | Commit subjects match `<type>(scope)?!?: subject (#123)` so every commit carries a GitHub issue reference. Supported types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `revert`, `style`. Extend via `GOVERNANCE_CC_EXTRA_TYPES`. Installs a `commit-msg` git hook. |
 | `no-orphan-todos`      | Every `TODO` / `FIXME` on a line references `#123` or `ABC-123`. |
 
 ### Quality

--- a/plans/2026-04-22-issue-linked-commit-subjects.md
+++ b/plans/2026-04-22-issue-linked-commit-subjects.md
@@ -1,0 +1,12 @@
+# Require Issue-Linked Commit Subjects
+
+## Goal
+
+Amend the existing `conventional-commits` governance rule so commit subjects must end with a parenthesized GitHub issue reference such as `(#123)`, and keep the live repo plus bootstrap assets aligned with that policy.
+
+## Steps
+
+1. Update the live `conventional-commits` rule and tracked `commit-msg` hook text to require the issue suffix.
+2. Mirror the same rule shape into the bootstrap assets and rule catalog so newly bootstrapped repos install the same policy.
+3. Amend `CONSTITUTION.md` and add an Evolution Log entry describing the strengthened commit-traceability requirement.
+4. Run syntax checks and the governance suite, then stage only the amendment files.

--- a/tests/governance/rules/conventional-commits.sh
+++ b/tests/governance/rules/conventional-commits.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Rule: Commit messages follow Conventional Commits.
-#   <type>(<optional-scope>)!?: <subject>
+# Rule: Commit messages follow Conventional Commits and end with a GitHub issue suffix.
+#   <type>(<optional-scope>)!?: <subject> (#123)
 # Allowed types: feat, fix, chore, docs, refactor, test, perf, build, ci, revert, style.
 # Extend via GOVERNANCE_CC_EXTRA_TYPES="foo bar baz".
 #
@@ -20,8 +20,8 @@ EXTRA_TYPES="${GOVERNANCE_CC_EXTRA_TYPES:-}"
 ALL_TYPES="$DEFAULT_TYPES $EXTRA_TYPES"
 # Build an alternation for the regex.
 types_alt=$(echo "$ALL_TYPES" | tr -s ' ' '|' | sed 's/^|//;s/|$//')
-# Conventional Commits header regex (first line only).
-HEADER_RE="^(${types_alt})(\([^)]+\))?!?: .+"
+# Conventional Commits header regex (first line only) plus a required GitHub issue suffix.
+HEADER_RE="^(${types_alt})(\([^)]+\))?!?: .+ \(#[1-9][0-9]*\)$"
 
 validate_subject() {
     local subject="$1"
@@ -34,7 +34,7 @@ validate_subject() {
     [[ "$subject" == fixup!\ * || "$subject" == squash!\ * || "$subject" == amend!\ * ]] && return 0
 
     if [[ ! "$subject" =~ $HEADER_RE ]]; then
-        violation "$label — '$subject' does not match Conventional Commits (<type>(scope)?: <subject>)"
+        violation "$label — '$subject' does not match Conventional Commits with an issue suffix (<type>(scope)?: <subject> (#123))"
         return 1
     fi
     # Subject ≤ 100 chars keeps PR titles and log output readable.


### PR DESCRIPTION
## Summary

- require `conventional-commits` subjects to end with a GitHub issue suffix like `(#123)`
- update the tracked `commit-msg` hook messaging to reflect the new format
- mirror the same behavior and documentation into the bootstrap assets and rule catalog

## Why

This makes every commit traceable to a durable GitHub work item instead of relying on commit text alone.

## Validation

- `bash tests/governance/rules/conventional-commits.sh`
- `bash tests/governance/run.sh`
