### PR TITLE
docs(readme): swap rule example to doc-freshness (#44)

### DIFF
--- a/COSTS.md
+++ b/COSTS.md
@@ -119,3 +119,5 @@ Schema:
 | claude-code-cbdb387d-7ce-1777032488 | claude-code | cbdb387d-7ce5-4d1e-811c-554144dfd305 | #42 | claude-opus-4-7 | 3 | 5970 | 313338 | 1012 | 6985 | 0.2193 | docs(readme): drop -g from quickstart install command (#42) |
 | claude-code-cbdb387d-7ce-1777032949 | claude-code | cbdb387d-7ce5-4d1e-811c-554144dfd305 | #42 | claude-opus-4-7 | 56 | 25257 | 2445714 | 20567 | 45880 | 1.8952 | docs(readme): reframe around direction-setting for frontier agents (#42) |
 | codex-019dbf52-2f5-1777033274 | codex | 019dbf52-2f52-7471-bfbe-26508d5f165a | #42 | gpt-5.5 | 136035 | 0 | 2682752 | 10209 | 146244 | 1.1639 | docs(readme): clarify direction-setting philosophy (#42) -m Tightens the governa |
+| claude-code-1e9311de-d96-1777033786 | claude-code | 1e9311de-d964-43a7-b5c3-589a068ad926 | #44 | claude-opus-4-7 | 53 | 61177 | 655272 | 9396 | 70626 | 0.9452 | docs(readme): swap example to doc-freshness (#44) |
+| claude-code-1e9311de-d96-1777033852 | claude-code | 1e9311de-d964-43a7-b5c3-589a068ad926 | #44 | claude-opus-4-7 | 7 | 12331 | 345455 | 3266 | 15604 | 0.3315 | docs(readme): swap rule example to doc-freshness (#44) |

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ $ git commit -m "stuff"
 
 ## What a rule looks like
 
-Every rule is a self-contained folder. Here's `conventional-commits` from the `core` pack:
+Every rule is a self-contained folder. Here's `doc-freshness` from the `core` pack:
 
 ```
-conventional-commits/
+doc-freshness/
 ├── rule.yaml         # category, summary, surface, hook
-├── check.sh          # the executable test (runs in commit-msg + CI)
+├── check.sh          # the executable test (runs in pre-commit + CI)
 ├── constitution.md   # Rule / Rationale / Enforced by / Exceptions
 └── evals/test.sh     # pass + fail fixtures
 ```
@@ -48,17 +48,18 @@ conventional-commits/
 The `constitution.md` carries the *why*:
 
 ```markdown
-### conventional-commits
+### doc-freshness
 
-- **Rule**: Commit messages match `<type>(scope)?!?: subject (#123)`.
-- **Rationale**: A trailing `(#123)` anchors every commit to a GitHub issue;
-  the typed prefix keeps changelogs scannable. Together they make `git log` a
-  readable audit trail instead of a stream of "fix stuff".
-- **Enforced by**: `tests/governance/rules/conventional-commits/check.sh`
-- **Exceptions**: Merge and revert commits are skipped automatically.
+- **Rule**: Docs opted into `tests/governance/freshness.conf` carry a
+  `<!-- last-verified: YYYY-MM-DD -->` marker dated within the last 90 days.
+- **Rationale**: Critical runbooks and onboarding docs decay. A periodic
+  "someone re-read this" checkpoint keeps them honest — if the deadline passes,
+  either the doc still reflects reality (bump the date) or it doesn't (fix it).
+- **Enforced by**: `tests/governance/rules/doc-freshness/check.sh`
+- **Exceptions**: Remove a doc from `freshness.conf` to opt it out entirely.
 ```
 
-When the rule changes, all four files move together — the kit enforces this.
+The rationale is the load-bearing part: an agent reading a doc with a stale marker knows not to trust it as ground truth, and an agent updating a doc knows to bump the date. A bare hook can enforce the date format; only the co-located rationale tells the next agent what the date *means*. When the rule changes, all four files move together — the kit enforces this.
 
 ## Install
 

--- a/plans/2026-04-24-issue-44-readme-rule-example-swap.md
+++ b/plans/2026-04-24-issue-44-readme-rule-example-swap.md
@@ -1,0 +1,49 @@
+<!-- last-verified: 2026-04-24 -->
+# Plan — issue-44: Swap README rule example to doc-freshness
+
+Closes [#44](https://github.com/Duaility/governance-kit/issues/44).
+
+## Goal
+
+The README's "What a rule looks like" section uses `conventional-commits`
+as its worked example. The rationale it carries ("scannable changelogs,
+audit trail") is something any plain commitlint config delivers, so a
+reader walks away thinking governance-kit is a hook runner with extra
+ceremony. That undercuts the README's own thesis — *rationale is
+alignment data; rule + test + rationale ship together* — which needs
+an example where the rationale is the load-bearing part.
+
+Swap the worked example to `doc-freshness`, where the rationale (an
+agent reading a doc with a stale marker knows not to trust it as
+ground truth) is exactly the kind of generalizable principle the
+philosophy section claims rationale unlocks.
+
+## Scope
+
+- Replace the rule-folder tree, `constitution.md` snippet, and
+  surrounding prose in the "What a rule looks like" section of
+  [README.md](../README.md).
+- Add one closing sentence tying the rationale directly to the
+  agent-steering thesis ("a bare hook can enforce the date format;
+  only the co-located rationale tells the next agent what the date
+  *means*").
+- Keep the quickstart bad-commit demo on `conventional-commits` —
+  it fires on any commit with no setup, which `doc-freshness`
+  cannot match.
+
+## Non-goals
+
+- The `core` pack catalog table — `conventional-commits` stays
+  listed there.
+- Any change to the rules themselves or their `check.sh` /
+  `constitution.md` files.
+- Re-recording or adding a demo GIF (deferred from #42).
+
+## Validation
+
+- `bash tests/governance/run.sh` passes — in particular
+  `no-broken-internal-doc-links` confirms the new
+  `tests/governance/rules/doc-freshness/check.sh` reference
+  resolves.
+- Visual pass that the rule-folder tree and the
+  `constitution.md` snippet render cleanly on GitHub.


### PR DESCRIPTION
## Summary

- Swaps the worked example in the README's "What a rule looks like" section from `conventional-commits` to `doc-freshness`.
- Adds one closing sentence tying the rationale directly to the README's agent-steering thesis.
- Quickstart bad-commit demo stays on `conventional-commits` — it fires on any commit with no setup, which `doc-freshness` cannot match.

## Why

The previous example couldn't carry the README's own pitch. Its rationale ("scannable changelogs, audit trail") is something any plain commitlint config delivers, so the section read as "governance-kit is a hook runner with extra ceremony." `doc-freshness` makes the rationale *load-bearing*: a bare hook can enforce the date format, but only the co-located rationale tells the next agent what the date *means* (whether to trust the doc as ground truth, when to bump it). That maps 1:1 onto the philosophy section's claim that rationale is what lets a rule generalize.

Closes [#44](https://github.com/Duaility/governance-kit/issues/44).

## Test plan

- [x] `bash tests/governance/run.sh` passes (ran via pre-commit hook).
- [ ] Visual pass on rendered README — rule-folder tree and `constitution.md` snippet display cleanly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)