### PR TITLE
feat(governance): add plan-per-issue rule (#15)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -102,6 +102,13 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 - **Enforced by**: `tests/governance/rules/plan-captured.sh`
 - **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-captured` (bare or inside an HTML comment) anywhere in the file exempts that plan from the structure check. Changes limited to `plans/` or `governance-health/` are exempt from the same-change requirement.
 
+### plan-per-issue
+
+- **Rule**: Every tracked `plans/*.md` filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plan files share the same issue number.
+- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate.
+- **Enforced by**: `tests/governance/rules/plan-per-issue.sh`
+- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-per-issue` (bare or inside an HTML comment) anywhere in the file exempts that plan. Used to grandfather plans that predate this rule.
+
 ### issues-tracked
 
 - **Rule**: `QUALITY.md` exists at the repo root with a top-level `# ` heading and contains `## Open` and `## Resolved` sections.
@@ -146,6 +153,7 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 - 2026-04-23 — @srikanth — Strengthen `agent-token-accounting` ledger: split prompt-cache traffic into its own `cache-create` and `cache-read` columns so the ledger is lossless (billing dollars and cache-hit-rate recoverable). Move ledger parse / sum / append / validate and trailer parse / cross-check into stdlib-only Python libs at `scripts/governance/lib/ledger.py` and `lib/trailers.py` — bash stays in charge of git plumbing, env detection, and argv walking, but schema-sensitive work uses named dataclass fields instead of positional `awk -F'\|'`. Trailer `Token-Input = input + cache_create` (excludes `cache_read`) to surface new work rather than cache rent. Legacy 8-column rows are accepted by the parser, so the migration is a one-time textual edit.
 - 2026-04-23 — @srikanth — Tighten `agent-token-accounting` total invariant: `COSTS.md` `total` now equals `input + cache_create + output` (cache_read is tracked but excluded from total), so the ledger's headline number represents new work rather than cache rent. This makes `row.total == Token-Total` in the trailer by construction; `trailers.py` gained a matching cross-check to catch any future drift between the two. One live row was recomputed in place; zero-cache-read rows are unaffected.
 - 2026-04-23 — @srikanth — Evolve `agent-token-accounting` schema to v3 (12 columns): add a `model` column (runtime-reported, e.g. `claude-sonnet-4-5`) and a `cost-usd` column computed from `scripts/governance/lib/rates.py` using **all four** token columns (cache_read included — that's where cache rent shows up). Rename `total` to `new-work` to stop pretending the raw token sum is a single comparable headline; the dollar column is the only number that lines up across commits with different cache mixes. Runtime readers now emit 6 values (add `<model>`); `agent-accounting.sh` passes model into the ledger; `lib/ledger.py` recomputes `new_work` and looks up `cost_usd` at append time. Legacy v2 (10 cols) and v1 (8 cols) rows are still parsed under the same `new_work` invariant; existing rows in `COSTS.md` were migrated in place by inserting empty `model`/`cost-usd` cells (token values unchanged since v2 `total` already matched the `new_work` semantic).
+- 2026-04-23 — @srikanth — Add `plan-per-issue`: require each `plans/*.md` filename to carry an `issue-<N>` token and forbid duplicate plans for the same issue, so the plan↔issue binding is one-to-one. Closes [#15](https://github.com/Duaility/governance-kit/issues/15).
 
 ## Escape hatches
 

--- a/plans/2026-04-22-add-compliance-directive.md
+++ b/plans/2026-04-22-add-compliance-directive.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Add Compliance directive (AGENTS.md + CONSTITUTION.md + bootstrap template)
 
 ## Goal

--- a/plans/2026-04-22-add-issues-tracked-rule.md
+++ b/plans/2026-04-22-add-issues-tracked-rule.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Add `issues-tracked` governance rule
 
 ## Goal

--- a/plans/2026-04-22-add-plan-captured-rule.md
+++ b/plans/2026-04-22-add-plan-captured-rule.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Add `plan-captured` governance rule
 
 Plan for the amendment that introduces the `plan-captured` rule. Captured here to satisfy the rule it creates — the first commit under the new regime should itself have a plan on disk.

--- a/plans/2026-04-22-agent-token-accounting.md
+++ b/plans/2026-04-22-agent-token-accounting.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # Agent Token Accounting
 
 ## Goal

--- a/plans/2026-04-22-author-skill-evals.md
+++ b/plans/2026-04-22-author-skill-evals.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # Author evals for all three skills
 
 ## Goal

--- a/plans/2026-04-22-bootstrap-injects-agents-directive.md
+++ b/plans/2026-04-22-bootstrap-injects-agents-directive.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Bootstrap injects the AGENTS.md directive
 
 ## Goal

--- a/plans/2026-04-22-governance-gardener.md
+++ b/plans/2026-04-22-governance-gardener.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Replace `doc-gardener` with `governance-gardener`
 
 ## Goal

--- a/plans/2026-04-22-hooks-configured-rule.md
+++ b/plans/2026-04-22-hooks-configured-rule.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 — Add `hooks-configured` rule and move hooks to `.githooks/`
 
 ## Goal

--- a/plans/2026-04-22-issue-linked-commit-subjects.md
+++ b/plans/2026-04-22-issue-linked-commit-subjects.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # Require Issue-Linked Commit Subjects
 
 ## Goal

--- a/plans/2026-04-22-refine-governance-skill-contracts.md
+++ b/plans/2026-04-22-refine-governance-skill-contracts.md
@@ -1,3 +1,5 @@
+<!-- governance: allow-plan-per-issue predates-rule -->
+
 # 2026-04-22 - Refine governance skill contracts
 
 Retrospective plan for the follow-up work that tightened the three governance skills after the initial PR was already in flight. This was originally missed during execution and is being captured now so the repo history still records why the change took this shape.

--- a/plans/2026-04-23-issue-15-plan-per-issue-rule.md
+++ b/plans/2026-04-23-issue-15-plan-per-issue-rule.md
@@ -1,0 +1,25 @@
+# Require One Plan File Per Issue
+
+## Goal
+
+Add a new governance rule `plan-per-issue` that binds every `plans/*.md` file
+to a single GitHub issue via an `issue-<N>` token in the filename, and rejects
+duplicate plans for the same issue. This addresses issue
+[#15](https://github.com/Duaility/governance-kit/issues/15): "Create a new
+constitution rule which enforces a single plan file for each issue."
+
+## Steps
+
+1. Add `tests/governance/rules/plan-per-issue.sh` — checks filenames, detects
+   duplicates, supports a per-file `governance: allow-plan-per-issue` waiver so
+   grandfathered plans do not block the rule.
+2. Insert a `plan-per-issue` **Invariants** subsection in `CONSTITUTION.md`
+   (after `plan-captured`) and append an **Evolution Log** entry dated
+   2026-04-23.
+3. Grandfather the nine existing pre-rule plan files by adding an HTML-comment
+   waiver line explaining they predate the convention.
+4. Smoke-test: run `bash tests/governance/rules/plan-per-issue.sh` and the
+   full `tests/governance/run.sh` suite; confirm the rule passes against the
+   current tree once waivers are in place.
+5. Stage only the amendment artifacts (rule script, constitution edits, the
+   nine waivered plan files, this plan).

--- a/tests/governance/rules/plan-per-issue.sh
+++ b/tests/governance/rules/plan-per-issue.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Rule: Each tracked plans/*.md file carries an `issue-<N>` token in its
+# filename, and no two plan files share the same issue number.
+# Rationale: Plans are the durable record of intent behind a change set. A
+# one-to-one binding between plan and issue keeps the system of record
+# unambiguous — reviewers jump from an issue to its single plan, and agents
+# can detect whether an issue already has a plan before drafting a duplicate.
+set -u
+source "$(dirname "$0")/../lib.sh"
+rule_start "plan-per-issue"
+require_git
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+if [[ ! -d "$ROOT/plans" ]]; then
+    rule_end
+fi
+
+plan_files=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    plan_files+=("$f")
+done < <(git ls-files -- 'plans/*.md' 2>/dev/null || true)
+
+if [[ ${#plan_files[@]} -eq 0 ]]; then
+    rule_end
+fi
+
+seen_nums=()
+seen_files=()
+for f in "${plan_files[@]}"; do
+    # Per-file waiver: `governance: allow-plan-per-issue` anywhere in the file.
+    if grep -qE '^[[:space:]]*(<!--)?[[:space:]]*governance:[[:space:]]*allow-plan-per-issue' "$f"; then
+        continue
+    fi
+
+    base="${f##*/}"
+    if [[ "$base" =~ issue-([0-9]+) ]]; then
+        num="${BASH_REMATCH[1]}"
+        dup_of=""
+        for i in "${!seen_nums[@]}"; do
+            if [[ "${seen_nums[$i]}" == "$num" ]]; then
+                dup_of="${seen_files[$i]}"
+                break
+            fi
+        done
+        if [[ -n "$dup_of" ]]; then
+            violation "$f — issue #$num already has a plan at $dup_of"
+        else
+            seen_nums+=("$num")
+            seen_files+=("$f")
+        fi
+    else
+        violation "$f — plan filename must include an 'issue-<N>' token (e.g. 2026-04-23-issue-15-summary.md)"
+    fi
+done
+
+rule_end


### PR DESCRIPTION
## Summary

- New governance rule **`plan-per-issue`**: every tracked `plans/*.md` filename must carry an `issue-<N>` token, and no two plan files may share the same issue number.
- Constitution amendment + Evolution Log entry landing in the same commit as the enforcing test (per the cardinal rule).
- 9 pre-existing plan files grandfathered with the standard `<!-- governance: allow-plan-per-issue predates-rule -->` waiver.

Closes #15.

## Why

Plans are the durable record of *why* a change took its shape. Without a one-to-one binding between plan and issue, the system of record drifts: agents draft duplicate plans for the same issue, and reviewers can't jump from an issue to its single motivating plan. Encoding the issue number in the filename makes the binding mechanically checkable and greppable.

## What changed

- `tests/governance/rules/plan-per-issue.sh` — new check. Scans tracked `plans/*.md`, parses an `issue-<N>` token from each filename, flags missing tokens and duplicate issue numbers. Honors per-file waivers.
- `CONSTITUTION.md` — new **Invariants** subsection `plan-per-issue` (alphabetical, after `plan-captured`) and a new **Evolution Log** entry dated 2026-04-23.
- `plans/2026-04-23-issue-15-plan-per-issue-rule.md` — plan for this change (itself using the new naming convention).
- 9 grandfathered plans under `plans/2026-04-22-*.md` — one-line waiver prepended.

## Enforcement surface

`repo-state` — the rule inspects tracked plan filenames at rest. Duplicate-plan and missing-token merges are blocked by the same check on every commit and in CI.

## Test plan

- [x] `bash tests/governance/rules/plan-per-issue.sh` — passes on the current tree
- [x] `bash tests/governance/run.sh` — all 14 rules pass
- [x] Negative smoke test in a scratch repo: rule correctly flags `bad-no-token.md` (no `issue-<N>`) and `issue-7-second.md` (duplicate of `issue-7-first.md`); exits 1 with per-file violation messages
- [x] Waiver path exercised — the 9 grandfathered plans pass without renaming

## Notes for reviewers

- I chose `issue-<N>` as the token form (readable, filesystem-safe, unambiguous) over `#<N>` or `i<N>`. Revisit if the team prefers a different convention.
- Grandfathering via waivers rather than renaming mirrors the `plan-captured` pattern already established in this repo.
- The rule is scoped to this repo's own governance (like `plan-captured` and `issues-tracked`) — not mirrored into `governance-bootstrap/assets/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)