### PR TITLE
fix(governance): rewrite eval-report.sh for verb-folder layout (#107)

### DIFF
--- a/COSTS.md
+++ b/COSTS.md
@@ -207,3 +207,4 @@ Schema:
 | claude-code-585e739b-832-1777566671 | claude-code | 585e739b-8325-4573-8e1d-6a177903eeef | #105 | claude-opus-4-7 | 5 | 15823 | 14820 | 24 | 15852 | 0.1069 | test(governance): rewrite evals for current verb surface (#105) |
 | claude-code-723f8267-3fd-1777566816 | claude-code | 723f8267-3fd0-45a4-86b9-8bbb91c0ca49 | #105 | claude-opus-4-7 | 198 | 327616 | 24445495 | 110330 | 438144 | 17.0296 | test(governance): rewrite evals for current verb surface (#105) |
 | claude-code-7355eafe-b1d-1777567250 | claude-code | 7355eafe-b1d7-4248-b6f9-ce574b7e9d6c | #105 | claude-opus-4-7 | 5 | 15790 | 14820 | 45 | 15840 | 0.1072 | test(governance): add first-class local-pack evals (#105) |
+| claude-code-6787bbce-116-1777624296 | claude-code | 6787bbce-1161-4e95-9331-35bcd688db7c | #107 | claude-opus-4-7 | 5 | 15886 | 14820 | 45 | 15936 | 0.1078 | fix(governance): rewrite eval-report.sh for verb-folder layout (#107) |

--- a/governance/evals/directive/evals.json
+++ b/governance/evals/directive/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "We had an incident yesterday (INC-4117) — someone committed a private key file (*.pem) and we had to rotate half our credentials. Add a governance directive that blocks committing *.pem, *.key, and *.p12 files. Wire it into the constitution properly.",
       "expected_output": "Following DIRECTIVE_AMEND_FLOW.md Steps 1–7: the atomic triple lands in one commit — (a) a new `.governance/packs/<owner>/<repo>/directives/<id>/` directive folder with `directive.yaml`, `check.sh`, and `constitution.md` blocking the listed extensions, (b) a new Directives subsection in `CONSTITUTION.md` citing INC-4117, (c) an Evolution Log entry dated today. Step 5b updates `.governance/packs.lock` (the local pack entry's `directives:` list gains the new id; if the local pack has no entry yet, `pack.yaml` is scaffolded and a `source: local` entry is created). The skill drafts, smoke-tests against the seeded repo, and commits in one pass without asking for approval of the draft. The summary reports the directive name, action type, intent map, smoke-test result, the commit sha+subject, and `Next: git push`.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "A new directive folder exists under `.governance/packs/<owner>/<repo>/directives/` with `directive.yaml`, `check.sh`, and `constitution.md`",
         "The directive `check.sh` blocks at least these extensions: `.pem`, `.key`, `.p12`",
@@ -25,7 +25,7 @@
       "id": 2,
       "prompt": "We want to raise our file-size-limit from 500 lines to 800 lines — the old limit is triggering too many false positives in the data-pipeline package. Modify the directive.",
       "expected_output": "Following DIRECTIVE_AMEND_FLOW.md, the existing `file-size-limit` directive's threshold is updated to 800 (in `check.sh` or via the directive's documented env-var convention). The constitution's directive subsection is updated to reflect 800. A new Evolution Log entry records the change with the data-pipeline false-positive reason. No new directive folder is created. Per Step 5b, modify is a no-op for `.governance/packs.lock` (id unchanged).",
-      "files": ["evals/files/repo-with-file-size-rule/"],
+      "files": ["files/repo-with-file-size-rule/"],
       "assertions": [
         "The existing `file-size-limit` directive folder was edited (not duplicated)",
         "The new limit value (800) appears in `check.sh` or its documented env-var default",
@@ -41,7 +41,7 @@
       "id": 3,
       "prompt": "Remove the no-console-log directive — we're keeping structured logs via pino and the rule is noisy. Do it properly.",
       "expected_output": "Following DIRECTIVE_AMEND_FLOW.md: the directive folder is removed, the Directives subsection is removed from CONSTITUTION.md, and an Evolution Log entry records the removal with the structured-logging reason. Step 5b updates `.governance/packs.lock` — the directive id is dropped from the owning local pack's `directives:` list (and if it was the last directive, the lock entry and `pack.yaml` are removed). The skill warns if any other docs or code reference the removed directive by name.",
-      "files": ["evals/files/repo-with-console-log-rule/"],
+      "files": ["files/repo-with-console-log-rule/"],
       "assertions": [
         "`.governance/packs/<owner>/<repo>/directives/no-console-log/` no longer exists",
         "The Directives section of `CONSTITUTION.md` no longer describes `no-console-log`",
@@ -56,7 +56,7 @@
       "id": 4,
       "prompt": "Can you run a governance health check and tell me if any of these rules look stale?",
       "expected_output": "The skill recognizes that this is a health-check / review request, not a targeted amendment (per DIRECTIVE_AMEND_FLOW.md Interaction policy). It does not edit files, does not stage changes, and answers directly.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "No files under `.governance/packs/<owner>/<repo>/directives/` or `CONSTITUTION.md` were modified",
         "`.governance/packs.lock` was not modified",
@@ -68,7 +68,7 @@
       "id": 5,
       "prompt": "Add a directive called plan-captured. The goal is that every substantive change ships with an updated plan in plans/*.md so reviewers can see the intent, not just the diff.",
       "expected_output": "The skill treats this as a change-set obligation (per DIRECTIVE_AMEND_FLOW.md Step 2's intent map), not a repo-state existence check. It creates a directive whose `check.sh` inspects the staged diff locally and the branch diff in CI so a substantive change without a companion `plans/*.md` update fails mechanically. The constitution entry says the directive blocks substantive changes landing without an updated plan, and the summary explicitly names the bad merge, policy surface, and enforcement surface. Step 5b adds the directive id to the local pack's `.governance/packs.lock` entry.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "The summary explicitly classifies the directive as a change-set obligation (or equivalent wording)",
         "The new directive's `check.sh` inspects changed files (e.g. via `git diff --cached`, `git diff origin/main...HEAD`, or branch-diff fallback) rather than only checking whether `plans/*.md` exists",
@@ -82,7 +82,7 @@
       "id": 7,
       "prompt": "Add a directive called cors-allowed-origins into our frontend pack — every CORS config in the codebase must read its origins from the ALLOWED_ORIGINS env var, never hardcoded.",
       "expected_output": "Following DIRECTIVE_AMEND_FLOW.md with `--pack acme/frontend` (or the equivalent inferred routing once the user names a non-default pack): the directive is created at `.governance/packs/acme/frontend/directives/cors-allowed-origins/`, NOT at the default `.governance/packs/acme/seeded-repo/directives/cors-allowed-origins/`. Step 5b is the canonical 'add into a `source: local` pack that has no lockfile entry yet' case — `acme/frontend/pack.yaml` already exists (from a prior `pack create frontend`), so the skill skips re-scaffolding `pack.yaml` and proceeds straight to `lock-add` to create the first `acme/frontend` lockfile entry with the new directive id. The atomic triple lands in one commit alongside the lockfile mutation.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "The new directive folder lives at `.governance/packs/acme/frontend/directives/cors-allowed-origins/` with `directive.yaml`, `check.sh`, and `constitution.md`",
         "No directive folder was created at `.governance/packs/acme/seeded-repo/directives/cors-allowed-origins/` (the default local pack is NOT used)",
@@ -99,7 +99,7 @@
       "id": 6,
       "prompt": "Modify the secrets-hygiene directive — I want to also block AWS access keys (AKIA*).",
       "expected_output": "The skill detects via `.governance/packs.lock` that `secrets-hygiene` is owned by `governance-kit/core` (`source: builtin`) and refuses the modify per DIRECTIVE_AMEND_FLOW.md's upstream-pinned table. It does NOT edit the directive locally; it routes the user to the correct verb — for a `builtin` directive, that is to either fork the directive into a local override (and remove the original via `directive remove` to opt out) or update the kit. No files are mutated.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "No files were modified — the directive folder, `CONSTITUTION.md`, and `.governance/packs.lock` are byte-identical to the fixture",
         "The skill explicitly stated that `secrets-hygiene` is owned by an upstream pack (lockfile `source: builtin`) and cannot be modified locally",

--- a/governance/evals/init/evals.json
+++ b/governance/evals/init/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "We're starting a new Python + TypeScript monorepo and I want to lock in some non-negotiables before the team grows. Run governance init for this repo and pick a sensible default set of rules — I'll tell you what to drop.",
       "expected_output": "Following INIT_FLOW.md Steps 1–8: a `.governance/` directory with a runner and per-pack directive folders under `.governance/packs/<owner>/<name>/directives/`, tracked hooks installed via `.githooks/` (or an explicitly preserved existing hook framework when one exists), a CONSTITUTION.md seeded from the template, a GitHub Actions workflow at `.github/workflows/governance.yml`, the install state pair (`.governance/install.yaml` v3 + `.governance/packs.lock` v2), an AGENTS.md directive block bounded by the paired markers, and a short report listing pack(s), preset, hook strategy, directives installed, directives skipped, hook collisions, and assumptions. The skill should have surfaced a preset choice before acting — it should not have silently chosen the directive set.",
-      "files": ["evals/files/empty-polyglot-repo/"],
+      "files": ["files/empty-polyglot-repo/"],
       "assertions": [
         "The skill detected both Python and TypeScript/JS before proposing directives (visible in its summary or in which directives it enabled)",
         "The skill surfaced a preset choice (minimal/standard/strict/custom) or clearly stated the assumed preset before installing directives",
@@ -27,7 +27,7 @@
       "id": 2,
       "prompt": "Run governance init here — but this repo already has a .governance/ directory from a previous run. Don't clobber anything I've customized.",
       "expected_output": "The skill detects the existing governance setup at Step 1, classifies the situation per INIT_FLOW.md's Interaction policy, and either continues in augment mode (filling missing pieces only) or stops to ask. It does not silently overwrite `lib.sh`, the runner, the install pair, or any existing directive folders.",
-      "files": ["evals/files/already-bootstrapped-repo/"],
+      "files": ["files/already-bootstrapped-repo/"],
       "assertions": [
         "The skill did NOT overwrite the pre-existing `.governance/run.sh`",
         "The skill did NOT overwrite the pre-existing directive folders under `.governance/packs/<owner>/<name>/directives/`",
@@ -40,7 +40,7 @@
       "id": 3,
       "prompt": "Run governance init for this repo. It's a Go service — keep the rule set tight, no stylistic stuff, and make sure security rules are included.",
       "expected_output": "The Security category directives from `governance-kit/core` (e.g. `secrets-hygiene`, `workflows-hardened`) are enabled. Go-relevant directives are chosen over Python/JS-specific ones. Stylistic directives are NOT enabled. The skill's summary explains which categories were included and which were deliberately dropped.",
-      "files": ["evals/files/go-service-repo/"],
+      "files": ["files/go-service-repo/"],
       "assertions": [
         "A directive folder for a secrets / key-material check exists under `.governance/packs/governance-kit/core/directives/` (e.g. `secrets-hygiene/check.sh`)",
         "A workflow-hardening directive exists under `.governance/packs/governance-kit/core/directives/` or was explicitly skipped with a reason",
@@ -54,7 +54,7 @@
       "id": 4,
       "prompt": "This repo already has governance. Can you review whether the constitution is missing anything obvious? Do not rewrite or reinstall anything.",
       "expected_output": "The skill does not run `init`. It recognizes that the request is for review rather than installation, leaves files untouched, and either answers directly or points the user to `governance directive *` for targeted changes (per INIT_FLOW.md Interaction policy).",
-      "files": ["evals/files/already-bootstrapped-repo/"],
+      "files": ["files/already-bootstrapped-repo/"],
       "assertions": [
         "No governance files were rewritten",
         "The skill explicitly recognized this as a review/explanation request rather than an installation request",
@@ -67,7 +67,7 @@
       "id": 5,
       "prompt": "Run governance init here and include a custom rule that says every substantive change must update a plan under plans/*.md so the reason for the change is preserved.",
       "expected_output": "The skill identifies this custom directive as a change-set obligation (per INIT_FLOW.md Step 3's policy-surface table) and implements it accordingly instead of falling back to a repo-level existence check. The directive is added to the repo's auto-created hand-authored pack at `.governance/packs/<owner>/<repo>/directives/<id>/`. The resulting constitution and directive folder describe the blocked bad merge in per-change terms, and the summary makes the chosen enforcement surface explicit.",
-      "files": ["evals/files/empty-polyglot-repo/"],
+      "files": ["files/empty-polyglot-repo/"],
       "assertions": [
         "The summary explicitly classifies the custom directive as a change-set obligation (or equivalent wording)",
         "The custom directive's `check.sh` inspects the staged diff or branch diff (e.g. `git diff --cached`, `git diff origin/main...HEAD`) rather than only checking whether `plans/*.md` exists",

--- a/governance/evals/pack/evals.json
+++ b/governance/evals/pack/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "Search the community pack catalog for SOC2 directives.",
       "expected_output": "Following PACK_VERBS.md `pack search [query]`: the skill reads `governance/assets/catalog.community.json` (in the kit checkout), runs `packverb catalog-search <catalog> soc2`, and renders the matched entries (`<id>\\t<ref>\\t<summary>`) as a readable table. No files are modified in the consumer repo.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "The skill read the kit's catalog at `governance/assets/catalog.community.json`",
         "The skill called `packverb catalog-search` (or equivalent helper) with the user's `soc2` query",
@@ -18,7 +18,7 @@
       "id": 2,
       "prompt": "Create a new repo-local pack called frontend for our team's frontend-specific directives.",
       "expected_output": "Following PACK_VERBS.md `pack create <name>`: the skill reads `owner:` from `.governance/install.yaml`, validates `frontend` is slug-safe, and scaffolds a hand-authored pack at `.governance/packs/<owner>/frontend/`. The new `pack.yaml` has NO `source:` field (the marker that distinguishes a repo-local pack from an installed one). No `directive add` is performed yet, no lockfile mutation, no hook regeneration — the pack is empty and the skill points the user at `governance directive add --pack <owner>/frontend <id>` as the next step.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "The skill read `owner:` from `.governance/install.yaml` (it should be `acme` for this fixture)",
         "`.governance/packs/acme/frontend/pack.yaml` was created",
@@ -34,7 +34,7 @@
       "id": 3,
       "prompt": "Install the pack at gh:acme/soc2-pack@main into this repo.",
       "expected_output": "Following PACK_VERBS.md `pack add <ref>` Steps 1–9: the skill parses the ref, refuses if not in a git repo or if `.governance/` is missing, fetches the pack into the shared cache (warning that `@main` is resolved to a concrete SHA), validates the manifest, capability-checks every directive, prints diff-before-exec for each directive, asks for confirmation, installs the directive folders into `.governance/packs/acme/soc2-pack/directives/`, regenerates the hook dispatcher, and writes the lockfile entry with `source: gh`, the resolved `sha`, the original `ref`, and the directive list. The report names the pinned SHA, directive ids installed, and updated hook scripts.",
-      "files": ["evals/files/seeded-repo/"],
+      "files": ["files/seeded-repo/"],
       "assertions": [
         "The skill parsed `gh:acme/soc2-pack@main` and warned that the pinned SHA (not the branch) is what gets recorded",
         "The skill called `packverb fetch` to populate the shared cache at `${GOVERNANCE_KIT_HOME:-$HOME/.governance/cache}/packs/acme__soc2-pack@<sha>/`",
@@ -51,7 +51,7 @@
       "id": 4,
       "prompt": "Update all installed packs.",
       "expected_output": "Following PACK_VERBS.md `pack update [<pack-id>]` with no argument: the skill reads the lockfile, re-fetches each `source: gh` entry using its original `ref` string, compares the new resolved SHA to the locked SHA, skips entries whose SHA hasn't drifted, and for drifted entries runs validation + capability-check + diff-before-exec before overwriting the directive folders. `governance-kit/core` (`source: builtin`) and any `source: local` packs are silently skipped. The lockfile is upserted with the new SHAs.",
-      "files": ["evals/files/repo-with-installed-pack/"],
+      "files": ["files/repo-with-installed-pack/"],
       "assertions": [
         "The skill re-fetched the `acme/widgets` pack using its original ref string (which carries the floating `@main`)",
         "If the resolved SHA matched the locked SHA, the skill skipped the entry and reported it as already up-to-date",
@@ -66,7 +66,7 @@
       "id": 5,
       "prompt": "Remove the acme/widgets pack from this repo.",
       "expected_output": "Following PACK_VERBS.md `pack remove <pack-id>`: the skill reads the lockfile, confirms `acme/widgets` is present and is NOT `source: builtin` (refuses on `governance-kit/core`), lists the directives the lockfile attributes to the pack, asks for confirmation, deletes each directive folder, removes their CONSTITUTION.md subsections, removes the pack's `pack.yaml` + the now-empty pack directory, regenerates the hook dispatcher, removes the lockfile entry, and prunes any seeded `install_assets_seeded` paths from `.governance/install.yaml`.",
-      "files": ["evals/files/repo-with-installed-pack/"],
+      "files": ["files/repo-with-installed-pack/"],
       "assertions": [
         "The skill read `.governance/packs.lock` and confirmed `acme/widgets` is `source: gh` (not `builtin`)",
         "The skill listed the directives attributed to `acme/widgets` and asked for explicit confirmation",
@@ -83,7 +83,7 @@
       "id": 6,
       "prompt": "List all installed packs.",
       "expected_output": "Following PACK_VERBS.md `pack list`: the skill calls `packverb lock-list .governance/packs.lock --long` and renders every pack — `governance-kit/core` (`builtin`), community packs (`gh`), and repo-local packs (`local`) — in a single table with columns for id, source, version, sha (when applicable), and ref (when applicable). No mutations.",
-      "files": ["evals/files/repo-with-installed-pack/"],
+      "files": ["files/repo-with-installed-pack/"],
       "assertions": [
         "The skill called `packverb lock-list` (or equivalent) on `.governance/packs.lock`",
         "The output includes `governance-kit/core` with `source: builtin` and no `sha` column value (or an explicit `—`)",
@@ -97,7 +97,7 @@
       "id": 7,
       "prompt": "Remove the local pack acme/repo-with-installed-pack — we're consolidating those rules into governance-kit/core upstream.",
       "expected_output": "Following PACK_VERBS.md `pack remove <pack-id>` against a `source: local` pack: the skill confirms the lockfile entry is `source: local` (not `builtin`), lists the directives the lockfile attributes to it (`team-policy`, `naming-convention`), asks for explicit confirmation, deletes both directive folders, removes both CONSTITUTION subsections, deletes `pack.yaml` and the now-empty pack directory, regenerates the hook dispatcher, and `lock-remove`s the entry. Repo-local packs are first-class — the same flow that handles `gh` packs handles `local` packs, with the only difference being there is no upstream cache to retain.",
-      "files": ["evals/files/repo-with-installed-pack/"],
+      "files": ["files/repo-with-installed-pack/"],
       "assertions": [
         "The skill confirmed `acme/repo-with-installed-pack` has `source: local` in `.governance/packs.lock` (not `builtin`)",
         "The skill listed BOTH directives (`team-policy` and `naming-convention`) attributed to the pack and asked for explicit confirmation",
@@ -114,7 +114,7 @@
       "id": 8,
       "prompt": "Create a new local pack called widgets for our team's widget directives.",
       "expected_output": "Following PACK_VERBS.md `pack create <name>`'s pre-flight: the skill reads `owner:` from `.governance/install.yaml` (`acme`), computes the target path `.governance/packs/acme/widgets/`, sees the directory already exists (the fixture's `acme/widgets` `gh` pack lives there), and refuses with a clear error before writing anything. The skill names the collision and tells the user the existing pack is `source: gh` (community-installed via `pack add`), so picking a different name is the right path; overwriting it would silently destroy a pinned community install.",
-      "files": ["evals/files/repo-with-installed-pack/"],
+      "files": ["files/repo-with-installed-pack/"],
       "assertions": [
         "No files were created, deleted, or modified — `.governance/packs/acme/widgets/` is byte-identical to the fixture",
         "The skill explicitly refused to scaffold the pack and named the reason: `.governance/packs/acme/widgets/` already exists",

--- a/governance/evals/reset/evals.json
+++ b/governance/evals/reset/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "Reset the secrets-hygiene directive — somebody locally edited it and now it's failing weird. Put it back to whatever was pinned.",
       "expected_output": "Following RESET_FLOW.md Steps 1–7: the skill reads `.governance/packs.lock`, confirms `secrets-hygiene` is owned by `governance-kit/core` (`source: builtin`), resolves the pristine source from the kit-bundled tree, computes the byte-diff vs the installed copy, prints the diff (diff-before-exec), asks for explicit `yes`, replaces the directive folder, restores its CONSTITUTION subsection, regenerates the hook dispatcher, smoke-tests, and commits one atomic commit with subject `chore(governance): reset secrets-hygiene to governance-kit/core@<short-sha>`. Hand-authored directives (the `acme/drifted-repo` pack's `team-policy`) are preserved by default. Working tree is unstaged otherwise.",
-      "files": ["evals/files/drifted-repo/"],
+      "files": ["files/drifted-repo/"],
       "assertions": [
         "The skill read `.governance/packs.lock` and identified `secrets-hygiene` as owned by `governance-kit/core` (`source: builtin`)",
         "The skill printed the per-directive diff between the installed `secrets-hygiene/check.sh` and the pristine source before any file was written",
@@ -23,7 +23,7 @@
       "id": 2,
       "prompt": "Reset every directive that came from the acme/widgets pack — we want them at exactly the SHA we pinned.",
       "expected_output": "Following RESET_FLOW.md with `--pack acme/widgets`: the skill resolves the pinned SHA from `.governance/packs.lock`, ensures the cache entry exists at `${GOVERNANCE_KIT_HOME:-~/.governance/cache}/packs/acme__widgets@<sha>/` (re-fetches if missing), restores every directive in `lock.packs[acme/widgets].directives`, regenerates hooks, commits with subject `chore(governance): reset pack acme/widgets to pinned <short-sha>`. `secrets-hygiene` (owned by `governance-kit/core`) and `team-policy` (hand-authored in `acme/drifted-repo`) are NOT touched.",
-      "files": ["evals/files/drifted-repo/"],
+      "files": ["files/drifted-repo/"],
       "assertions": [
         "The skill resolved the cache directory at `${GOVERNANCE_KIT_HOME:-$HOME/.governance/cache}/packs/acme__widgets@<sha>/` (with `/` encoded as `__`) and re-fetched via `packverb fetch` if the cache was missing",
         "Every directive in `acme/widgets`'s lockfile entry had its installed folder overwritten with the pristine source",
@@ -37,7 +37,7 @@
       "id": 3,
       "prompt": "Reset every directive — but show me the plan first, don't commit.",
       "expected_output": "Following RESET_FLOW.md with `--all --dry-run`: the skill computes the plan for every pack-sourced directive, prints the per-directive diffs and the would-commit subject, but performs no writes and creates no commit. `--drop-handauthored` was NOT requested, so hand-authored directives are listed under Preserved.",
-      "files": ["evals/files/drifted-repo/"],
+      "files": ["files/drifted-repo/"],
       "assertions": [
         "No files were modified — every directive folder, `CONSTITUTION.md`, the lockfile, and `.governance/freshness.conf` are byte-identical to the fixture",
         "No commit was created",
@@ -51,7 +51,7 @@
       "id": 4,
       "prompt": "Reset all the directives. The packs.lock file is missing because somebody deleted it.",
       "expected_output": "Following RESET_FLOW.md's Interaction policy: with `.governance/packs.lock` missing, the skill refuses to run and tells the user reset is lockfile-driven (no safe heuristic for pack provenance). It directs the user to the recovery path: `governance uninstall` + `governance init`. No files are mutated.",
-      "files": ["evals/files/lockfile-missing/"],
+      "files": ["files/lockfile-missing/"],
       "assertions": [
         "No files were created, deleted, or modified",
         "The skill explicitly refused to run because `.governance/packs.lock` is missing",
@@ -63,7 +63,7 @@
       "id": 5,
       "prompt": "Reset everything to pinned, and drop the hand-authored directives too — we want a clean slate.",
       "expected_output": "Following RESET_FLOW.md with `--all --drop-handauthored`: the skill restores every pack-sourced directive (`governance-kit/core` + `acme/widgets`) AND deletes every directive owned by `source: local` packs (including the `team-policy` directive in `acme/drifted-repo`). The local pack's `pack.yaml` is removed if it has no surviving directives, and its lockfile entry is removed too. The commit subject is `chore(governance): reset all directives + drop hand-authored`.",
-      "files": ["evals/files/drifted-repo/"],
+      "files": ["files/drifted-repo/"],
       "assertions": [
         "Every pack-sourced directive folder under `governance-kit/core` and `acme/widgets` was restored to its pinned source",
         "The hand-authored `team-policy` directive folder in `acme/drifted-repo` was deleted",

--- a/governance/evals/uninstall/evals.json
+++ b/governance/evals/uninstall/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "We installed governance-kit into this repo months ago and the preset was wrong. I want a clean slate before re-running governance init. Run governance uninstall — remove every governance artifact this repo has, including the seeded QUALITY.md and COSTS.md (we haven't put real content in them yet). Don't touch anything else.",
       "expected_output": "Following UNINSTALL_FLOW.md Steps 1–6: the skill surveys the repo, reads the install state pair (`.governance/install.yaml` v3 + `.governance/packs.lock` v2), classifies the state as `fully-installed`, asks the user for a mode (dry-run / soft / hard) via AskUserQuestion, and — given the user's 'include seeded docs' direction — proceeds in `hard` mode after explicit confirmation. It deletes every kit-owned artifact (constitution, .governance tree, CI workflow, managed hooks, install.yaml, packs.lock, AGENTS.md directive block, seeded docs). It unsets `core.hooksPath` only if it still points at `.githooks`. It leaves changes unstaged. The summary names mode, classification, source-of-truth, files deleted, files preserved, AGENTS.md outcome, git config outcome, assumptions, and `Next command: git status`.",
-      "files": ["evals/files/bootstrapped-repo/"],
+      "files": ["files/bootstrapped-repo/"],
       "assertions": [
         "The skill read `.governance/install.yaml` AND `.governance/packs.lock` and reported `Source of truth: manifest` (or equivalent)",
         "The skill asked the user to choose a mode (dry-run / soft / hard) before executing",
@@ -25,7 +25,8 @@
       "id": 2,
       "prompt": "This repo has no governance setup. Run governance uninstall.",
       "expected_output": "Following UNINSTALL_FLOW.md Step 2's `none-detected` classification: the skill surveys the repo, finds no manifest, no managed hooks, no `CONSTITUTION.md`, no `.governance/` — classifies as `none-detected` — and reports 'nothing to remove' without asking for a mode. No files are modified. Idempotency contract: running uninstall on a clean repo is a success, not an error.",
-      "files": ["evals/files/clean-repo/"],
+      "files": ["files/clean-repo/"],
+      "fixture_empty_by_design": true,
       "assertions": [
         "No files were created, deleted, or modified in the fixture",
         "The skill classified the repo as `none-detected` (or equivalent wording)",
@@ -37,7 +38,7 @@
       "id": 3,
       "prompt": "Run governance uninstall. But only show me the plan — don't delete anything yet.",
       "expected_output": "Following UNINSTALL_FLOW.md Step 3: the skill runs the full survey and builds the execute plan, then honors the user's explicit dry-run request by printing the plan without executing. The working tree is byte-identical before and after. The summary is prefixed with 'would-' verbs so it is unambiguous that nothing happened.",
-      "files": ["evals/files/bootstrapped-repo/"],
+      "files": ["files/bootstrapped-repo/"],
       "assertions": [
         "No files were deleted or modified in the fixture",
         "The skill explicitly chose `dry-run` mode (the user's request made the default obvious; no AskUserQuestion needed)",
@@ -50,7 +51,7 @@
       "id": 4,
       "prompt": "I want to remove governance from this repo but soft-mode only — keep my QUALITY.md and COSTS.md, those are real docs now.",
       "expected_output": "Following UNINSTALL_FLOW.md Step 5: the skill executes in `soft` mode after confirmation. Pack-seeded docs (`QUALITY.md`, `COSTS.md`) are preserved and reported as orphaned. Every other kit-owned artifact is deleted. The summary makes the soft-vs-hard distinction explicit so the user understands which files were intentionally kept.",
-      "files": ["evals/files/bootstrapped-repo/"],
+      "files": ["files/bootstrapped-repo/"],
       "assertions": [
         "`QUALITY.md` and `COSTS.md` still exist after uninstall (preserved per soft-mode contract)",
         "`CONSTITUTION.md`, `.governance/`, `.github/workflows/governance.yml`, and the marked `.githooks/*` files were deleted",

--- a/receipts/issue-107-eval-report-verb-folder-layout.md
+++ b/receipts/issue-107-eval-report-verb-folder-layout.md
@@ -1,0 +1,30 @@
+# issue-107 — rewrite `eval-report.sh` for verb-folder layout
+
+Closes [#107](https://github.com/Duaility/governance-kit/issues/107).
+
+## Checklist
+
+- [x] Rewrite `scripts/eval-report.sh` to walk `governance/evals/<verb>/`
+- [x] Strip stale `evals/` prefix from every `files` entry across the five `evals.json`
+- [x] Add `fixture_empty_by_design` opt-in flag for intentionally-empty fixtures
+- [x] Verify report exits 0 with all five verbs ready
+
+## What changed
+
+- **Rewrite `scripts/eval-report.sh` to walk `governance/evals/<verb>/`.** The old script hardcoded `SKILLS=(governance-bootstrap governance-amend)` — two skills that haven't existed in this repo since the unified-skill collapse. It exited non-zero with both rows marked `missing`. The rewrite drops the hardcoded list, auto-discovers verbs by globbing `governance/evals/*/evals.json`, and emits one row per verb against a single `governance` skill. Header reads "Governance skill evals report" and the markdown table is keyed by verb (not skill). JSON output renamed `skills` → `verbs` for the same reason. A "total" row is added so the per-verb counts roll up to a single number (29 cases / 203 assertions today).
+- **Strip stale `evals/` prefix from every `files` entry across the five `evals.json`.** The path convention `"evals/files/<fixture>/"` was a leftover from the pre-collapse layout where each skill had its own top-level dir (e.g. `governance-bootstrap/evals/files/foo/`). After the collapse, the fixture lives at `governance/evals/<verb>/files/<fixture>/`, so the leading `evals/` segment resolves to a directory that doesn't exist. Stripped `"evals/files/` → `"files/` across all 29 fixture references in `governance/evals/{init,uninstall,reset,pack,directive}/evals.json`. Path is now relative to the verb's `evals.json` directory, which matches what the rewritten script joins on.
+- **Add `fixture_empty_by_design` opt-in flag for intentionally-empty fixtures.** `governance/evals/uninstall/files/clean-repo/` ships with only a README on purpose — the eval verifies `governance uninstall` is a no-op on a repo with zero kit footprint, so an empty tree IS the test. The naïve "directory contains only README.md → placeholder" rule false-positived on it. Added an opt-in `"fixture_empty_by_design": true` field at the eval-case level (set on `uninstall` case 2) and taught the script to exempt those cases from the placeholder check. Other cases still fail loudly if their fixtures haven't been seeded.
+- **Verify report exits 0 with all five verbs ready.** `bash scripts/eval-report.sh` now emits a clean report: directive (7 / 50), init (5 / 36), pack (8 / 58), reset (5 / 33), uninstall (4 / 26) — all `ready`, zero missing, zero placeholder, total 29 / 203, exit 0. `bash .governance/run.sh` continues to pass 14/14 directives.
+
+## Out of scope
+
+- **Executing the evals.** Evals are LLM-graded behavioral checks; running them means spinning up a Claude Code session per case against a seeded fixture. `eval-report.sh` only reports *readiness*, not pass/fail. An execution harness is a separate piece of work.
+- **Schema / validation for `evals.json`.** No formal schema lives in-tree today. The rewrite only loosens the placeholder rule with one new optional field; codifying the full shape can wait until there are more consumers.
+- **Updating the historical `plans/` docs that reference the old `SKILLS=` list.** Those plans describe past PRs and are accurate for the state at the time. Rewriting them would be revisionist; the live source of truth is the script itself.
+
+## Verification
+
+- `bash scripts/eval-report.sh` → exits 0 with all five verbs (`directive`, `init`, `pack`, `reset`, `uninstall`) reporting `ready`, totals 29 cases / 203 assertions, no missing or placeholder fixtures.
+- `for f in governance/evals/*/evals.json; do jq -e . "$f"; done` → all five files parse as valid JSON after the prefix strip and the `fixture_empty_by_design` insertion.
+- `bash .governance/run.sh` → 14/14 dogfood directives green; the script rewrite + JSON edits don't break any constitutional check.
+- Spot-checked the path resolution: `governance/evals/uninstall/files/clean-repo/` matches the (now-stripped) `"files/clean-repo/"` reference, and the empty-by-design exemption lets that fixture pass without seeding it.

--- a/scripts/eval-report.sh
+++ b/scripts/eval-report.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Produces a coverage/readiness report for the skill evals in this repo.
+# Produces a coverage/readiness report for the governance skill's evals.
 #
-# Evals are behavioral (prompt + expected_output + assertions) and are graded by
-# an LLM, so this script does not execute them. It inspects each skill's
-# evals/evals.json and reports: case counts, assertion counts, and whether the
-# referenced fixture directories exist and contain more than a placeholder.
+# Evals are behavioral (prompt + expected_output + assertions) and are graded
+# by an LLM, so this script does not execute them. It walks the verb folders
+# under governance/evals/<verb>/evals.json and reports per-verb case counts,
+# assertion counts, and whether the referenced fixture directories exist and
+# contain more than a placeholder README.
+#
+# An eval case may declare `"fixture_empty_by_design": true` to mark a fixture
+# whose emptiness is itself the test (e.g. uninstall on a repo with no
+# governance footprint). Such fixtures are not flagged as placeholders.
 #
 # Usage:
 #   bash scripts/eval-report.sh              # markdown report to stdout
@@ -14,7 +19,8 @@
 set -u
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILLS=(governance-bootstrap governance-amend)
+SKILL_DIR="$ROOT/governance"
+EVALS_ROOT="$SKILL_DIR/evals"
 
 OUT=""
 FORMAT="md"
@@ -22,7 +28,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --out) OUT="$2"; shift 2 ;;
         --json) FORMAT="json"; shift ;;
-        -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+        -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
@@ -32,7 +38,24 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-# Collect results into parallel arrays (bash 3.2 compatible).
+if [[ ! -d "$EVALS_ROOT" ]]; then
+    echo "error: $EVALS_ROOT not found" >&2
+    exit 2
+fi
+
+# Discover verbs by globbing evals.json files.
+verbs=()
+while IFS= read -r spec; do
+    verb="$(basename "$(dirname "$spec")")"
+    verbs+=("$verb")
+done < <(find "$EVALS_ROOT" -mindepth 2 -maxdepth 2 -name evals.json | sort)
+
+if [[ ${#verbs[@]} -eq 0 ]]; then
+    echo "error: no verb evals.json files under $EVALS_ROOT" >&2
+    exit 2
+fi
+
+# Parallel arrays (bash 3.2 compatible).
 names=()
 statuses=()
 case_counts=()
@@ -43,20 +66,9 @@ issues=()
 
 overall_ready=1
 
-for skill in "${SKILLS[@]}"; do
-    spec="$ROOT/$skill/evals/evals.json"
-    names+=("$skill")
-
-    if [[ ! -f "$spec" ]]; then
-        statuses+=("missing")
-        case_counts+=(0)
-        assertion_counts+=(0)
-        fixture_missing+=(0)
-        fixture_placeholder+=(0)
-        issues+=("no evals/evals.json")
-        overall_ready=0
-        continue
-    fi
+for verb in "${verbs[@]}"; do
+    spec="$EVALS_ROOT/$verb/evals.json"
+    names+=("$verb")
 
     if ! jq -e . "$spec" >/dev/null 2>&1; then
         statuses+=("invalid-json")
@@ -74,22 +86,21 @@ for skill in "${SKILLS[@]}"; do
 
     miss=0
     place=0
-    skill_issues=""
-    while IFS= read -r rel; do
+    verb_issues=""
+    while IFS=$'\t' read -r rel empty_flag; do
         [[ -z "$rel" ]] && continue
-        path="$ROOT/$skill/$rel"
+        path="$EVALS_ROOT/$verb/$rel"
         if [[ ! -e "$path" ]]; then
             miss=$((miss + 1))
-            skill_issues+="missing fixture: $rel; "
+            verb_issues+="missing fixture: $rel; "
         elif [[ -d "$path" ]]; then
-            # Placeholder = directory contains only a README.md (no seeded repo).
             entries=$(find "$path" -mindepth 1 -maxdepth 1 ! -name README.md | head -n 1)
-            if [[ -z "$entries" ]]; then
+            if [[ -z "$entries" && "$empty_flag" != "true" ]]; then
                 place=$((place + 1))
-                skill_issues+="fixture is placeholder only: $rel; "
+                verb_issues+="fixture is placeholder only: $rel; "
             fi
         fi
-    done < <(jq -r '.evals[].files[]?' "$spec")
+    done < <(jq -r '.evals[] | (.fixture_empty_by_design // false) as $e | (.files // []) | .[] | [., ($e|tostring)] | @tsv' "$spec")
 
     fixture_missing+=("$miss")
     fixture_placeholder+=("$place")
@@ -102,42 +113,50 @@ for skill in "${SKILLS[@]}"; do
     else
         statuses+=("ready")
     fi
-    issues+=("${skill_issues%% ; }")
+    issues+=("${verb_issues%% ; }")
 done
 
 emit_md() {
-    printf '# Skill evals report\n\n'
+    printf '# Governance skill evals report\n\n'
     printf '_Generated %s_\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    printf '| Skill | Status | Cases | Assertions | Missing fixtures | Placeholder fixtures |\n'
+    printf 'Skill: `governance` (single skill, one verb-folder per row).\n\n'
+    printf '| Verb | Status | Cases | Assertions | Missing fixtures | Placeholder fixtures |\n'
     printf '|---|---|---:|---:|---:|---:|\n'
+    local total_cases=0 total_assert=0
     for i in "${!names[@]}"; do
         printf '| %s | %s | %s | %s | %s | %s |\n' \
             "${names[$i]}" "${statuses[$i]}" "${case_counts[$i]}" \
             "${assertion_counts[$i]}" "${fixture_missing[$i]}" "${fixture_placeholder[$i]}"
+        total_cases=$((total_cases + ${case_counts[$i]}))
+        total_assert=$((total_assert + ${assertion_counts[$i]}))
     done
+    printf '| **total** | — | **%d** | **%d** | — | — |\n' "$total_cases" "$total_assert"
     printf '\n## Notes\n\n'
+    local any_notes=0
     for i in "${!names[@]}"; do
         if [[ -n "${issues[$i]}" ]]; then
             printf -- '- **%s**: %s\n' "${names[$i]}" "${issues[$i]}"
+            any_notes=1
         fi
     done
+    [[ $any_notes -eq 0 ]] && printf '_No issues._\n'
     printf '\n## How to run the evals\n\n'
     printf 'Evals are LLM-graded behavioral checks, not unit tests. For each case in '
-    printf 'a skill'\''s `evals.json`:\n\n'
-    printf '1. Copy the fixture under `<skill>/evals/files/<fixture>/` into a fresh temp dir and `git init` it.\n'
-    printf '2. Start a Claude Code session scoped to that dir with the skill installed.\n'
+    printf 'a verb'\''s `evals.json`:\n\n'
+    printf '1. Copy the fixture under `governance/evals/<verb>/files/<fixture>/` into a fresh temp dir and `git init` it.\n'
+    printf '2. Start a Claude Code session scoped to that dir with the `governance` skill installed.\n'
     printf '3. Paste the `prompt` field verbatim.\n'
     printf '4. Compare the resulting state against `expected_output` and each item in `assertions`.\n\n'
     if [[ $overall_ready -eq 1 ]]; then
-        printf '**All skills have complete eval specs and fixtures.**\n'
+        printf '**All verbs have complete eval specs and fixtures.**\n'
     else
-        printf '**Some skills are not eval-ready** — see the Notes section.\n'
+        printf '**Some verbs are not eval-ready** — see the Notes section.\n'
     fi
 }
 
 emit_json() {
     local first=1
-    printf '{"generated_at":"%s","skills":[' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '{"generated_at":"%s","skill":"governance","verbs":[' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     for i in "${!names[@]}"; do
         [[ $first -eq 0 ]] && printf ','
         first=0


### PR DESCRIPTION
Closes #107.

## Summary

- Rewrite `scripts/eval-report.sh` to walk the current `governance/evals/<verb>/` layout instead of the hardcoded pre-collapse `SKILLS=(governance-bootstrap governance-amend)` list. Auto-discovers verbs by globbing `evals.json` files; emits one row per verb with a totals row.
- Strip the dead `evals/` segment from every `files` entry across all five `evals.json` files (29 paths). Paths now resolve relative to each verb's `evals.json` directory, matching what the script joins on.
- Add an opt-in `fixture_empty_by_design: true` flag at the eval-case level so `uninstall/clean-repo` (intentionally empty — the eval verifies uninstall is a no-op on a repo with zero kit footprint) is not flagged as a placeholder fixture.

`bash scripts/eval-report.sh` now exits 0 with all five verbs `ready` (29 cases / 203 assertions). `bash .governance/run.sh` — 14/14 directives green.

## Test plan

- [x] `bash scripts/eval-report.sh` → exit 0, all five verbs ready, totals 29 / 203, no missing or placeholder fixtures
- [x] `for f in governance/evals/*/evals.json; do jq -e . "$f"; done` → all five parse as valid JSON
- [x] `bash .governance/run.sh` → 14/14 dogfood directives pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)