### PR TITLE
fix(governance): sum agent-steering-accounting trailers across squash sub-commits (#136)

### DIFF
--- a/packs/core/directives/agent-steering-accounting/evals/test.sh
+++ b/packs/core/directives/agent-steering-accounting/evals/test.sh
@@ -269,4 +269,61 @@ reset_ledger
 git commit --allow-empty --quiet --no-verify -F /tmp/msg-mode-b-fail
 EVAL_LABEL="$EVAL_ID mode-b-on-main-missing-triple" expect_fail "$CHECK"
 
+# ──────────────────────────────────────────────────────────────
+# Case 16 — pass: squash-merge body with two stacked trailer triples.
+# GitHub squash-merge concatenates each sub-commit's body into the
+# resulting commit message, so the summary triple appears N times. The
+# parser must sum across occurrences so the trailer total agrees with the
+# cumulative STEERING.md diff. Issue #136.
+# ──────────────────────────────────────────────────────────────
+reset_ledger
+KEY_S1="steer-${SS}-1800001000-1"
+KEY_S2="steer-${SS}-1800001100-1"
+append_row "$KEY_S1" "interrupt" "" "feat: squashed pair"
+append_row "$KEY_S2" "correction" "" "feat: squashed pair"
+git add STEERING.md
+{
+    printf 'feat: squashed pair\n\n'
+    printf 'Body line.\n\n'
+    agent_block
+    # Sub-commit 1 trailer block — added KEY_S1.
+    printf 'Steer-Count: 1\n'
+    printf 'Steer-Types: interrupt=1\n'
+    printf 'Steer-Tiers: structural=1\n\n'
+    # Sub-commit 2 trailer block — added KEY_S2.
+    printf 'Steer-Count: 1\n'
+    printf 'Steer-Types: correction=1\n'
+    printf 'Steer-Tiers: structural=1\n'
+} > /tmp/msg-squash-aggregate
+git commit --quiet --no-verify -F /tmp/msg-squash-aggregate
+EVAL_LABEL="$EVAL_ID squash-merge-sums-stacked-triples" expect_pass "$CHECK"
+
+# ──────────────────────────────────────────────────────────────
+# Case 17 — pass: squashed body where the trailing sub-commit's triple
+# is the all-zero default. Under the old last-wins parse this would
+# incorrectly drop to `Steer-Count: 0` and disagree with the row added
+# by the earlier sub-commit. Mirrors run 25950635716's failure shape.
+# ──────────────────────────────────────────────────────────────
+reset_ledger
+KEY_S3="steer-${SS}-1800001200-1"
+KEY_S4="steer-${SS}-1800001300-1"
+append_row "$KEY_S3" "interrupt" "" "feat: squashed with trailing zero"
+append_row "$KEY_S4" "interrupt" "" "feat: squashed with trailing zero"
+git add STEERING.md
+{
+    printf 'feat: squashed with trailing zero\n\n'
+    printf 'Body line.\n\n'
+    agent_block
+    # First sub-commit added two rows.
+    printf 'Steer-Count: 2\n'
+    printf 'Steer-Types: interrupt=2\n'
+    printf 'Steer-Tiers: structural=2\n\n'
+    # Trailing sub-commit was a no-op for STEERING.md.
+    printf 'Steer-Count: 0\n'
+    printf 'Steer-Types: none\n'
+    printf 'Steer-Tiers: none\n'
+} > /tmp/msg-squash-trailing-zero
+git commit --quiet --no-verify -F /tmp/msg-squash-trailing-zero
+EVAL_LABEL="$EVAL_ID squash-merge-trailing-zero-block" expect_pass "$CHECK"
+
 eval_done

--- a/packs/core/directives/agent-steering-accounting/lib/trailers.py
+++ b/packs/core/directives/agent-steering-accounting/lib/trailers.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 # ledger.py sits next to this file; relative import works under
@@ -56,6 +57,60 @@ def extract_scalar_trailers(msg: str) -> dict[str, str]:
         m = _SCALAR_TRAILER_RE.match(line)
         if m:
             out[m.group(1)] = m.group(2).strip()
+    return out
+
+
+@dataclass
+class _Aggregated:
+    occurrences: int = 0
+    summed_int: int = 0
+    summed_breakdown: dict[str, int] = field(default_factory=dict)
+    bad_values: list[str] = field(default_factory=list)
+
+
+def extract_summed_trailers(
+    msg: str,
+    *,
+    count_keys: tuple[str, ...] = (),
+    breakdown_keys: tuple[str, ...] = (),
+) -> dict[str, _Aggregated]:
+    """Aggregate count and breakdown trailers across every occurrence in `msg`.
+
+    Squash-merge concatenates each sub-commit's body into the resulting commit,
+    so the same partition trailer can appear N times. For `Steer-Count` /
+    `Steer-Types` / `Steer-Tiers` the correct semantics is sum-across-
+    occurrences, not last-wins — anything else makes the squashed body
+    disagree with the cumulative STEERING.md diff by construction.
+
+    Returned dict only contains keys that appeared at least once. For each
+    key, `summed_int` accumulates count-style values, `summed_breakdown`
+    accumulates `key=N,...` partitions key-wise (with `none` treated as the
+    empty bag), and `bad_values` collects raw values that failed shape
+    validation so the caller can report them in the same format the
+    single-occurrence path used.
+    """
+    out: dict[str, _Aggregated] = {}
+    for line in msg.splitlines():
+        m = _SCALAR_TRAILER_RE.match(line)
+        if not m:
+            continue
+        k, raw = m.group(1), m.group(2).strip()
+        if k in count_keys:
+            agg = out.setdefault(k, _Aggregated())
+            agg.occurrences += 1
+            if raw.isdigit():
+                agg.summed_int += int(raw)
+            else:
+                agg.bad_values.append(raw)
+        elif k in breakdown_keys:
+            agg = out.setdefault(k, _Aggregated())
+            agg.occurrences += 1
+            parsed = _parse_breakdown(raw)
+            if parsed is None:
+                agg.bad_values.append(raw)
+            else:
+                for kk, vv in parsed.items():
+                    agg.summed_breakdown[kk] = agg.summed_breakdown.get(kk, 0) + vv
     return out
 
 
@@ -115,20 +170,22 @@ def validate(
     Mode B.
     """
     violations: list[str] = []
-    scalars = extract_scalar_trailers(msg)
-    has_count = "Steer-Count" in scalars
-    has_types = "Steer-Types" in scalars
-    has_tiers = "Steer-Tiers" in scalars
+    # Sum across occurrences instead of last-wins: GitHub squash-merge
+    # concatenates each sub-commit's body, so the trailer triple can appear
+    # N times in the resulting commit message. The cumulative STEERING.md
+    # diff is the union of all sub-commits' added rows, so the only
+    # arithmetically consistent reading of the trailer triple is the sum.
+    summed = extract_summed_trailers(
+        msg,
+        count_keys=("Steer-Count",),
+        breakdown_keys=("Steer-Types", "Steer-Tiers"),
+    )
 
     # Every in-scope commit — full summary triple required, even at N=0.
     missing = [
         name
-        for name, present in (
-            ("Steer-Count", has_count),
-            ("Steer-Types", has_types),
-            ("Steer-Tiers", has_tiers),
-        )
-        if not present
+        for name in ("Steer-Count", "Steer-Types", "Steer-Tiers")
+        if name not in summed
     ]
     if missing:
         violations.append(
@@ -136,24 +193,27 @@ def validate(
         )
         return violations
 
-    count_val = scalars["Steer-Count"]
-    if not count_val.isdigit():
+    count_agg = summed["Steer-Count"]
+    if count_agg.bad_values:
         violations.append(
-            f"{label} — Steer-Count {count_val!r} must be a non-negative integer"
+            f"{label} — Steer-Count {count_agg.bad_values[0]!r} must be a "
+            f"non-negative integer"
         )
         return violations
-    expected_count = int(count_val)
+    expected_count = count_agg.summed_int
 
-    types_parsed = _parse_breakdown(scalars["Steer-Types"])
-    tiers_parsed = _parse_breakdown(scalars["Steer-Tiers"])
-    if types_parsed is None:
+    types_agg = summed["Steer-Types"]
+    tiers_agg = summed["Steer-Tiers"]
+    types_parsed = None if types_agg.bad_values else types_agg.summed_breakdown
+    tiers_parsed = None if tiers_agg.bad_values else tiers_agg.summed_breakdown
+    if types_agg.bad_values:
         violations.append(
-            f"{label} — Steer-Types {scalars['Steer-Types']!r} is malformed "
+            f"{label} — Steer-Types {types_agg.bad_values[0]!r} is malformed "
             f"(expected `key=N,key=N` or `none`)"
         )
-    if tiers_parsed is None:
+    if tiers_agg.bad_values:
         violations.append(
-            f"{label} — Steer-Tiers {scalars['Steer-Tiers']!r} is malformed "
+            f"{label} — Steer-Tiers {tiers_agg.bad_values[0]!r} is malformed "
             f"(expected `key=N,key=N` or `none`)"
         )
 
@@ -192,13 +252,15 @@ def validate(
         actual_tiers = _tally(matched, "tier")
         if types_parsed is not None and types_parsed != actual_types:
             violations.append(
-                f"{label} — Steer-Types {scalars['Steer-Types']} disagrees with "
-                f"newly-added rows' types {_format_breakdown(actual_types)}"
+                f"{label} — Steer-Types {_format_breakdown(types_parsed)} "
+                f"disagrees with newly-added rows' types "
+                f"{_format_breakdown(actual_types)}"
             )
         if tiers_parsed is not None and tiers_parsed != actual_tiers:
             violations.append(
-                f"{label} — Steer-Tiers {scalars['Steer-Tiers']} disagrees with "
-                f"newly-added rows' tiers {_format_breakdown(actual_tiers)}"
+                f"{label} — Steer-Tiers {_format_breakdown(tiers_parsed)} "
+                f"disagrees with newly-added rows' tiers "
+                f"{_format_breakdown(actual_tiers)}"
             )
 
     if subject is not None:


### PR DESCRIPTION
## Summary

- `agent-steering-accounting`'s trailer parser now sums `Steer-Count` / `Steer-Types` / `Steer-Tiers` across every occurrence in the commit body instead of last-wins. GitHub squash-merge concatenates each sub-commit's body into the resulting commit, so the partition trailers can appear N times — only sum-of-occurrences agrees with the cumulative STEERING.md diff.
- Adds `extract_summed_trailers` alongside `extract_scalar_trailers`; non-partition trailers (`Agent`, `Session`, `Cost-Key`, ...) keep git-trailer last-wins semantics. Single-occurrence cases sum to themselves, so non-squashed commits are unchanged.
- Two new eval cases cover the squash shape: stacked non-zero blocks and a trailing all-zero block (the latter mirrors run [25950635716](https://github.com/srikanth235/centraid/actions/runs/25950635716) cited in the issue).

Closes [#136](https://github.com/Duaility/governance-kit/issues/136).

The token-accounting sibling flagged in the issue's "Likely sibling" note is a different shape of bug (multiple `Cost-Key:` trailers in the squashed body — only the last gets cross-checked against its row, the rest go silently unverified). It's worth its own PR; not addressed here.

## Test plan

- [x] `bash packs/core/directives/agent-steering-accounting/evals/test.sh` — all 17 cases pass
- [x] `bash scripts/test-packs.sh` — 14 directives, all evals pass
- [x] `bash .governance/run.sh` — dogfood suite green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)