### PR TITLE
feat(governance): roll harness-engineering lessons into existing rules (#39)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -29,7 +29,7 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 
 - **Rule**: The repo ships the baseline set of root-level documents and local-hook scaffolding expected by governance-kit — each sub-check below is enabled by default and can be opted out of individually via `GOVERNANCE_REQUIRED_DOCS_DISABLE` (comma-separated list of sub-check keys):
     - `constitution` — `CONSTITUTION.md` at repo root, non-empty, ≥ 10 lines.
-    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`).
+    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`), and a link to `CONSTITUTION.md` so the file functions as a map to the bedrock durable docs rather than a standalone manual.
     - `readme` — `README.md`, `README`, or `README.rst` at repo root with a top-level heading and ≥ 30 words.
     - `license` — `LICENSE`, `LICENSE.md`, `LICENSE.txt`, `COPYING`, or `COPYING.md` exists at repo root and is non-empty.
     - `security` — `SECURITY.md` (root, `docs/`, or `.github/`) exists and lists a contact email, URL, or vulnerability-disclosure platform.
@@ -99,10 +99,14 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 
 ### plan-per-issue
 
-- **Rule**: Every tracked `plans/*.md` filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plan files share the same issue number.
-- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate.
+- **Rule**: Every tracked `plans/*.md` file satisfies two shape requirements:
+    1. The filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plans share the same issue number.
+    2. The body contains at least one `## Validation`, `## Verification`, or `## Acceptance` section describing how completion will be judged.
+- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate. A validation-intent section forces the author to name the exit criterion before code is written, which is what distinguishes a plan from a running commentary.
 - **Enforced by**: `tests/governance/rules/plan-per-issue/check.sh`
-- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-per-issue` (bare or inside an HTML comment) anywhere in the file exempts that plan. Used to grandfather plans that predate this rule.
+- **Exceptions**: Two per-file waivers, each matched as a bare line or inside an HTML comment anywhere in the file:
+    - `governance: allow-plan-per-issue` — exempts the plan from the filename-token and duplicate-issue checks. Used to grandfather plans that predate this rule.
+    - `governance: allow-plan-validation` — exempts the plan from the validation-section check only. Used to grandfather legacy plans imported before the validation requirement existed; new plans should carry the section instead.
 
 ### commit-issue-plan-match
 
@@ -159,6 +163,7 @@ If a specific change cannot satisfy a rule, document the deviation in the PR des
 - 2026-04-23 — @srikanth — Re-bootstrap after `governance-reset`: reinstall `core + agent-governance` at the `standard` preset (16 rules including `doc-freshness`, which prior hand-customization had removed). Clean slate for the constitution text; evolution log and principles preserved.
 - 2026-04-23 — @srikanth — Roll up low-signal core rules into three substantive ones. `constitution-exists`, `agents-md-exists`, `readme-exists`, `license-exists`, `security-md-exists`, `architecture-doc-exists`, `ci-workflow-exists`, `env-example-current`, and `hooks-configured` collapse into `required-docs`. `no-large-files`, `no-committed-build-artifacts`, `no-merge-conflict-markers`, `no-debug-statements`, and `file-size-limit` collapse into `repo-hygiene`. `no-secrets` and `dotenv-gitignored` collapse into `secrets-hygiene`. The three new rules expose `GOVERNANCE_<NAME>_DISABLE` env vars as per-sub-check opt-outs — tradeoff acknowledged: one invariant paragraph now justifies a bag of checks, but the `core` pack shrinks from 21 rules to 8 and the `minimal`/`standard`/`strict` presets stop burying the substantive entries alongside a pile of `[ -f X ] || fail` checks. Waiver strings for the formerly-independent rules migrate: `allow-no-secrets` → `allow-secrets-hygiene`, `allow-no-debug-statements` → `allow-repo-hygiene`. Closes [#29](https://github.com/Duaility/governance-kit/issues/29).
 - 2026-04-24 — @srikanth — Add `pre-commit-test-gate`: require the governance-kit source repo's tracked pre-commit hook to run `scripts/test-packs.sh`, with `scripts/test-packverb.py` included in that pack test gate, so the pack helper and pack-author contracts run locally before commit instead of relying on manual execution. Closes [#33](https://github.com/Duaility/governance-kit/issues/33).
+- 2026-04-24 — @srikanth — Fold the Harness Engineering ideas into rules that already own the surface: `required-docs`' `agents` sub-check now additionally requires `AGENTS.md` to link to `CONSTITUTION.md`, making the file's "map to durable docs" contract mechanically checkable rather than aspirational; `plan-per-issue` now additionally requires every tracked plan to carry a `## Validation`, `## Verification`, or `## Acceptance` section so the exit criterion is named before code is written. Legacy plans are grandfathered via a new `governance: allow-plan-validation` per-file waiver — deliberately separate from `allow-plan-per-issue` so future rewrites can drop the legacy waiver without touching the filename-token exemption. Draft standalone rule names `agent-docs-map` and `plan-validation-evidence` are discarded: both describe refinements to policy the existing rules already own, and a separate rule would split ownership of one file's shape across two checks. Closes [#39](https://github.com/Duaility/governance-kit/issues/39).
 
 ## Escape hatches
 

--- a/COSTS.md
+++ b/COSTS.md
@@ -107,3 +107,4 @@ Schema:
 | claude-code-35defae4-ca7-1777023627 | claude-code | 35defae4-ca70-47d2-adbb-4db6e0489b11 | #35 | claude-opus-4-7 | 136 | 306699 | 11526635 | 79456 | 386291 | 9.6673 | feat(accounting): make Cost-USD mandatory (#35) |
 | claude-code-04b28aac-fc8-1777024974 | claude-code | 04b28aac-fc85-4c80-8c94-9734e26101ac | #37 | claude-opus-4-7 | 10228 | 116988 | 4594193 | 31105 | 158321 | 3.8570 | chore(gardener): remove governance-gardener skill (#37) |
 | claude-code-04b28aac-fc8-1777025034 | claude-code | 04b28aac-fc85-4c80-8c94-9734e26101ac | #37 | claude-opus-4-7 | 6 | 10552 | 488065 | 3333 | 13891 | 0.3933 | chore(gardener): remove governance-gardener skill (#37) |
+| claude-code-b5006e23-eec-1777028604 | claude-code | b5006e23-eec5-490f-a729-b1b521ef6d7c | #39 | claude-opus-4-7 | 113 | 141430 | 6236287 | 40440 | 181983 | 5.0136 | feat(governance): roll harness-engineering lessons into existing rules (#39) |

--- a/extensions/packs/agent-governance/rules/plan-per-issue/check.sh
+++ b/extensions/packs/agent-governance/rules/plan-per-issue/check.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Rule: Each tracked plans/*.md file carries an `issue-<N>` token in its
-# filename, and no two plan files share the same issue number.
+# filename, no two plan files share the same issue number, and every plan
+# includes at least one validation-intent section heading
+# (`## Validation`, `## Verification`, or `## Acceptance`).
 # Rationale: Plans are the durable record of intent behind a change set. A
 # one-to-one binding between plan and issue keeps the system of record
 # unambiguous — reviewers jump from an issue to its single plan, and agents
 # can detect whether an issue already has a plan before drafting a duplicate.
+# A validation-intent section tells a reviewer (human or agent) how the plan
+# will be judged complete before any code is written.
 set -u
 source "$(dirname "$0")/../../lib.sh"
 rule_start "plan-per-issue"
@@ -53,6 +57,16 @@ for f in "${plan_files[@]}"; do
         fi
     else
         violation "$f — plan filename must include an 'issue-<N>' token (e.g. 2026-04-23-issue-15-summary.md)"
+    fi
+
+    # Validation-intent section. Legacy plans opt out with a
+    # `governance: allow-plan-validation` waiver so the rule takes effect
+    # for new plans without forcing a mass rewrite of historical records.
+    if grep -qE '^[[:space:]]*(<!--)?[[:space:]]*governance:[[:space:]]*allow-plan-validation' "$f"; then
+        continue
+    fi
+    if ! grep -qE '^##[[:space:]]+(Validation|Verification|Acceptance)\b' "$f"; then
+        violation "$f — plan is missing a '## Validation', '## Verification', or '## Acceptance' section describing how completion will be judged"
     fi
 done
 

--- a/extensions/packs/agent-governance/rules/plan-per-issue/constitution.md
+++ b/extensions/packs/agent-governance/rules/plan-per-issue/constitution.md
@@ -1,6 +1,10 @@
 ### plan-per-issue
 
-- **Rule**: Every tracked `plans/*.md` filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plan files share the same issue number.
-- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate.
+- **Rule**: Every tracked `plans/*.md` file satisfies two shape requirements:
+    1. The filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plans share the same issue number.
+    2. The body contains at least one `## Validation`, `## Verification`, or `## Acceptance` section describing how completion will be judged.
+- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate. A validation-intent section forces the author to name the exit criterion before code is written, which is what distinguishes a plan from a running commentary.
 - **Enforced by**: `tests/governance/rules/plan-per-issue/check.sh`
-- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-per-issue` (bare or inside an HTML comment) anywhere in the file exempts that plan. Used to grandfather plans that predate this rule.
+- **Exceptions**: Two per-file waivers, each matched as a bare line or inside an HTML comment anywhere in the file:
+    - `governance: allow-plan-per-issue` — exempts the plan from the filename-token and duplicate-issue checks. Used to grandfather plans that predate this rule.
+    - `governance: allow-plan-validation` — exempts the plan from the validation-section check only. Used to grandfather legacy plans imported before the validation requirement existed; new plans should carry the section instead.

--- a/extensions/packs/agent-governance/rules/plan-per-issue/evals/test.sh
+++ b/extensions/packs/agent-governance/rules/plan-per-issue/evals/test.sh
@@ -12,25 +12,62 @@ install_rule "$PACK_DIR" "$EVAL_ID"
 # pass — no plans/ directory, rule is a no-op
 EVAL_LABEL="$EVAL_ID no-plans" expect_pass "$RULE"
 
-# pass — two plans, distinct issue numbers
+# pass — two plans, distinct issue numbers, each with a validation section
 mkdir -p plans
-printf '# Plan one\n' > plans/2026-04-23-issue-1-alpha.md
-printf '# Plan two\n' > plans/2026-04-23-issue-2-beta.md
+cat > plans/2026-04-23-issue-1-alpha.md <<'EOF'
+# Plan one
+
+## Validation
+
+Rule evals pass.
+EOF
+cat > plans/2026-04-23-issue-2-beta.md <<'EOF'
+# Plan two
+
+## Acceptance
+
+Ship it when tests go green.
+EOF
 stage_all
 commit_quiet "docs: add two plans"
 EVAL_LABEL="$EVAL_ID distinct" expect_pass "$RULE"
 
 # fail — a plan filename missing the issue token
-printf '# Rogue plan\n' > plans/rogue.md
+printf '# Rogue plan\n\n## Validation\n\nok\n' > plans/rogue.md
 stage_all
 commit_quiet "docs: add untokened plan"
 EVAL_LABEL="$EVAL_ID no-token" expect_fail "$RULE"
 
 # fail — duplicate issue number across two plans
 rm plans/rogue.md
-printf '# Plan three\n' > plans/2026-04-23-issue-1-duplicate.md
+cat > plans/2026-04-23-issue-1-duplicate.md <<'EOF'
+# Plan three
+
+## Verification
+
+done.
+EOF
 stage_all
 commit_quiet "docs: dup plan"
 EVAL_LABEL="$EVAL_ID dup" expect_fail "$RULE"
+
+# fail — validation/verification/acceptance section missing
+rm plans/2026-04-23-issue-1-duplicate.md
+printf '# Plan four\n\nbody without validation heading.\n' > plans/2026-04-23-issue-3-gamma.md
+stage_all
+commit_quiet "docs: plan without validation"
+EVAL_LABEL="$EVAL_ID missing-validation" expect_fail "$RULE"
+
+# pass — validation waiver grandfathers the missing-section plan
+cat > plans/2026-04-23-issue-3-gamma.md <<'EOF'
+# Plan four
+
+<!-- governance: allow-plan-validation legacy -->
+
+Body without a validation heading, waived.
+EOF
+stage_all
+commit_quiet "docs: waive validation on legacy plan"
+EVAL_LABEL="$EVAL_ID validation-waiver" expect_pass "$RULE"
 
 eval_done

--- a/extensions/packs/agent-governance/rules/plan-per-issue/rule.yaml
+++ b/extensions/packs/agent-governance/rules/plan-per-issue/rule.yaml
@@ -1,6 +1,6 @@
-# plan-per-issue — Every tracked plans/*.md filename carries a unique issue-<N> token.
+# plan-per-issue — plans bind 1:1 to a GitHub issue and name their exit criterion.
 category: AgentDiscipline
 recommended: true
-summary: Every tracked plans/*.md filename carries a unique issue-<N> token.
+summary: Every tracked plans/*.md has a unique issue-<N> filename token and a Validation/Verification/Acceptance section.
 surface: repo-state
 hook: pre-commit

--- a/governance/assets/packs/core/rules/required-docs/check.sh
+++ b/governance/assets/packs/core/rules/required-docs/check.sh
@@ -53,6 +53,14 @@ if is_enabled agents; then
         if [[ $link_count -lt $MIN_LINKS ]]; then
             violation "AGENTS.md has $link_count internal links — an index should link out (min: $MIN_LINKS)"
         fi
+        # AGENTS.md should be a map to the bedrock durable docs. The
+        # `constitution` sub-check already mandates CONSTITUTION.md at
+        # root — require AGENTS.md to link to it so a fresh reader has
+        # one anchored hop to the rule set.
+        if [[ -f "$ROOT/CONSTITUTION.md" ]] \
+            && ! grep -qE '\]\((\./)?CONSTITUTION\.md(#[^)]*)?\)' "$FILE"; then
+            violation "AGENTS.md does not link to CONSTITUTION.md — an index should point at the bedrock durable docs"
+        fi
     fi
 fi
 

--- a/governance/assets/packs/core/rules/required-docs/constitution.md
+++ b/governance/assets/packs/core/rules/required-docs/constitution.md
@@ -2,7 +2,7 @@
 
 - **Rule**: The repo ships the baseline set of root-level documents and local-hook scaffolding expected by governance-kit — each sub-check below is enabled by default and can be opted out of individually via `GOVERNANCE_REQUIRED_DOCS_DISABLE` (comma-separated list of sub-check keys):
     - `constitution` — `CONSTITUTION.md` at repo root, non-empty, ≥ 10 lines.
-    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`).
+    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`), and a link to `CONSTITUTION.md` so the file functions as a map to the bedrock durable docs rather than a standalone manual.
     - `readme` — `README.md`, `README`, or `README.rst` at repo root with a top-level heading and ≥ 30 words.
     - `license` — `LICENSE`, `LICENSE.md`, `LICENSE.txt`, `COPYING`, or `COPYING.md` exists at repo root and is non-empty.
     - `security` — `SECURITY.md` (root, `docs/`, or `.github/`) exists and lists a contact email, URL, or vulnerability-disclosure platform.

--- a/governance/assets/packs/core/rules/required-docs/evals/test.sh
+++ b/governance/assets/packs/core/rules/required-docs/evals/test.sh
@@ -68,4 +68,63 @@ rm ARCHITECTURE.md
 GOVERNANCE_REQUIRED_DOCS_DISABLE="license,architecture" \
     EVAL_LABEL="$EVAL_ID disable skips sub-checks" expect_pass "$RULE"
 
+# restore license + architecture, then fail via AGENTS.md missing a link to CONSTITUTION.md.
+# Rewrite AGENTS.md with the required length + link count but no CONSTITUTION.md anchor.
+cat > LICENSE <<'EOF'
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software to deal in the Software without restriction.
+EOF
+cat > ARCHITECTURE.md <<'EOF'
+# Architecture
+
+## Overview
+
+Placeholder architecture doc with enough lines to clear the minimum
+threshold. Describes the layering and boundaries that would actually
+be documented in a real repo.
+
+## Layers
+
+- data
+- service
+- api
+
+## Invariants
+
+No upward dependencies. The api layer depends on service; service
+depends on data. Breaking this triggers review.
+
+## Further reading
+
+See the README and the constitution.
+EOF
+cat > AGENTS.md <<'EOF'
+# AGENTS.md
+
+Index for agents working in this fixture. Intentionally omits a link to
+CONSTITUTION.md so the map-to-bedrock check fires.
+
+## Quick links
+
+- [README](README.md) — public-facing overview of the fixture
+- [Architecture](ARCHITECTURE.md) — top-level layering and domains
+- [Security](SECURITY.md) — how to report a vulnerability
+
+## Working in this repo
+
+Placeholder body text to clear the minimum line count so we isolate the
+missing-CONSTITUTION-link failure from the stub-length failure. The
+agents sub-check should fail only because the required link is absent,
+not because the file is too short.
+
+More filler to push the document past the minimum line threshold so the
+missing-link assertion is the only failure surface reported by the
+rule under test.
+EOF
+EVAL_LABEL="$EVAL_ID agents missing constitution link" expect_fail "$RULE"
+
 eval_done

--- a/governance/references/RULES_CATALOG.md
+++ b/governance/references/RULES_CATALOG.md
@@ -24,7 +24,7 @@ The three consolidated rules (`required-docs`, `repo-hygiene`, `secrets-hygiene`
 ### Foundation
 | Rule | What it checks |
 |---|---|
-| `required-docs` | Rolled-up presence check for repo-root docs and local-hook scaffolding. Sub-checks (all enabled by default, keys for `GOVERNANCE_REQUIRED_DOCS_DISABLE`): `constitution` (`CONSTITUTION.md` ≥ 10 lines); `agents` (`AGENTS.md` at repo root, 30–250 lines, ≥ 3 internal links); `readme` (`README.md`/`.rst` with heading + ≥ 30 words); `license` (`LICENSE`/variants at repo root, non-empty); `security` (`SECURITY.md` with contact); `architecture` (`ARCHITECTURE.md` ≥ 20 lines); `ci-workflow` (≥ 1 non-governance workflow); `env-example` (every key in local `.env` is declared in `.env.example`); `hooks` (`.githooks/pre-commit` tracked + executable, `core.hooksPath=.githooks`; no-ops on non-`githooks` strategies). |
+| `required-docs` | Rolled-up presence check for repo-root docs and local-hook scaffolding. Sub-checks (all enabled by default, keys for `GOVERNANCE_REQUIRED_DOCS_DISABLE`): `constitution` (`CONSTITUTION.md` ≥ 10 lines); `agents` (`AGENTS.md` at repo root, 30–250 lines, ≥ 3 internal links, **and a link to `CONSTITUTION.md`** so the file is a map to the bedrock durable docs rather than a standalone manual); `readme` (`README.md`/`.rst` with heading + ≥ 30 words); `license` (`LICENSE`/variants at repo root, non-empty); `security` (`SECURITY.md` with contact); `architecture` (`ARCHITECTURE.md` ≥ 20 lines); `ci-workflow` (≥ 1 non-governance workflow); `env-example` (every key in local `.env` is declared in `.env.example`); `hooks` (`.githooks/pre-commit` tracked + executable, `core.hooksPath=.githooks`; no-ops on non-`githooks` strategies). |
 
 ### Security
 | Rule | What it checks |
@@ -66,7 +66,7 @@ For repos where every tree-change is produced through an agent runtime (Codex, C
 ### Agent discipline
 | Rule | What it checks |
 |---|---|
-| `plan-per-issue`           | Every tracked `plans/*.md` filename carries a unique `issue-<N>` token. |
+| `plan-per-issue`           | Every tracked `plans/*.md` file carries a unique `issue-<N>` token in its filename **and** includes a `## Validation`, `## Verification`, or `## Acceptance` section naming how completion will be judged. Per-file waivers: `governance: allow-plan-per-issue` (skips filename/duplicate checks) and `governance: allow-plan-validation` (skips the validation-section check only) — both bare or inside an HTML comment. |
 | `commit-issue-plan-match`  | Each commit's `(#N)` subject anchor matches an `issue-<N>` token on a plan file it touches. Installs a `commit-msg` hook. |
 | `issues-tracked`           | `QUALITY.md` exists at repo root with `Open` and `Resolved` sections. Ships `install-assets/QUALITY.md` so a newly bootstrapped repo starts green. |
 | `agent-token-accounting`   | Every non-merge, non-revert commit carries the full trailer set (`Agent`, `Issue`, `Session`, `Token-Input`, `Token-Output`, `Token-Total`, `Cost-Key`), satisfies `Total = Input + Output`, and has exactly one matching append-only row in `COSTS.md`. Ships `install-assets/COSTS.md` plus rule-owned pre-commit and prepare-commit-msg helpers. Runtime-agnostic — see [AGENT_TOKEN_ACCOUNTING.md](AGENT_TOKEN_ACCOUNTING.md) for Codex / Claude Code wiring. |

--- a/plans/2026-04-22-add-compliance-directive.md
+++ b/plans/2026-04-22-add-compliance-directive.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Add Compliance directive (AGENTS.md + CONSTITUTION.md + bootstrap template)

--- a/plans/2026-04-22-add-issues-tracked-rule.md
+++ b/plans/2026-04-22-add-issues-tracked-rule.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Add `issues-tracked` governance rule

--- a/plans/2026-04-22-add-plan-captured-rule.md
+++ b/plans/2026-04-22-add-plan-captured-rule.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Add `plan-captured` governance rule

--- a/plans/2026-04-22-agent-token-accounting.md
+++ b/plans/2026-04-22-agent-token-accounting.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # Agent Token Accounting

--- a/plans/2026-04-22-author-skill-evals.md
+++ b/plans/2026-04-22-author-skill-evals.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # Author evals for all three skills

--- a/plans/2026-04-22-bootstrap-injects-agents-directive.md
+++ b/plans/2026-04-22-bootstrap-injects-agents-directive.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Bootstrap injects the AGENTS.md directive

--- a/plans/2026-04-22-governance-gardener.md
+++ b/plans/2026-04-22-governance-gardener.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Replace `doc-gardener` with `governance-gardener`

--- a/plans/2026-04-22-hooks-configured-rule.md
+++ b/plans/2026-04-22-hooks-configured-rule.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 — Add `hooks-configured` rule and move hooks to `.githooks/`

--- a/plans/2026-04-22-issue-linked-commit-subjects.md
+++ b/plans/2026-04-22-issue-linked-commit-subjects.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # Require Issue-Linked Commit Subjects

--- a/plans/2026-04-22-refine-governance-skill-contracts.md
+++ b/plans/2026-04-22-refine-governance-skill-contracts.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- governance: allow-plan-per-issue predates-rule -->
 
 # 2026-04-22 - Refine governance skill contracts

--- a/plans/2026-04-23-issue-13-codex-agent-accounting.md
+++ b/plans/2026-04-23-issue-13-codex-agent-accounting.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 # 2026-04-23 — Complete Codex Agent Accounting
 
 ## Goal

--- a/plans/2026-04-23-issue-15-plan-per-issue-rule.md
+++ b/plans/2026-04-23-issue-15-plan-per-issue-rule.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 # Require One Plan File Per Issue
 
 ## Goal

--- a/plans/2026-04-23-issue-17-mandatory-agent-token-accounting.md
+++ b/plans/2026-04-23-issue-17-mandatory-agent-token-accounting.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 # Make `agent-token-accounting` mandatory on every non-merge commit
 
 Tracks [#17](https://github.com/Duaility/governance-kit/issues/17).

--- a/plans/2026-04-23-issue-19-commit-issue-plan-match.md
+++ b/plans/2026-04-23-issue-19-commit-issue-plan-match.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-23 -->
 
 # 2026-04-23 — Add `commit-issue-plan-match`, retire `plan-captured`

--- a/plans/2026-04-23-issue-23-rule-packs.md
+++ b/plans/2026-04-23-issue-23-rule-packs.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-23 -->
 
 # 2026-04-23 — Model governance rules as extensible rule packs

--- a/plans/2026-04-23-issue-25-governance-reset.md
+++ b/plans/2026-04-23-issue-25-governance-reset.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-23 -->
 
 # 2026-04-23 — Add `governance-reset` skill

--- a/plans/2026-04-23-issue-27-setup-clone-script.md
+++ b/plans/2026-04-23-issue-27-setup-clone-script.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-23 -->
 
 # 2026-04-23 — Ship `scripts/setup-clone.sh` and fix `install-assets/` leak

--- a/plans/2026-04-24-issue-31-unified-governance-skill.md
+++ b/plans/2026-04-24-issue-31-unified-governance-skill.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-24 -->
 
 

--- a/plans/2026-04-24-issue-33-unified-governance-contract-drift.md
+++ b/plans/2026-04-24-issue-33-unified-governance-contract-drift.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 <!-- last-verified: 2026-04-24 -->
 
 # 2026-04-24 — Fix unified governance skill contract drift

--- a/plans/2026-04-24-issue-37-remove-gardener.md
+++ b/plans/2026-04-24-issue-37-remove-gardener.md
@@ -1,3 +1,4 @@
+<!-- governance: allow-plan-validation legacy -->
 # Plan — issue-37: Remove governance-gardener skill
 
 Closes [#37](https://github.com/Duaility/governance-kit/issues/37).

--- a/plans/2026-04-24-issue-39-harness-engineering-lessons.md
+++ b/plans/2026-04-24-issue-39-harness-engineering-lessons.md
@@ -1,0 +1,68 @@
+# Plan — issue-39: Roll harness-engineering lessons into existing rules
+
+Closes [#39](https://github.com/Duaility/governance-kit/issues/39).
+
+## Goal
+
+Fold the durable ideas from OpenAI's Harness Engineering post into the
+rules that already own the relevant policy surface, instead of spawning
+one-off rules per insight. Two concrete strengthenings:
+
+1. `core/required-docs` agents sub-check — AGENTS.md must be an explicit
+   map to the repo's bedrock durable docs, not a standalone manual.
+2. `agent-governance/plan-per-issue` — every tracked plan must carry a
+   validation-intent section (`## Validation`, `## Verification`, or
+   `## Acceptance`), so a reviewer can tell at a glance how the plan
+   will be judged complete.
+
+Draft names `agent-docs-map` and `plan-validation-evidence` are dropped —
+they duplicate ownership the existing rules already have.
+
+## Steps
+
+1. **Decide ownership.** AGENTS.md presence already lives in
+   `core/required-docs` — the `agents` sub-check is the right home for
+   the map-shape tightening. Putting it in an agent-governance extension
+   would split one file's shape across two rules.
+2. **Strengthen the agents sub-check.** Require AGENTS.md to link to
+   `CONSTITUTION.md` at minimum — the bedrock durable doc the same rule
+   already mandates. Keep the existing bounded-length and
+   minimum-internal-links checks. Update `check.sh`, `constitution.md`,
+   and evals (new fail fixture: AGENTS.md without a CONSTITUTION.md
+   link).
+3. **Strengthen `plan-per-issue`.** Add a scan for `^##[[:space:]]+
+   (Validation|Verification|Acceptance)\b`. Introduce a new per-file
+   waiver `governance: allow-plan-validation` so existing plans can be
+   grandfathered without touching the filename-token check's waiver.
+   Update `check.sh`, `constitution.md`, and evals.
+4. **Grandfather legacy plans.** Add
+   `<!-- governance: allow-plan-validation legacy -->` to every plan in
+   `plans/` that predates this rule and does not already include a
+   validation-intent section. This keeps the repo green while the rule
+   takes effect for new plans.
+5. **Catalog + references.** Update
+   `governance/references/RULES_CATALOG.md` to mention the new agents
+   sub-check details and the validation-section requirement on
+   `plan-per-issue`.
+6. **Verify.** Run `bash scripts/test-packs.sh` and
+   `bash tests/governance/run.sh` — both must pass.
+
+## Validation
+
+- `bash tests/governance/run.sh` exits 0 on this branch.
+- `bash scripts/test-packs.sh` exits 0 — every rule eval (including the
+  new fail fixtures for the strengthened checks) passes.
+- New negative assertions exist in
+  `governance/assets/packs/core/rules/required-docs/evals/test.sh` and
+  `extensions/packs/agent-governance/rules/plan-per-issue/evals/test.sh`.
+- No legacy plan file is reported as a violation — each is either
+  updated or carries the `allow-plan-validation` waiver.
+
+## Non-goals
+
+- Standalone architecture-boundary rules. The issue explicitly defers
+  these until there is a concrete checker.
+- Tightening `issues-tracked` to grade domain/layer quality. Also
+  deferred per the issue.
+- Renaming or restructuring `AGENTS.md` on this or target repos beyond
+  the link-to-CONSTITUTION.md requirement.

--- a/tests/governance/rules/plan-per-issue/check.sh
+++ b/tests/governance/rules/plan-per-issue/check.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Rule: Each tracked plans/*.md file carries an `issue-<N>` token in its
-# filename, and no two plan files share the same issue number.
+# filename, no two plan files share the same issue number, and every plan
+# includes at least one validation-intent section heading
+# (`## Validation`, `## Verification`, or `## Acceptance`).
 # Rationale: Plans are the durable record of intent behind a change set. A
 # one-to-one binding between plan and issue keeps the system of record
 # unambiguous — reviewers jump from an issue to its single plan, and agents
 # can detect whether an issue already has a plan before drafting a duplicate.
+# A validation-intent section tells a reviewer (human or agent) how the plan
+# will be judged complete before any code is written.
 set -u
 source "$(dirname "$0")/../../lib.sh"
 rule_start "plan-per-issue"
@@ -53,6 +57,16 @@ for f in "${plan_files[@]}"; do
         fi
     else
         violation "$f — plan filename must include an 'issue-<N>' token (e.g. 2026-04-23-issue-15-summary.md)"
+    fi
+
+    # Validation-intent section. Legacy plans opt out with a
+    # `governance: allow-plan-validation` waiver so the rule takes effect
+    # for new plans without forcing a mass rewrite of historical records.
+    if grep -qE '^[[:space:]]*(<!--)?[[:space:]]*governance:[[:space:]]*allow-plan-validation' "$f"; then
+        continue
+    fi
+    if ! grep -qE '^##[[:space:]]+(Validation|Verification|Acceptance)\b' "$f"; then
+        violation "$f — plan is missing a '## Validation', '## Verification', or '## Acceptance' section describing how completion will be judged"
     fi
 done
 

--- a/tests/governance/rules/plan-per-issue/constitution.md
+++ b/tests/governance/rules/plan-per-issue/constitution.md
@@ -1,6 +1,10 @@
 ### plan-per-issue
 
-- **Rule**: Every tracked `plans/*.md` filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plan files share the same issue number.
-- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate.
+- **Rule**: Every tracked `plans/*.md` file satisfies two shape requirements:
+    1. The filename includes an `issue-<N>` token identifying the GitHub issue it plans for, and no two plans share the same issue number.
+    2. The body contains at least one `## Validation`, `## Verification`, or `## Acceptance` section describing how completion will be judged.
+- **Rationale**: Plans are the durable record of intent behind a change set. A one-to-one binding between plan and issue keeps the system of record unambiguous — reviewers jump from an issue to its single plan, and agents can detect whether an issue already has a plan before drafting a duplicate. A validation-intent section forces the author to name the exit criterion before code is written, which is what distinguishes a plan from a running commentary.
 - **Enforced by**: `tests/governance/rules/plan-per-issue/check.sh`
-- **Exceptions**: Per-file waiver — a line matching `governance: allow-plan-per-issue` (bare or inside an HTML comment) anywhere in the file exempts that plan. Used to grandfather plans that predate this rule.
+- **Exceptions**: Two per-file waivers, each matched as a bare line or inside an HTML comment anywhere in the file:
+    - `governance: allow-plan-per-issue` — exempts the plan from the filename-token and duplicate-issue checks. Used to grandfather plans that predate this rule.
+    - `governance: allow-plan-validation` — exempts the plan from the validation-section check only. Used to grandfather legacy plans imported before the validation requirement existed; new plans should carry the section instead.

--- a/tests/governance/rules/plan-per-issue/rule.yaml
+++ b/tests/governance/rules/plan-per-issue/rule.yaml
@@ -1,6 +1,6 @@
-# plan-per-issue — Every tracked plans/*.md filename carries a unique issue-<N> token.
+# plan-per-issue — plans bind 1:1 to a GitHub issue and name their exit criterion.
 category: AgentDiscipline
 recommended: true
-summary: Every tracked plans/*.md filename carries a unique issue-<N> token.
+summary: Every tracked plans/*.md has a unique issue-<N> filename token and a Validation/Verification/Acceptance section.
 surface: repo-state
 hook: pre-commit

--- a/tests/governance/rules/required-docs/check.sh
+++ b/tests/governance/rules/required-docs/check.sh
@@ -53,6 +53,14 @@ if is_enabled agents; then
         if [[ $link_count -lt $MIN_LINKS ]]; then
             violation "AGENTS.md has $link_count internal links — an index should link out (min: $MIN_LINKS)"
         fi
+        # AGENTS.md should be a map to the bedrock durable docs. The
+        # `constitution` sub-check already mandates CONSTITUTION.md at
+        # root — require AGENTS.md to link to it so a fresh reader has
+        # one anchored hop to the rule set.
+        if [[ -f "$ROOT/CONSTITUTION.md" ]] \
+            && ! grep -qE '\]\((\./)?CONSTITUTION\.md(#[^)]*)?\)' "$FILE"; then
+            violation "AGENTS.md does not link to CONSTITUTION.md — an index should point at the bedrock durable docs"
+        fi
     fi
 fi
 

--- a/tests/governance/rules/required-docs/constitution.md
+++ b/tests/governance/rules/required-docs/constitution.md
@@ -2,7 +2,7 @@
 
 - **Rule**: The repo ships the baseline set of root-level documents and local-hook scaffolding expected by governance-kit — each sub-check below is enabled by default and can be opted out of individually via `GOVERNANCE_REQUIRED_DOCS_DISABLE` (comma-separated list of sub-check keys):
     - `constitution` — `CONSTITUTION.md` at repo root, non-empty, ≥ 10 lines.
-    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`).
+    - `agents` — `AGENTS.md` at repo root, 30–250 lines (configurable via `GOVERNANCE_AGENTS_MD_MIN` / `GOVERNANCE_AGENTS_MD_MAX`), with ≥ 3 links to other repo docs (configurable via `GOVERNANCE_AGENTS_MD_MIN_LINKS`), and a link to `CONSTITUTION.md` so the file functions as a map to the bedrock durable docs rather than a standalone manual.
     - `readme` — `README.md`, `README`, or `README.rst` at repo root with a top-level heading and ≥ 30 words.
     - `license` — `LICENSE`, `LICENSE.md`, `LICENSE.txt`, `COPYING`, or `COPYING.md` exists at repo root and is non-empty.
     - `security` — `SECURITY.md` (root, `docs/`, or `.github/`) exists and lists a contact email, URL, or vulnerability-disclosure platform.


### PR DESCRIPTION
## Summary

Closes [#39](https://github.com/Duaility/governance-kit/issues/39). Folds the durable ideas from OpenAI's Harness Engineering post into the two rules that already own the relevant policy surface, instead of spawning standalone `agent-docs-map` / `plan-validation-evidence` rules and splitting ownership of one file's shape across two checks.

- **`core/required-docs` (agents sub-check)** — `AGENTS.md` must now link to `CONSTITUTION.md`. The `constitution` sub-check already mandates the doc exists; this extension makes the "map to the bedrock durable docs" contract mechanically checkable rather than aspirational. Existing bounded-length (30–250) and ≥ 3 internal links checks are preserved. New fail eval: `required-docs agents missing constitution link`.
- **`agent-governance/plan-per-issue`** — every tracked `plans/*.md` must carry a `## Validation`, `## Verification`, or `## Acceptance` section so the exit criterion is named before code is written. Introduces a new per-file waiver `governance: allow-plan-validation` (bare or HTML comment), kept deliberately separate from the existing `allow-plan-per-issue` waiver so future rewrites can drop the legacy validation waiver without touching the filename-token exemption. Two new eval cases: `missing-validation` (fail), `validation-waiver` (pass).
- **Legacy grandfathering** — 20 historical plans under `plans/` had the waiver comment prepended as an HTML comment. Historical plan content is untouched (plans are append-only records per this repo's own convention).
- **Docs** — [RULES_CATALOG.md](governance/references/RULES_CATALOG.md), [CONSTITUTION.md](CONSTITUTION.md) (rule text + evolution-log entry), and each rule's `constitution.md` snippet updated. In-repo copies under `tests/governance/rules/` re-synced with the pack.

Deferred per the issue: standalone architecture-boundary rules, `issues-tracked` quality-score grading.

## Test plan

- [x] `bash tests/governance/run.sh` — all 12 rules pass on this branch.
- [x] `bash scripts/test-packs.sh` — 2 packs, 12 rules, all evals pass (including the new fail fixtures for the strengthened checks and the legacy-waiver pass case).
- [x] Manual check: every legacy plan under `plans/` either carries a validation section already or starts with the `allow-plan-validation` waiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)