### PR TITLE
[codex] complete codex agent accounting

### DIFF
--- a/COSTS.md
+++ b/COSTS.md
@@ -50,3 +50,4 @@ Schema:
 | claude-code-b8c3537c-03c-1776934485 | claude-code | b8c3537c-03c3-4ba3-8e42-ceb02b2da58b | #13 | claude-opus-4-7 | 0 | 19641 | 2798442 | 9089 | 28730 | 1.7492 | docs(plans): consolidate PR #14 plans into one umbrella file (#13) |
 | claude-code-d70074d5-c7d-1776937263 | claude-code | d70074d5-c7d9-47e9-872e-d6434ebba353 | #17 | claude-opus-4-7 | 90 | 135005 | 4221982 | 55041 | 190136 | 4.3312 | feat(governance): make agent-token-accounting mandatory on every non-merge commi |
 | claude-code-2ff1de86-c43-1776938847 | claude-code | 2ff1de86-c431-4d9f-b1f6-3207628ac98e | #19 | claude-opus-4-7 | 93 | 183429 | 4516732 | 42054 | 225576 | 4.4566 | feat(governance): replace plan-captured with commit-issue-plan-match (#19) |
+| codex-019db9a2-47d-1776939439 | codex | 019db9a2-47d3-7012-93b5-4b0cbb9adaa8 | #13 | gpt-5.4 | 228312 | 0 | 5097984 | 19716 | 248028 | 2.1410 | fix(governance): complete codex agent accounting (#13) |

--- a/governance-bootstrap/assets/scripts/governance/lib/rates.py
+++ b/governance-bootstrap/assets/scripts/governance/lib/rates.py
@@ -5,10 +5,11 @@ Rates are per-million-tokens, split by usage mode:
 
     (base_input, cache_create_5m, cache_read, output)
 
-Source: Anthropic pricing table (Opus 4.x / Sonnet 3.7-4.6 as of 2026-04-23).
-Cache writes assume the **5-minute** TTL, which is Claude Code's default.
-If a runtime ever surfaces 1h cache writes separately we'll need a second
-column — for now cache_create in the ledger is implicitly 5m.
+Source: Anthropic pricing table (Opus 4.x / Sonnet 3.7-4.6) and OpenAI API
+pricing table (GPT-5.4 family) as of 2026-04-23.
+Cache writes assume the **5-minute** TTL for Anthropic models, which is
+Claude Code's default. OpenAI models do not charge a separate cache-write
+rate in this ledger, so their cache-create rate matches base input.
 
 Model lookup is tolerant:
   - lowercase + strip whitespace
@@ -42,6 +43,10 @@ RATES: dict[str, tuple[float, float, float, float]] = {
     "claude-sonnet-4-5": (3.00, 3.75, 0.30, 15.00),
     "claude-sonnet-4":   (3.00, 3.75, 0.30, 15.00),
     "claude-sonnet-3-7": (3.00, 3.75, 0.30, 15.00),
+    # OpenAI GPT-5.4 — standard processing, text tokens
+    "gpt-5.4":      (2.50, 2.50, 0.25, 15.00),
+    "gpt-5.4-mini": (0.75, 0.75, 0.075, 4.50),
+    "gpt-5.4-nano": (0.20, 0.20, 0.02, 1.25),
 }
 
 _DATE_SUFFIX_RE = re.compile(r"-\d{8}$")

--- a/governance-bootstrap/assets/scripts/governance/runtimes/codex.sh
+++ b/governance-bootstrap/assets/scripts/governance/runtimes/codex.sh
@@ -5,10 +5,13 @@
 #   <session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>
 # Exit non-zero if no transcript can be located.
 #
-# Codex transcripts typically do not report prompt-cache fields (that's an
-# Anthropic-API feature), so cache_create / cache_read come out as 0. Keeping
-# the shape identical to claude-code.sh lets the caller treat all runtime
-# readers uniformly.
+# Codex transcripts report OpenAI cached input as a subset of input tokens.
+# The ledger wants lossless split columns, so this reader records:
+#   input       = input_tokens - cached_input_tokens
+#   cache_read  = cached_input_tokens
+#   cache_create = 0
+# Keeping the shape identical to claude-code.sh lets the caller treat all
+# runtime readers uniformly.
 #
 # Environment overrides:
 #   CODEX_TRANSCRIPT_PATH   absolute path to the session JSONL
@@ -18,40 +21,42 @@
 set -u
 
 CODEX_SESSIONS="${CODEX_SESSIONS_DIR:-${HOME}/.codex/sessions}"
+CODEX_ARCHIVED_SESSIONS="${CODEX_ARCHIVED_SESSIONS_DIR:-${HOME}/.codex/archived_sessions}"
 
 TRANSCRIPT="${CODEX_TRANSCRIPT_PATH:-}"
 if [[ -z "$TRANSCRIPT" ]]; then
     if [[ -n "${CODEX_THREAD_ID:-}" ]]; then
-        candidate="$CODEX_SESSIONS/${CODEX_THREAD_ID}.jsonl"
-        [[ -f "$candidate" ]] && TRANSCRIPT="$candidate"
+        for dir in "$CODEX_SESSIONS" "$CODEX_ARCHIVED_SESSIONS"; do
+            [[ -d "$dir" ]] || continue
+            TRANSCRIPT="$(find "$dir" -type f -name "*${CODEX_THREAD_ID}*.jsonl" -print 2>/dev/null | head -n1)"
+            [[ -n "$TRANSCRIPT" ]] && break
+        done
     fi
     if [[ -z "$TRANSCRIPT" && -d "$CODEX_SESSIONS" ]]; then
-        TRANSCRIPT="$(ls -t "$CODEX_SESSIONS"/*.jsonl 2>/dev/null | head -n1)"
+        TRANSCRIPT="$(find "$CODEX_SESSIONS" -type f -name "*.jsonl" -print0 2>/dev/null \
+            | xargs -0 ls -t 2>/dev/null \
+            | head -n1)"
     fi
 fi
 
 [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]] && exit 1
 
-SESSION_ID="${CODEX_THREAD_ID:-}"
-if [[ -z "$SESSION_ID" ]]; then
-    base="$(basename "$TRANSCRIPT")"
-    SESSION_ID="${base%.jsonl}"
-fi
-[[ -z "$SESSION_ID" ]] && exit 2
-
-# Sum tokens across the common Codex transcript shapes — top-level `usage`,
-# nested `message.usage`, `response.usage` — and both `input_tokens` /
-# `output_tokens` and `prompt_tokens` / `completion_tokens` key pairs.
-# Also surface cache_creation / cache_read fields if the transcript happens
-# to carry them (some Anthropic-via-Codex configurations do).
-read -r CUM_INPUT CUM_CACHE_CREATE CUM_CACHE_READ CUM_OUTPUT MODEL < <(python3 - "$TRANSCRIPT" <<'PY'
+# Read cumulative tokens across the common Codex transcript shapes:
+#   - Codex Desktop event_msg token_count.info.total_token_usage
+#   - top-level usage / message.usage / response.usage dictionaries
+#   - OpenAI input_tokens_details.cached_tokens dictionaries
+#   - prompt_tokens / completion_tokens fallback keys
+OUT="$(python3 - "$TRANSCRIPT" "${CODEX_THREAD_ID:-}" <<'PY'
 import json, sys
 path = sys.argv[1]
+env_sid = sys.argv[2]
+sid = env_sid or ""
 t_input = 0
 t_cache_create = 0
 t_cache_read = 0
 t_output = 0
 model = ""
+latest_total = None
 
 def pull(u):
     """Return (input, cache_create, cache_read, output) from a usage dict."""
@@ -61,10 +66,25 @@ def pull(u):
     o  = u.get("output_tokens") or u.get("completion_tokens") or 0
     cc = u.get("cache_creation_input_tokens", 0) or 0
     cr = u.get("cache_read_input_tokens", 0) or 0
+    # OpenAI-style cached input is a subset of input tokens, not an additional
+    # bucket. Split it out so pricing uses cached-input rates for those tokens.
+    if not cr:
+        cr = u.get("cached_input_tokens", 0) or 0
+    details = u.get("input_tokens_details") or u.get("prompt_tokens_details")
+    if not cr and isinstance(details, dict):
+        cr = details.get("cached_tokens", 0) or 0
     try:
-        return int(i or 0), int(cc or 0), int(cr or 0), int(o or 0)
+        i = int(i or 0)
+        cc = int(cc or 0)
+        cr = int(cr or 0)
+        o = int(o or 0)
     except (TypeError, ValueError):
         return 0, 0, 0, 0
+    # Only OpenAI cached-input fields are included in input_tokens. Anthropic
+    # cache_read_input_tokens is already separate, so do not subtract it.
+    if ("cached_input_tokens" in u) or isinstance(details, dict):
+        i = max(i - cr, 0)
+    return i, cc, cr, o
 
 with open(path) as f:
     for line in f:
@@ -72,15 +92,35 @@ with open(path) as f:
             d = json.loads(line)
         except Exception:
             continue
+        payload = d.get("payload") if isinstance(d.get("payload"), dict) else None
+        if not sid and payload and d.get("type") == "session_meta":
+            candidate = payload.get("id")
+            if isinstance(candidate, str) and candidate:
+                sid = candidate
         # Model can live at any of several places depending on transcript version.
-        for container in (d, d.get("message"), d.get("response")):
+        for container in (d, payload, d.get("message"), d.get("response")):
             if isinstance(container, dict):
-                m = container.get("model")
+                m = container.get("model") or container.get("model_slug") or container.get("model_id")
                 if isinstance(m, str) and m:
                     model = m
                     break
+                collaboration = container.get("collaboration_mode")
+                if isinstance(collaboration, dict):
+                    settings = collaboration.get("settings")
+                    if isinstance(settings, dict):
+                        m = settings.get("model")
+                        if isinstance(m, str) and m:
+                            model = m
+                            break
+        if payload and payload.get("type") == "token_count":
+            info = payload.get("info")
+            total = info.get("total_token_usage") if isinstance(info, dict) else None
+            if isinstance(total, dict):
+                latest_total = pull(total)
+                continue
         for container in (
             d,
+            payload,
             d.get("message")  if isinstance(d.get("message"),  dict) else None,
             d.get("response") if isinstance(d.get("response"), dict) else None,
         ):
@@ -94,9 +134,17 @@ with open(path) as f:
                 t_cache_read   += cr
                 t_output       += o
                 break
-print(f"{t_input} {t_cache_create} {t_cache_read} {t_output} {model or 'unknown'}")
+if latest_total is not None:
+    t_input, t_cache_create, t_cache_read, t_output = latest_total
+if not sid:
+    base = path.rsplit("/", 1)[-1]
+    if base.endswith(".jsonl"):
+        base = base[:-6]
+    sid = base.split("rollout-", 1)[-1] if base.startswith("rollout-") else base
+print(f"{sid} {t_input} {t_cache_create} {t_cache_read} {t_output} {model or 'unknown'}")
 PY
-)
+)"
+read -r SESSION_ID CUM_INPUT CUM_CACHE_CREATE CUM_CACHE_READ CUM_OUTPUT MODEL <<<"$OUT"
 
 printf '%s %s %s %s %s %s\n' \
     "$SESSION_ID" "${CUM_INPUT:-0}" "${CUM_CACHE_CREATE:-0}" "${CUM_CACHE_READ:-0}" "${CUM_OUTPUT:-0}" "${MODEL:-unknown}"

--- a/governance-bootstrap/references/AGENT_TOKEN_ACCOUNTING.md
+++ b/governance-bootstrap/references/AGENT_TOKEN_ACCOUNTING.md
@@ -232,21 +232,27 @@ The reader at `scripts/governance/runtimes/claude-code.sh`:
 Same story — `CODEX_THREAD_ID` is already set in Codex sessions, so no
 wrapper is needed. The reader at `scripts/governance/runtimes/codex.sh`:
 
-1. Locates the transcript at `~/.codex/sessions/${CODEX_THREAD_ID}.jsonl`,
-   falling back to the most recently modified `*.jsonl` in the sessions dir.
-   Override with `CODEX_TRANSCRIPT_PATH`.
-2. Derives the session id from `CODEX_THREAD_ID` or from the transcript
-   filename.
-3. Sums tokens across the common shapes — top-level `usage`, `message.usage`,
-   `response.usage` — handling both `input_tokens` / `output_tokens` and
-   `prompt_tokens` / `completion_tokens` key pairs, since Codex's transcript
-   schema varies by version. Also picks up `cache_creation_input_tokens` /
-   `cache_read_input_tokens` when present; zeroes the cache columns when
-   the runtime doesn't expose them.
-4. Tracks `model` from the same containers. Defaults to `unknown` if none
-   of the transcript entries carry it — the ledger's `cost-usd` column
+1. Locates the transcript by searching recursively under
+   `~/.codex/sessions/` and `~/.codex/archived_sessions/` for a filename
+   containing `CODEX_THREAD_ID`, falling back to the most recently modified
+   `*.jsonl` under the sessions dir. Override with `CODEX_TRANSCRIPT_PATH`.
+2. Derives the session id from `CODEX_THREAD_ID`, `session_meta.payload.id`,
+   or finally the transcript filename.
+3. Reads Codex Desktop's cumulative
+   `event_msg.payload.info.total_token_usage` records when present. For
+   OpenAI cached input, `cached_input_tokens` is a subset of `input_tokens`,
+   so the reader emits `input = input_tokens - cached_input_tokens`,
+   `cache_read = cached_input_tokens`, and `cache_create = 0`.
+4. Falls back to summing common API shapes — top-level `usage`,
+   `message.usage`, `response.usage` — handling both `input_tokens` /
+   `output_tokens` and `prompt_tokens` / `completion_tokens` key pairs.
+   It also understands `input_tokens_details.cached_tokens` and
+   `prompt_tokens_details.cached_tokens`.
+5. Tracks `model` from `payload.model`, `collaboration_mode.settings.model`,
+   and the older top-level / nested model fields. Defaults to `unknown` if
+   none of the transcript entries carry it — the ledger's `cost-usd` column
    stays empty in that case.
-5. Prints `<session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>`.
+6. Prints `<session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>`.
 
 ### Other runtimes
 

--- a/plans/2026-04-23-issue-13-codex-agent-accounting.md
+++ b/plans/2026-04-23-issue-13-codex-agent-accounting.md
@@ -1,0 +1,12 @@
+# 2026-04-23 — Complete Codex Agent Accounting
+
+## Goal
+
+Make Codex-authored commits produce complete `COSTS.md` rows with the same fidelity as Claude Code: reliable transcript discovery, model capture, cached-token split, and priced `cost-usd` values.
+
+## Steps
+
+1. Update the Codex runtime reader to find nested rollout transcripts by `CODEX_THREAD_ID`, including archived sessions.
+2. Parse Codex Desktop `token_count.info.total_token_usage` records as cumulative usage and split OpenAI cached input out of base input.
+3. Capture Codex model ids from current transcript metadata and add GPT-5.4 family rates to the pricing table.
+4. Verify the reader against the current Codex Desktop transcript and run the governance suite.

--- a/scripts/governance/lib/rates.py
+++ b/scripts/governance/lib/rates.py
@@ -5,10 +5,11 @@ Rates are per-million-tokens, split by usage mode:
 
     (base_input, cache_create_5m, cache_read, output)
 
-Source: Anthropic pricing table (Opus 4.x / Sonnet 3.7-4.6 as of 2026-04-23).
-Cache writes assume the **5-minute** TTL, which is Claude Code's default.
-If a runtime ever surfaces 1h cache writes separately we'll need a second
-column — for now cache_create in the ledger is implicitly 5m.
+Source: Anthropic pricing table (Opus 4.x / Sonnet 3.7-4.6) and OpenAI API
+pricing table (GPT-5.4 family) as of 2026-04-23.
+Cache writes assume the **5-minute** TTL for Anthropic models, which is
+Claude Code's default. OpenAI models do not charge a separate cache-write
+rate in this ledger, so their cache-create rate matches base input.
 
 Model lookup is tolerant:
   - lowercase + strip whitespace
@@ -42,6 +43,10 @@ RATES: dict[str, tuple[float, float, float, float]] = {
     "claude-sonnet-4-5": (3.00, 3.75, 0.30, 15.00),
     "claude-sonnet-4":   (3.00, 3.75, 0.30, 15.00),
     "claude-sonnet-3-7": (3.00, 3.75, 0.30, 15.00),
+    # OpenAI GPT-5.4 — standard processing, text tokens
+    "gpt-5.4":      (2.50, 2.50, 0.25, 15.00),
+    "gpt-5.4-mini": (0.75, 0.75, 0.075, 4.50),
+    "gpt-5.4-nano": (0.20, 0.20, 0.02, 1.25),
 }
 
 _DATE_SUFFIX_RE = re.compile(r"-\d{8}$")

--- a/scripts/governance/runtimes/codex.sh
+++ b/scripts/governance/runtimes/codex.sh
@@ -5,10 +5,13 @@
 #   <session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>
 # Exit non-zero if no transcript can be located.
 #
-# Codex transcripts typically do not report prompt-cache fields (that's an
-# Anthropic-API feature), so cache_create / cache_read come out as 0. Keeping
-# the shape identical to claude-code.sh lets the caller treat all runtime
-# readers uniformly.
+# Codex transcripts report OpenAI cached input as a subset of input tokens.
+# The ledger wants lossless split columns, so this reader records:
+#   input       = input_tokens - cached_input_tokens
+#   cache_read  = cached_input_tokens
+#   cache_create = 0
+# Keeping the shape identical to claude-code.sh lets the caller treat all
+# runtime readers uniformly.
 #
 # Environment overrides:
 #   CODEX_TRANSCRIPT_PATH   absolute path to the session JSONL
@@ -18,40 +21,42 @@
 set -u
 
 CODEX_SESSIONS="${CODEX_SESSIONS_DIR:-${HOME}/.codex/sessions}"
+CODEX_ARCHIVED_SESSIONS="${CODEX_ARCHIVED_SESSIONS_DIR:-${HOME}/.codex/archived_sessions}"
 
 TRANSCRIPT="${CODEX_TRANSCRIPT_PATH:-}"
 if [[ -z "$TRANSCRIPT" ]]; then
     if [[ -n "${CODEX_THREAD_ID:-}" ]]; then
-        candidate="$CODEX_SESSIONS/${CODEX_THREAD_ID}.jsonl"
-        [[ -f "$candidate" ]] && TRANSCRIPT="$candidate"
+        for dir in "$CODEX_SESSIONS" "$CODEX_ARCHIVED_SESSIONS"; do
+            [[ -d "$dir" ]] || continue
+            TRANSCRIPT="$(find "$dir" -type f -name "*${CODEX_THREAD_ID}*.jsonl" -print 2>/dev/null | head -n1)"
+            [[ -n "$TRANSCRIPT" ]] && break
+        done
     fi
     if [[ -z "$TRANSCRIPT" && -d "$CODEX_SESSIONS" ]]; then
-        TRANSCRIPT="$(ls -t "$CODEX_SESSIONS"/*.jsonl 2>/dev/null | head -n1)"
+        TRANSCRIPT="$(find "$CODEX_SESSIONS" -type f -name "*.jsonl" -print0 2>/dev/null \
+            | xargs -0 ls -t 2>/dev/null \
+            | head -n1)"
     fi
 fi
 
 [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]] && exit 1
 
-SESSION_ID="${CODEX_THREAD_ID:-}"
-if [[ -z "$SESSION_ID" ]]; then
-    base="$(basename "$TRANSCRIPT")"
-    SESSION_ID="${base%.jsonl}"
-fi
-[[ -z "$SESSION_ID" ]] && exit 2
-
-# Sum tokens across the common Codex transcript shapes — top-level `usage`,
-# nested `message.usage`, `response.usage` — and both `input_tokens` /
-# `output_tokens` and `prompt_tokens` / `completion_tokens` key pairs.
-# Also surface cache_creation / cache_read fields if the transcript happens
-# to carry them (some Anthropic-via-Codex configurations do).
-read -r CUM_INPUT CUM_CACHE_CREATE CUM_CACHE_READ CUM_OUTPUT MODEL < <(python3 - "$TRANSCRIPT" <<'PY'
+# Read cumulative tokens across the common Codex transcript shapes:
+#   - Codex Desktop event_msg token_count.info.total_token_usage
+#   - top-level usage / message.usage / response.usage dictionaries
+#   - OpenAI input_tokens_details.cached_tokens dictionaries
+#   - prompt_tokens / completion_tokens fallback keys
+OUT="$(python3 - "$TRANSCRIPT" "${CODEX_THREAD_ID:-}" <<'PY'
 import json, sys
 path = sys.argv[1]
+env_sid = sys.argv[2]
+sid = env_sid or ""
 t_input = 0
 t_cache_create = 0
 t_cache_read = 0
 t_output = 0
 model = ""
+latest_total = None
 
 def pull(u):
     """Return (input, cache_create, cache_read, output) from a usage dict."""
@@ -61,10 +66,25 @@ def pull(u):
     o  = u.get("output_tokens") or u.get("completion_tokens") or 0
     cc = u.get("cache_creation_input_tokens", 0) or 0
     cr = u.get("cache_read_input_tokens", 0) or 0
+    # OpenAI-style cached input is a subset of input tokens, not an additional
+    # bucket. Split it out so pricing uses cached-input rates for those tokens.
+    if not cr:
+        cr = u.get("cached_input_tokens", 0) or 0
+    details = u.get("input_tokens_details") or u.get("prompt_tokens_details")
+    if not cr and isinstance(details, dict):
+        cr = details.get("cached_tokens", 0) or 0
     try:
-        return int(i or 0), int(cc or 0), int(cr or 0), int(o or 0)
+        i = int(i or 0)
+        cc = int(cc or 0)
+        cr = int(cr or 0)
+        o = int(o or 0)
     except (TypeError, ValueError):
         return 0, 0, 0, 0
+    # Only OpenAI cached-input fields are included in input_tokens. Anthropic
+    # cache_read_input_tokens is already separate, so do not subtract it.
+    if ("cached_input_tokens" in u) or isinstance(details, dict):
+        i = max(i - cr, 0)
+    return i, cc, cr, o
 
 with open(path) as f:
     for line in f:
@@ -72,15 +92,35 @@ with open(path) as f:
             d = json.loads(line)
         except Exception:
             continue
+        payload = d.get("payload") if isinstance(d.get("payload"), dict) else None
+        if not sid and payload and d.get("type") == "session_meta":
+            candidate = payload.get("id")
+            if isinstance(candidate, str) and candidate:
+                sid = candidate
         # Model can live at any of several places depending on transcript version.
-        for container in (d, d.get("message"), d.get("response")):
+        for container in (d, payload, d.get("message"), d.get("response")):
             if isinstance(container, dict):
-                m = container.get("model")
+                m = container.get("model") or container.get("model_slug") or container.get("model_id")
                 if isinstance(m, str) and m:
                     model = m
                     break
+                collaboration = container.get("collaboration_mode")
+                if isinstance(collaboration, dict):
+                    settings = collaboration.get("settings")
+                    if isinstance(settings, dict):
+                        m = settings.get("model")
+                        if isinstance(m, str) and m:
+                            model = m
+                            break
+        if payload and payload.get("type") == "token_count":
+            info = payload.get("info")
+            total = info.get("total_token_usage") if isinstance(info, dict) else None
+            if isinstance(total, dict):
+                latest_total = pull(total)
+                continue
         for container in (
             d,
+            payload,
             d.get("message")  if isinstance(d.get("message"),  dict) else None,
             d.get("response") if isinstance(d.get("response"), dict) else None,
         ):
@@ -94,9 +134,17 @@ with open(path) as f:
                 t_cache_read   += cr
                 t_output       += o
                 break
-print(f"{t_input} {t_cache_create} {t_cache_read} {t_output} {model or 'unknown'}")
+if latest_total is not None:
+    t_input, t_cache_create, t_cache_read, t_output = latest_total
+if not sid:
+    base = path.rsplit("/", 1)[-1]
+    if base.endswith(".jsonl"):
+        base = base[:-6]
+    sid = base.split("rollout-", 1)[-1] if base.startswith("rollout-") else base
+print(f"{sid} {t_input} {t_cache_create} {t_cache_read} {t_output} {model or 'unknown'}")
 PY
-)
+)"
+read -r SESSION_ID CUM_INPUT CUM_CACHE_CREATE CUM_CACHE_READ CUM_OUTPUT MODEL <<<"$OUT"
 
 printf '%s %s %s %s %s %s\n' \
     "$SESSION_ID" "${CUM_INPUT:-0}" "${CUM_CACHE_CREATE:-0}" "${CUM_CACHE_READ:-0}" "${CUM_OUTPUT:-0}" "${MODEL:-unknown}"


### PR DESCRIPTION
## Summary

Completes the Codex side of agent token accounting so Codex-authored commits can append accurate `COSTS.md` rows like Claude Code already does.

## What changed

- Finds Codex rollout transcripts recursively under `~/.codex/sessions/` and archived sessions by `CODEX_THREAD_ID`.
- Parses Codex Desktop `token_count.info.total_token_usage` records, including splitting OpenAI cached input into `cache-read` while excluding it from new-work tokens.
- Captures current Codex model metadata such as `gpt-5.4` and adds GPT-5.4 family pricing so `cost-usd` is populated.
- Updates the accounting reference and adds the issue plan required by governance.

## Root cause

The Codex reader assumed a flat `~/.codex/sessions/<thread>.jsonl` file and older `usage` dictionaries. Current Codex Desktop stores nested rollout transcripts and reports cumulative token usage through `event_msg` token-count payloads.

## Validation

- `scripts/governance/runtimes/codex.sh`
- `bash tests/governance/run.sh`
