### PR TITLE
refactor(governance): drop reconcile from the kit's own CI and clone setup

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -19,17 +19,11 @@ jobs:
           # Full history so git-grep-based directives can inspect all tracked files.
           fetch-depth: 0
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
-      - name: Reconcile gh-source packs from packs.lock
-        # Materialize directive folders for every `source: gh` entry into
-        # .governance/packs/<owner>/<name>/. Those trees are gitignored
-        # (reconstructable artifacts), so without this step the runner
-        # below would only see committed `source: local` packs.
-        run: bash governance/assets/packs/lib/reconcile.sh "$PWD"
-
       - name: Run bash governance directives
+        # Directive trees are committed (vendored) under .governance/packs/,
+        # so the runner sees them directly — no reconcile/fetch step, exactly
+        # like a consumer repo. Re-vendor with `governance pack update` after
+        # editing packs/core.
         run: bash .governance/run.sh
 
       # The kit-internal test umbrella (scripts/test.sh) runs in tests.yml so

--- a/COSTS.md
+++ b/COSTS.md
@@ -245,3 +245,4 @@ Schema:
 | claude-code-e5be56d9-598-1781021766 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #160 | claude-opus-4-8 | 6 | 6951 | 692892 | 9894 | 16851 | 0.6373 | docs: cover kit + pack lifecycle and core ideas in README (#160) |
 | claude-code-e5be56d9-598-1781021898 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #160 | claude-opus-4-8 | 149 | 15791 | 2375796 | 13613 | 29553 | 1.6277 | docs: cover kit + pack lifecycle and core ideas in README (#160) |
 | claude-code-e5be56d9-598-1781022094 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #160 | claude-opus-4-8 | 411 | 31870 | 2955636 | 28378 | 60659 | 2.3885 | docs: cover kit + pack lifecycle and core ideas in README (#160) |
+| claude-code-e5be56d9-598-1781022610 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #162 | claude-opus-4-8 | 844 | 43056 | 9261036 | 40301 | 84201 | 5.9114 | refactor(governance): drop reconcile from the kit's own CI and clone setup (#162 |

--- a/receipts/issue-162-drop-reconcile-kit-loop.md
+++ b/receipts/issue-162-drop-reconcile-kit-loop.md
@@ -1,0 +1,57 @@
+# issue-162 — drop reconcile from the kit's own CI and clone setup
+
+Addresses [#162](https://github.com/Duaility/governance-kit/issues/162).
+
+## Checklist
+
+- [x] Remove the reconcile step (and Install uv) from governance.yml
+- [x] Remove the reconcile block from enable-governance.sh
+- [x] Suite stays green running the committed tree directly
+
+## Problem
+
+Since #158/#159 the kit commits its consumed `governance-kit/core` directive
+tree (no longer gitignored/reconstructed). That left `reconcile.sh` redundant in
+the kit's *own* loop: the committed tree is what should run, exactly like every
+consumer. The shipped CI template and `enable-governance.sh` asset never call
+reconcile; only the kit's own copies did — a leftover from the gitignore era.
+
+## What changed
+
+- **Remove the reconcile step (and Install uv) from governance.yml** —
+  `.github/workflows/governance.yml` now runs `.governance/run.sh` over the
+  committed tree directly. The "Reconcile gh-source packs" step and its
+  only-needed-for-reconcile "Install uv" step are gone (no `check.sh` needs
+  `uv`); the kit's CI now matches the shipped consumer template's shape.
+- **Remove the reconcile block from enable-governance.sh** — dropped the
+  trailing `reconcile.sh` invocation (and its stale "gitignored / reconstructable
+  artifacts" comment) from `scripts/enable-governance.sh`; a fresh clone already
+  has the committed tree.
+
+`reconcile.sh` and the working-tree resolver are intentionally kept — still
+shipped for the gitignore-it consumer pattern and used by `pack update`. The
+deeper "delete the resolver / make core first-party" restructure is out of scope.
+
+## Out of scope
+
+- The working-tree resolver (`working_tree.py`), `reconcile.sh` itself, and the
+  `packs/core` ↔ committed-tree duplication — the structural simplification was
+  deliberately deferred; this is the leaf cleanup only.
+
+## Decisions
+
+- **Accepted that the dogfood now enforces the committed/pinned core, not
+  bleeding-edge `packs/core`.** Editing a directive in `packs/core` requires a
+  deliberate `governance pack update governance-kit/core` + commit to re-vendor
+  before the dogfood picks it up — consistent with how consumers work, and the
+  point of vendoring.
+- **Removed `Install uv` alongside reconcile.** It was added solely for
+  `reconcile.sh`'s `uv run --with PyYAML`; nothing in the `run.sh` path needs it.
+
+## Verification
+
+- **Suite stays green running the committed tree directly** — `bash
+  .governance/run.sh` → all 17 directives pass with no reconcile step.
+- `bash .governance/run.sh workflows-hardened` → green (the trimmed
+  `governance.yml` still declares `permissions:` and pins its remaining action
+  to a SHA).

--- a/scripts/enable-governance.sh
+++ b/scripts/enable-governance.sh
@@ -21,10 +21,6 @@ git config core.hooksPath .githooks
 current="$(git config --get core.hooksPath)"
 echo "enable-governance: core.hooksPath=$current"
 
-# Materialize directive folders for every `source: gh` entry in packs.lock.
-# Those trees are gitignored (reconstructable artifacts), so without this
-# step `.governance/run.sh` would only see committed `source: local` packs.
-# Re-run after pulling lockfile changes.
-if [[ -f .governance/packs.lock ]]; then
-    bash governance/assets/packs/lib/reconcile.sh "$ROOT"
-fi
+# No reconcile step: directive trees are committed (vendored) under
+# .governance/packs/, so a fresh clone already has them. Re-vendor with
+# `governance pack update` after editing a pack's source.


### PR DESCRIPTION
Closes #162.

Since #158/#159 the kit commits its consumed `governance-kit/core` tree, so `reconcile.sh` is redundant in the kit's *own* loop — the committed tree is what should run, like every consumer.

## What
- `.github/workflows/governance.yml`: removed the "Reconcile gh-source packs" step + its only-for-reconcile "Install uv" step. CI runs `.governance/run.sh` over the committed tree directly (no `check.sh` needs `uv`).
- `scripts/enable-governance.sh`: removed the trailing reconcile block + its stale "gitignored artifacts" comment.

`reconcile.sh` and the working-tree resolver stay (shipped for the gitignore-it consumer pattern + used by `pack update`). Leaf cleanup only; the resolver-deletion restructure is out of scope.

## Tradeoff
The dogfood now enforces the committed/pinned core, not bleeding-edge `packs/core` — editing a directive there needs `governance pack update governance-kit/core` + commit to re-vendor first.

## Verification
- `bash .governance/run.sh` → all 17 directives green with no reconcile step.
- `workflows-hardened` green (trimmed workflow still declares `permissions:` + SHA-pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)