### PR TITLE
fix(governance): surface kit-update staleness + reproducible kit-plan (#170)

### DIFF
--- a/COSTS.md
+++ b/COSTS.md
@@ -250,3 +250,4 @@ Schema:
 | claude-code-e5be56d9-598-1781024615 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #164 | claude-opus-4-8 | 3369 | 148461 | 30830627 | 131861 | 283691 | 19.6566 | refactor(governance): delete working-tree resolver; dogfood pack update via real |
 | claude-code-95102b22-38b-1781025210 | claude-code | 95102b22-38b4-4fbc-a5a4-d56309cf821c | #166 | claude-opus-4-8 | 5380 | 21846 | 32008 | 1120 | 28346 | 0.2074 | refactor(governance): delete orphaned reconcile.sh (#166) |
 | claude-code-521d18ae-fc0-1781072291 | claude-code | 521d18ae-fc03-48fd-be1d-0957a9bdf969 | #170 | claude-opus-4-8 | 43111 | 144567 | 1831796 | 22342 | 210020 | 2.5935 |  |
+| claude-code-521d18ae-fc0-1781072417 | claude-code | 521d18ae-fc03-48fd-be1d-0957a9bdf969 | #170 | claude-opus-4-8 | 0 | 0 | 0 | 0 | 0 | 0.0000 |  |

--- a/COSTS.md
+++ b/COSTS.md
@@ -249,3 +249,4 @@ Schema:
 | claude-code-765dbd1b-b19-1781024545 | claude-code | 765dbd1b-b19b-4cba-9588-a52734635d6d | #164 | claude-opus-4-8 | 5744 | 22898 | 32008 | 1434 | 30076 | 0.2237 | refactor(governance): delete working-tree resolver; dogfood pack update via real |
 | claude-code-e5be56d9-598-1781024615 | claude-code | e5be56d9-5982-40ea-aacd-912b10fc2e84 | #164 | claude-opus-4-8 | 3369 | 148461 | 30830627 | 131861 | 283691 | 19.6566 | refactor(governance): delete working-tree resolver; dogfood pack update via real |
 | claude-code-95102b22-38b-1781025210 | claude-code | 95102b22-38b4-4fbc-a5a4-d56309cf821c | #166 | claude-opus-4-8 | 5380 | 21846 | 32008 | 1120 | 28346 | 0.2074 | refactor(governance): delete orphaned reconcile.sh (#166) |
+| claude-code-521d18ae-fc0-1781072291 | claude-code | 521d18ae-fc03-48fd-be1d-0957a9bdf969 | #170 | claude-opus-4-8 | 43111 | 144567 | 1831796 | 22342 | 210020 | 2.5935 |  |

--- a/governance/SKILL.md
+++ b/governance/SKILL.md
@@ -18,10 +18,11 @@ Tracking issue: [Duaility/governance-kit#31](https://github.com/Duaility/governa
 
 ```
 governance init                                       # bootstrap a repo
-governance kit update [--with-packs] [--dry-run] [--force]
+governance kit update [--with-packs] [--check-upstream] [--dry-run] [--force]
                                                       # re-sync runtime files (run.sh, lib.sh, enable-governance.sh,
                                                       # governance.yml, hook dispatchers) when a new kit
-                                                      # version is on PATH; --with-packs also re-pins gh packs
+                                                      # version is on PATH; --with-packs also re-pins gh packs;
+                                                      # --check-upstream reports if the installed skill is behind
 governance pack search [query]                        # search community catalog
 governance pack create <name>                         # scaffold a repo-local pack at packs/<repo-owner>/<name>/
 governance pack add <ref>                             # e.g. gh:acme/soc2-pack@main
@@ -97,6 +98,7 @@ Key invariants:
 - Diff-before-exec per file. Files without a line-2 `governance-kit:managed` marker are surfaced as `Skipped (unmanaged)` and the user picks `keep` / `apply anyway` / `overwrite-with-backup`.
 - No silent downgrades: a manifest stamp newer than the kit on PATH stops the verb.
 - `--with-packs` chains `pack update` for every `source: gh` entry; without the flag, kit-runtime sync is a pure local file-copy and never touches the network.
+- `--check-upstream` adds a read-only `git ls-remote` against the kit's upstream to report whether the *installed skill* is behind the latest published `kit/vX.Y.Z` — a signal only. It never fetches-and-applies the kit (that stays the skill manager's job, `npx skills update governance --global`); the verb only ever syncs the repo to the installed kit.
 - Refuses on a dirty working tree (override with `--force`).
 - One atomic commit per run, Conventional Commits subject, no auto-push.
 

--- a/governance/assets/packs/lib/kitverb.py
+++ b/governance/assets/packs/lib/kitverb.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Kit-verb helper: the deterministic core of `governance kit update`.
+
+`kit-plan <root>` resolves everything UPDATE_FLOW.md Steps 1–3 need as one
+pure, side-effect-free computation and prints it as JSON:
+
+  * the recorded `installed_kit_version` — read from
+    `<root>/.governance/install.yaml`, or reconstructed from the
+    `kit-version=` markers on the managed runtime files when the manifest is
+    missing (mirrors install.sh `read_marker_kit_version`, taking the min);
+  * the version `delta` vs the kit on PATH (`forward` / `up-to-date` /
+    `downgrade` / `pre-tracking` / `no-recoverable-pin`);
+  * the managed-file inventory — each kit asset paired with its install
+    destination, the destination's current marker state, and a plan-status
+    hint (`skip` / `apply` / `add` / `unmanaged`).
+
+This is the piece consumers previously hand-assembled from prose — the bash
+arrays, the marker scan, the min-reduction, the no-downgrade gate — i.e. the
+exact surface where a missed `bash 3.2` quirk or a skipped phase silently
+produced a wrong plan (issue #170, finding B). It writes nothing: the agent
+still owns diff-before-exec, the per-file confirmation, and the apply itself
+(`cp` + install.sh `stamp_managed_marker` + hooks.sh
+`generate_hooks_for_strategy` + install.sh `write_installed_manifest`). The
+plan is reproducible and unit-tested; the apply primitives already are.
+
+`kit-upstream [--repo <owner/repo>]` is the opt-in read-only staleness check
+behind `governance kit update --check-upstream` (issue #170, option 2). It
+resolves the latest published `kit/vX.Y.Z` tag via `git ls-remote` and compares
+it to the installed `KIT_VERSION`, reporting `current` / `behind` (with a count
+and the skill-manager refresh command) / `ahead` / `unknown` (offline). It is
+strictly a *signal*: it never fetches-and-applies the kit — that stays the
+skill manager's job, so the running flow never applies a version it doesn't
+understand and the skill manager's pinning is never bypassed.
+
+Run via:
+    uv run --with PyYAML python governance/assets/packs/lib/kitverb.py kit-plan <root>
+    uv run --with PyYAML python governance/assets/packs/lib/kitverb.py kit-upstream [--repo <owner/repo>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from packctl import KIT_VERSION, _version_tuple, load_yaml, scalar
+
+# Default upstream the kit is published from. The installed skill records its
+# real origin in the `skills` lockfile (`source: Duaility/governance-kit`);
+# `--repo` overrides this for forks. GitHub owner/repo is case-insensitive.
+DEFAULT_KIT_REPO = "duaility/governance-kit"
+
+# Skill-manager refresh command — the one trusted, pinned channel for pulling a
+# newer kit onto the machine. kit-upstream only ever points here; never applies.
+REFRESH_CMD = "npx skills update governance --global"
+
+# Kit releases are tagged `kit/vX.Y[.Z]`; annotated tags also emit a `^{}` deref
+# line, which the dedupe below collapses.
+_KIT_TAG_RE = re.compile(r"refs/tags/kit/v(\d+(?:\.\d+){1,2})(?:\^\{\})?$")
+
+# Kit asset root — `<skill>/governance/assets`. kitverb.py lives at
+# `governance/assets/packs/lib/kitverb.py`, so the assets dir is parents[2].
+KIT_ASSETS = Path(__file__).resolve().parents[2]
+
+_MARKER_RE = re.compile(r"^# governance-kit:managed", re.MULTILINE)
+_KIT_VERSION_TOKEN_RE = re.compile(r"kit-version=(\S+)")
+
+
+def read_marker(dest: Path) -> dict[str, Any]:
+    """Marker state of a managed file, mirroring install.sh read_marker_kit_version.
+
+    Returns {"state": versioned|bare|absent, "version": <v>|None}. Scans for the
+    first `# governance-kit:managed` line; `bare` is the pre-kit-version form.
+    """
+    if not dest.is_file():
+        return {"state": "absent", "version": None}
+    try:
+        text = dest.read_text(errors="replace")
+    except OSError:
+        return {"state": "absent", "version": None}
+    m = _MARKER_RE.search(text)
+    if not m:
+        return {"state": "absent", "version": None}
+    line = text[m.start():].splitlines()[0]
+    token = _KIT_VERSION_TOKEN_RE.search(line)
+    if token:
+        return {"state": "versioned", "version": token.group(1)}
+    return {"state": "bare", "version": None}
+
+
+def _status_for(marker: dict[str, Any], exists: bool) -> str:
+    """Plan-status hint from the destination's marker state.
+
+    A hint, not a verdict: the agent still computes the byte-diff (`diff -u`)
+    before showing or applying anything. `apply` on a same-version stamp is a
+    byte-identical no-op, so the diff is what ultimately decides.
+    """
+    if not exists:
+        return "add"
+    if marker["state"] == "absent":
+        return "unmanaged"          # user-owned — never silently overwritten
+    if marker["state"] == "bare":
+        return "apply"              # re-stamp brings it under per-file tracking
+    # versioned
+    if marker["version"] == KIT_VERSION:
+        return "skip"
+    return "apply"
+
+
+def _inventory(root: Path, manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Managed kit-asset ↔ destination pairs, per UPDATE_FLOW.md Step 3.
+
+    Derived from manifest fields so the set matches exactly what `init` wrote.
+    The hook dispatchers are regenerated wholesale (hooks.sh), not copied from a
+    static asset, so they are reported via `hook_strategy`, not as file pairs.
+    """
+    tests_dir = scalar(manifest.get("tests_dir")) or ".governance"
+    ci_workflow = scalar(manifest.get("ci_workflow"))
+    enable_script = scalar(manifest.get("enable_governance_script"))
+
+    pairs: list[tuple[str, str, str]] = [
+        (str(KIT_ASSETS / "dot-governance" / "run.sh"), f"{tests_dir}/run.sh", "run.sh"),
+        (str(KIT_ASSETS / "dot-governance" / "lib.sh"), f"{tests_dir}/lib.sh", "lib.sh"),
+    ]
+    if ci_workflow:
+        pairs.append((str(KIT_ASSETS / "governance.yml"), ci_workflow, "ci_workflow"))
+    if enable_script:
+        pairs.append((str(KIT_ASSETS / "enable-governance.sh"), enable_script, "enable_governance_script"))
+
+    files: list[dict[str, Any]] = []
+    for src, rel_dest, key in pairs:
+        dest = root / rel_dest
+        exists = dest.is_file()
+        marker = read_marker(dest)
+        files.append({
+            "key": key,
+            "src": src,
+            "dest": rel_dest,
+            "exists": exists,
+            "marker": marker["state"],
+            "dest_version": marker["version"],
+            "status": _status_for(marker, exists),
+        })
+    return files
+
+
+def _reconstruct(root: Path) -> dict[str, Any]:
+    """Rebuild the version pin from per-file markers when the manifest is gone.
+
+    Scans the default managed-file set for `kit-version=` tokens and takes the
+    min (an update only lands when *every* file catches up). Returns the
+    reconstructed version and the files that contributed, or version=None when
+    nothing versioned is found (the no-recoverable-pin case).
+    """
+    candidates = [
+        ".governance/run.sh",
+        ".governance/lib.sh",
+        ".github/workflows/governance.yml",
+        "scripts/enable-governance.sh",
+        ".githooks/pre-commit",
+    ]
+    found: list[tuple[str, str]] = []
+    for rel in candidates:
+        marker = read_marker(root / rel)
+        if marker["state"] == "versioned":
+            found.append((rel, marker["version"]))
+    if not found:
+        return {"version": None, "from": []}
+    lowest = min((v for _, v in found), key=_version_tuple)
+    return {"version": lowest, "from": [rel for rel, _ in found]}
+
+
+def _delta(installed: str | None, manifest_present: bool) -> str:
+    """Version delta vs the kit on PATH.
+
+    When `installed` is unknown the distinction is whether a manifest exists at
+    all: a manifest with no `kit_version` is a *pre-tracking* install (recover
+    by recording the current version), whereas no manifest and no reconstructable
+    marker is *no-recoverable-pin* (recover only via uninstall + init).
+    """
+    if installed is None:
+        return "pre-tracking" if manifest_present else "no-recoverable-pin"
+    inst, kit = _version_tuple(installed), _version_tuple(KIT_VERSION)
+    if inst < kit:
+        return "forward"
+    if inst > kit:
+        return "downgrade"
+    return "up-to-date"
+
+
+def cmd_kit_plan(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    manifest_path = root / ".governance" / "install.yaml"
+
+    manifest: dict[str, Any] = {}
+    reconstructed_from: list[str] = []
+    manifest_present = manifest_path.is_file()
+
+    if manifest_present:
+        manifest = load_yaml(manifest_path)
+        manifest_source = "install.yaml"
+        installed = scalar(manifest.get("kit_version")) or None
+    else:
+        recon = _reconstruct(root)
+        installed = recon["version"]
+        reconstructed_from = recon["from"]
+        manifest_source = "reconstructed" if installed is not None else "absent"
+
+    plan = {
+        "kit_version": KIT_VERSION,
+        "installed_kit_version": installed,
+        "manifest_source": manifest_source,
+        "reconstructed_from": reconstructed_from,
+        "delta": _delta(installed, manifest_present),
+        "hook_strategy": scalar(manifest.get("hook_strategy")) or "githooks",
+        "tests_dir": scalar(manifest.get("tests_dir")) or ".governance",
+        "files": _inventory(root, manifest),
+    }
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def parse_kit_tags(ls_remote_output: str) -> list[str]:
+    """Distinct kit versions from `git ls-remote --tags` output, in encounter
+    order. Matches `refs/tags/kit/vX.Y[.Z]`, ignores non-kit tags (e.g.
+    `core/v*`) and the `^{}` annotated-tag deref duplicates."""
+    versions: list[str] = []
+    seen: set[str] = set()
+    for line in ls_remote_output.splitlines():
+        m = _KIT_TAG_RE.search(line.strip())
+        if m and m.group(1) not in seen:
+            seen.add(m.group(1))
+            versions.append(m.group(1))
+    return versions
+
+
+def upstream_status(published: list[str], installed: str) -> dict[str, Any]:
+    """Compare the installed kit to the published set. `releases_behind` counts
+    distinct published versions strictly newer than the installed one."""
+    if not published:
+        return {"status": "unknown", "latest_published": None, "releases_behind": 0}
+    latest = max(published, key=_version_tuple)
+    behind = [v for v in published if _version_tuple(v) > _version_tuple(installed)]
+    inst, lat = _version_tuple(installed), _version_tuple(latest)
+    status = "current" if inst == lat else ("ahead" if inst > lat else "behind")
+    return {"status": status, "latest_published": latest, "releases_behind": len(behind)}
+
+
+def cmd_kit_upstream(args: argparse.Namespace) -> int:
+    repo = args.repo or DEFAULT_KIT_REPO
+    result: dict[str, Any] = {
+        "installed_kit_version": KIT_VERSION,
+        "repo": repo,
+        "refresh_cmd": REFRESH_CMD,
+    }
+    error = None
+    try:
+        proc = subprocess.run(
+            ["git", "ls-remote", "--tags", f"https://github.com/{repo}"],
+            check=False, text=True, capture_output=True, timeout=20,
+        )
+        error = proc.stderr.strip() if proc.returncode != 0 else None
+    except (OSError, subprocess.SubprocessError) as exc:
+        error = str(exc)
+
+    if error is not None:
+        # Offline / git missing / bad repo — degrade to `unknown`, never block.
+        result.update(status="unknown", latest_published=None, releases_behind=0, error=error)
+    else:
+        published = parse_kit_tags(proc.stdout)
+        result.update(upstream_status(published, KIT_VERSION), published=published)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("kit-plan")
+    p.add_argument("root")
+    p.set_defaults(func=cmd_kit_plan)
+
+    p = sub.add_parser("kit-upstream")
+    p.add_argument("--repo", default=None,
+                   help=f"owner/repo to query for kit/v* tags (default {DEFAULT_KIT_REPO})")
+    p.set_defaults(func=cmd_kit_upstream)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/governance/evals/kit-update/evals.json
+++ b/governance/evals/kit-update/evals.json
@@ -4,11 +4,11 @@
     {
       "id": 1,
       "prompt": "I just upgraded governance-kit on my machine. Pull whatever's new from the kit into this repo.",
-      "expected_output": "Following UPDATE_FLOW.md Steps 1–8: the skill reads `.governance/install.yaml`, sees `kit_version: \"0.1\"`, queries the kit on PATH for `KIT_VERSION` (`packctl.py kit-version`), determines a forward update is needed, builds the file inventory (`run.sh`, `lib.sh`, `enable-governance.sh`, `governance.yml`), shows per-file diffs (diff-before-exec), asks for explicit `yes`, applies the diffs, regenerates the hook dispatcher via `generate_hooks_for_strategy`, rewrites `install.yaml` with `kit_version: \"<new>\"`, smoke-tests, and commits one atomic commit with subject `chore(governance): kit update 0.1 → <new>`. Pack updates are NOT chained because `--with-packs` was not requested; the report mentions chaining as a hint.",
+      "expected_output": "Following UPDATE_FLOW.md Steps 1–8: the skill runs `kitverb.py kit-plan` to resolve the plan in one call — reading `.governance/install.yaml` (`kit_version: \"0.1\"`), comparing against the kit on PATH's `KIT_VERSION`, classifying `delta: forward`, and emitting the managed-file inventory (`run.sh`, `lib.sh`, `enable-governance.sh`, `governance.yml`). It shows per-file diffs (diff-before-exec), asks for explicit `yes`, applies the diffs, regenerates the hook dispatcher via `generate_hooks_for_strategy`, rewrites `install.yaml` with `kit_version: \"<new>\"`, smoke-tests, and commits one atomic commit with subject `chore(governance): kit update 0.1 → <new>`. Pack updates are NOT chained because `--with-packs` was not requested; the report mentions chaining as a hint.",
       "files": ["files/stale-repo/"],
       "assertions": [
-        "The skill read `.governance/install.yaml` and identified `kit_version: \"0.1\"` as the recorded pin",
-        "The skill queried the kit on PATH for `KIT_VERSION` (e.g. via `packctl.py kit-version`) and confirmed it is newer than 0.1",
+        "The skill resolved the plan via `kitverb.py kit-plan` and identified `kit_version: \"0.1\"` as the recorded pin (`manifest_source: install.yaml`)",
+        "The plan's `delta` was `forward` — the kit on PATH's `KIT_VERSION` is newer than 0.1",
         "The skill printed a per-file diff for each kit-runtime file BEFORE writing — same diff-before-exec discipline as `pack add` and `reset`",
         "The skill asked for an explicit `yes` to execute (no silent acceptance)",
         "The hook dispatcher was regenerated via `generate_hooks_for_strategy` (or explicitly noted as unchanged in the report)",
@@ -21,24 +21,26 @@
     {
       "id": 2,
       "prompt": "Run governance kit update — I want to make sure we're synced.",
-      "expected_output": "Following UPDATE_FLOW.md Step 2: the skill reads `kit_version: \"0.3\"` from `install.yaml`, finds it equal to the kit on PATH's `KIT_VERSION`, short-circuits the kit-runtime block, and reports `kit: up-to-date`. Without `--with-packs`, the verb exits without writing anything. No diffs are computed, no commit is created.",
+      "expected_output": "Following UPDATE_FLOW.md Step 2: the skill reads the recorded `kit_version` from `install.yaml`, finds it equal to the kit on PATH's `KIT_VERSION`, short-circuits the kit-runtime block, and reports `kit: up-to-date`. Without `--with-packs`, the verb exits without writing anything. No diffs are computed, no commit is created. The report's `Assumptions:` row still names the skill provenance — `up-to-date` is relative to the locally installed skill, not the published kit.",
       "files": ["files/up-to-date-repo/"],
       "assertions": [
         "The skill reported `kit: up-to-date` (or equivalent — the version delta was zero)",
         "No files were modified — every runtime file, the manifest, hook dispatchers, and lockfile are byte-identical to the fixture",
         "No commit was created",
         "The skill did NOT walk the file inventory or print per-file diffs (the version short-circuit precedes Step 3)",
-        "The report mentions that `--with-packs` was not requested (so pack-update chaining did not run)"
+        "The report mentions that `--with-packs` was not requested (so pack-update chaining did not run)",
+        "The report's `Assumptions:` row names the skill provenance — that `up-to-date` is relative to the locally installed skill, not the published kit — and points at refreshing the skill (e.g. `npx skills update`) to check for a newer release",
+        "The report's `Upstream:` row reads the `not checked (use --check-upstream)` sentinel — no network call was made because `--check-upstream` was not requested"
       ]
     },
     {
       "id": 3,
       "prompt": "Update the kit in this repo.",
-      "expected_output": "Following UPDATE_FLOW.md's Interaction policy and Step 1's marker-reconstruction fallback: with `.governance/install.yaml` missing, the skill first tries to reconstruct the version pin by scanning kit-owned files (`.governance/run.sh`, `.governance/lib.sh`, hook dispatchers) for the `kit-version=<v>` marker token. The fixture's runtime stubs carry only the bare `# governance-kit:managed` marker (no `kit-version=` field), so reconstruction yields nothing. The skill then refuses with the recovery path `governance uninstall` + `governance init` — without either the manifest or a versioned marker, there is no recoverable pin.",
+      "expected_output": "Following UPDATE_FLOW.md's Interaction policy and Step 1's marker-reconstruction fallback: `kitverb.py kit-plan` finds `.governance/install.yaml` missing and reconstructs the pin by scanning kit-owned files (`.governance/run.sh`, `.governance/lib.sh`, hook dispatchers) for the `kit-version=<v>` marker token. The fixture's runtime stubs carry only the bare `# governance-kit:managed` marker (no `kit-version=` field), so reconstruction yields nothing — the plan returns `delta: no-recoverable-pin` (`manifest_source: absent`). The skill then refuses with the recovery path `governance uninstall` + `governance init` — without either the manifest or a versioned marker, there is no recoverable pin.",
       "files": ["files/no-manifest-repo/"],
       "assertions": [
         "No files were created, deleted, or modified",
-        "The skill explicitly tried marker reconstruction (scanning `kit-version=` in runtime files) before refusing — not an immediate refusal on missing manifest",
+        "`kit-plan` returned `delta: no-recoverable-pin` after attempting marker reconstruction (scanning `kit-version=` in runtime files) — not an immediate refusal on missing manifest",
         "The skill explained that reconstruction failed because the runtime files carry only the bare marker (no `kit-version=` token)",
         "The skill named the recovery path: `governance uninstall` followed by `governance init`",
         "The skill did NOT fall back to a heuristic that would invent a `kit_version`"
@@ -75,12 +77,12 @@
     {
       "id": 6,
       "prompt": "Update the kit in this repo.",
-      "expected_output": "Following UPDATE_FLOW.md Step 1's marker-reconstruction fallback: with `.governance/install.yaml` missing, the skill scans kit-owned files (`.governance/run.sh`, `.governance/lib.sh`) for the `kit-version=<v>` marker token, finds `kit-version=0.1` in both, and reconstructs the version pin as `\"0.1\"` (the min). The skill proceeds through Steps 3–8 as a forward update from `0.1` to the kit's `KIT_VERSION` (`0.3`), shows per-file diffs (diff-before-exec), asks for explicit `yes`, applies the diffs and re-stamps each file's marker with the new `kit-version=`, regenerates the hook dispatcher, writes a fresh `install.yaml` with `kit_version: \"<new>\"` (and the rest of the v3 fields populated from defaults + current state), smoke-tests, and commits one atomic commit with subject `chore(governance): kit update 0.1 → <new>`. The report's `Assumptions:` line records that the manifest was reconstructed from per-file markers.",
+      "expected_output": "Following UPDATE_FLOW.md Step 1's marker-reconstruction fallback: with `.governance/install.yaml` missing, `kitverb.py kit-plan` scans kit-owned files (`.governance/run.sh`, `.governance/lib.sh`) for the `kit-version=<v>` marker token, finds `kit-version=0.1` in both, and reconstructs the pin as `\"0.1\"` (the min) — returning `manifest_source: reconstructed`, `reconstructed_from: [.governance/run.sh, .governance/lib.sh]`, `delta: forward`. The skill proceeds through Steps 3–8 as a forward update from `0.1` to the kit's `KIT_VERSION`, shows per-file diffs (diff-before-exec), asks for explicit `yes`, applies the diffs and re-stamps each file's marker with the new `kit-version=`, regenerates the hook dispatcher, writes a fresh `install.yaml` with `kit_version: \"<new>\"` (and the rest of the v3 fields populated from defaults + current state), smoke-tests, and commits one atomic commit with subject `chore(governance): kit update 0.1 → <new>`. The report's `Assumptions:` line records that the manifest was reconstructed from per-file markers.",
       "files": ["files/reconstructable-repo/"],
       "assertions": [
-        "The skill noticed `.governance/install.yaml` was missing AND attempted marker reconstruction before any user prompt",
-        "The skill scanned at least `.governance/run.sh` and `.governance/lib.sh` for the `kit-version=` token (and stated which files contributed to the reconstruction)",
-        "The skill reported `kit-version=0.1` was extracted from the markers and used as the recorded pin (taking the min when multiple files were scanned)",
+        "The skill noticed `.governance/install.yaml` was missing AND `kit-plan` attempted marker reconstruction before any user prompt",
+        "`kit-plan` scanned at least `.governance/run.sh` and `.governance/lib.sh` for the `kit-version=` token and reported them in `reconstructed_from`",
+        "`kit-plan` reported `installed_kit_version: 0.1` extracted from the markers (taking the min when multiple files were scanned), with `manifest_source: reconstructed`",
         "The skill proceeded through the normal forward-update flow (per-file diff, explicit `yes`, apply, regenerate hooks, smoke-test) — same discipline as eval case 1",
         "Each rewritten runtime file was re-stamped with the new `kit-version=<new>` marker (verified by reading line 2 / line 1 after the run)",
         "A fresh `.governance/install.yaml` was written with `kit_version: \"<new>\"` and the remaining v3 fields populated (owner, repo, hook_strategy, etc.)",

--- a/governance/evals/kit-update/files/up-to-date-repo/.governance/install.yaml
+++ b/governance/evals/kit-update/files/up-to-date-repo/.governance/install.yaml
@@ -2,7 +2,7 @@ version: "3"
 generated_at: 2026-05-08T00:00:00Z
 owner: acme
 repo: up-to-date-repo
-kit_version: "0.3"
+kit_version: "0.3.5"
 hook_strategy: githooks
 constitution: true
 ci_workflow: .github/workflows/governance.yml

--- a/governance/evals/kit-update/files/up-to-date-repo/README.md
+++ b/governance/evals/kit-update/files/up-to-date-repo/README.md
@@ -1,5 +1,9 @@
 # up-to-date-repo
 
-Bootstrapped at the same kit version that's currently on PATH (`kit_version:
-"0.2"`). `kit update` should short-circuit at Step 2 with `kit:
-up-to-date` and exit without writing anything.
+Bootstrapped at the same kit version that's currently on PATH (`kit_version`
+matches the kit's `KIT_VERSION`). `kit update` should short-circuit at Step 2
+with `kit: up-to-date` and exit without writing anything. The pin must be kept
+equal to `governance/assets/kit.yaml`'s `version` whenever the kit is released
+— `scripts/release.sh` deliberately skips `governance/evals/*`, so a kit bump
+that forgets this fixture turns the up-to-date case into a forward update.
+`test-kitverb.py` guards against that drift.

--- a/governance/references/UPDATE_FLOW.md
+++ b/governance/references/UPDATE_FLOW.md
@@ -45,6 +45,7 @@ copies. This verb closes the loop:
 | A managed file was hand-edited (line-2 marker present, byte-diff non-empty) | Show the diff and ask per-file: `apply` / `skip` / `overwrite-with-backup` (writes `<path>.pre-update.bak` then overwrites). Default `apply`. |
 | A managed file is missing the line-2 marker | Treat as user-owned. Skip silently and surface in the report under `Skipped (unmanaged):`. |
 | `--with-packs` was passed | After the kit-runtime block, run `pack update` against every `source: gh` entry in the lockfile. Each pack still uses its own diff-before-exec confirmation. |
+| `--check-upstream` was passed | Run the read-only upstream check (`kitverb.py kit-upstream`) and surface the result in the `Upstream:` report row. **Never** auto-fetch-and-apply — if the installed skill is behind, route the user to the skill manager (`npx skills update governance --global`), then re-run. The verb still syncs the repo to the *installed* kit as usual. |
 | Structured question tools are unavailable | Use short free-text prompts. If no answer to a destructive prompt, stop. |
 
 ---
@@ -57,52 +58,100 @@ Run these steps in order. Do not skip steps unless noted.
 
 Run in parallel:
 - `git rev-parse --show-toplevel` — confirm git repo; capture the root.
-- Read `<root>/.governance/install.yaml`. Schema in [INSTALL_SCHEMA.md](INSTALL_SCHEMA.md).
 - Read `<root>/.governance/packs.lock` (only required when `--with-packs`).
-- Resolve `KIT_VERSION` from the kit currently loaded:
+- Resolve the full update plan in one deterministic call:
   ```sh
   uv run --quiet --isolated --with PyYAML python \
-      governance/assets/packs/lib/packctl.py kit-version
+      governance/assets/packs/lib/kitverb.py kit-plan "<root>"
   ```
 
-If `install.yaml` is missing, attempt **manifest reconstruction from
-markers** before giving up:
+`kit-plan` is the side-effect-free core of Steps 1–3. It reads
+`<root>/.governance/install.yaml`, or — when the manifest is absent —
+reconstructs the pin from the `kit-version=` markers on the default managed
+set (taking the semver-aware **min**, since an update only lands when *every*
+managed file catches up). It resolves the version delta against the kit on
+PATH and emits the managed-file inventory with each destination's marker state
+and a plan-status hint. It writes nothing. **Consume its JSON rather than
+re-deriving any of this by hand** — the bash-array reconstruction and
+min-reduction that used to live inline here is exactly the surface where a
+shell-portability quirk or a skipped phase silently produced a wrong plan
+(issue #170, finding B).
 
-```sh
-source governance/assets/packs/lib/install.sh
-versions=()
-for f in "$root"/.governance/run.sh \
-         "$root"/.governance/lib.sh \
-         "$root"/.github/workflows/governance.yml \
-         "$root"/scripts/enable-governance.sh \
-         "$root"/.githooks/pre-commit; do
-    v=$(read_marker_kit_version "$f" 2>/dev/null) || continue
-    [[ -n "$v" ]] && versions+=("$v")
-done
-```
+| Field | Use |
+|---|---|
+| `kit_version` | `KIT_VERSION` of the kit on PATH (the installed skill copy). |
+| `installed_kit_version` | The recorded/reconstructed pin, or `null`. |
+| `manifest_source` | `install.yaml` / `reconstructed` / `absent`. |
+| `reconstructed_from` | Files that contributed to a reconstructed pin (name them in the `Assumptions:` line). |
+| `delta` | `forward` / `up-to-date` / `downgrade` / `pre-tracking` / `no-recoverable-pin` — drives Step 2. |
+| `files[]` | `{key, src, dest, exists, marker, dest_version, status}` per managed file — the Step 3 inventory. |
 
-Take the minimum (semver-aware) of `versions[]` as the reconstructed
-`installed_kit_version`. The marker is the per-file version pin; taking
-the min reflects that an update only lands when *every* managed file
-catches up. If any versioned marker is found, proceed — the manifest
-will be rewritten on success and a `Assumptions:` line records the
-reconstruction.
+`status` is a hint, not a verdict — `skip` (versioned marker == `KIT_VERSION`),
+`apply` (older or bare marker), `add` (destination missing), `unmanaged`
+(no marker; user-owned). The agent still computes the byte-diff (`diff -u`) in
+Step 3 before showing or applying anything.
 
-If `install.yaml` is missing **and** no runtime file carries a
-versioned `kit-version=` marker, stop. The user has no recoverable
-version pin (truly pre-marker install or all managed files were
-hand-stripped). Recovery: `governance uninstall` + `governance init`.
+If `delta` is `no-recoverable-pin` (`manifest_source: absent`), stop: the user
+has no recoverable version pin (truly pre-marker install or all managed files
+were hand-stripped). Recovery: `governance uninstall` + `governance init`.
+When `manifest_source` is `reconstructed`, proceed — the manifest is rewritten
+on success and an `Assumptions:` line records the reconstruction.
 
 ### Step 2 — Resolve the version delta
 
-Read `installed_kit_version` from `install.yaml.kit_version`. Three cases:
+`kit-plan`'s `delta` field already classifies the update. Act on it:
 
-| Case | Action |
+| `delta` | Action |
 |---|---|
-| Field is absent (`null`) | Pre-tracking install. Treat `installed_kit_version` as `"0"` for the purpose of reporting; proceed. |
-| `installed_kit_version` < `KIT_VERSION` | Forward update. Continue to Step 3. |
-| `installed_kit_version` == `KIT_VERSION` | No-op for kit-runtime. If `--with-packs`, jump to Step 6. Else report `kit: up-to-date` and exit. |
-| `installed_kit_version` > `KIT_VERSION` | Stop. The repo was last touched by a newer kit; running an older `kit update` against it would silently downgrade. The user's recovery path is to upgrade the kit on PATH (e.g., `uvx --reinstall …`) and re-run. |
+| `pre-tracking` | Manifest present but carries no `kit_version`. Offer to record the current `KIT_VERSION`; proceed (render `<prev>` as `unknown` in the report). |
+| `forward` | Forward update. Continue to Step 3. |
+| `up-to-date` | No-op for kit-runtime. If `--with-packs`, jump to Step 6. Else report `kit: up-to-date` and exit — but **always** emit the skill-provenance line (below). |
+| `downgrade` | Stop. The repo was last touched by a newer kit; running an older `kit update` against it would silently downgrade. The user's recovery path is to upgrade the kit on PATH (e.g., `uvx --reinstall …`) and re-run. |
+| `no-recoverable-pin` | Already handled in Step 1 — stop with the `uninstall` + `init` recovery path. |
+
+**Skill-provenance line (up-to-date branch).** `KIT_VERSION` is resolved
+*only* from the locally installed skill (`packctl.py kit-version` →
+`governance/assets/kit.yaml`). The verb has **no awareness of the kit version
+published upstream**: if the installed skill is itself stale, this branch
+reports `up-to-date` while a newer kit exists — the single most confusing
+failure mode of a routine "pull the latest kit" (issue #170). So whenever this
+branch fires, the `Assumptions:` row must name the provenance and the refresh
+path, verbatim shape:
+
+> `Kit source: locally installed governance skill (kit <v>). "Up-to-date" is relative to the installed skill, not the published kit — to check for a newer release, refresh the skill (e.g. `npx skills update governance --global`) and re-run.`
+
+This is a no-network reminder: it does not fetch anything, it just stops the
+user from concluding "I'm current" when the real fix is one layer up, in the
+skill install.
+
+**Opt-in upstream check (`--check-upstream`).** When the user wants the hint
+turned into a measurement, `--check-upstream` resolves the latest published
+`kit/vX.Y.Z` tag and reports how far behind the installed skill is:
+
+```sh
+uv run --quiet --isolated --with PyYAML python \
+    governance/assets/packs/lib/kitverb.py kit-upstream
+```
+
+`kit-upstream` is read-only — a single `git ls-remote` against the kit's
+upstream (`duaility/governance-kit` by default; the skill records its real
+origin in the `skills` lockfile). It returns `status`
+(`current`/`behind`/`ahead`/`unknown`), `latest_published`, and
+`releases_behind`. Surface it in the `Upstream:` report row:
+
+- `behind` → `behind by <N> (latest <v>) — refresh the skill: npx skills update governance --global, then re-run`.
+- `current` → `current (latest <v>)`.
+- `unknown` (offline / git unavailable) → `not reachable (offline?)` — never block the verb on it.
+
+It is **only** a signal. `kit update` never fetches-and-applies a newer kit
+itself: that would make the *currently running* flow apply assets and a
+manifest contract it predates (silent version skew — the exact failure this
+verb exists to prevent), and it would bypass the skill manager's pinned,
+lock-verified install path with a second unaudited code-ingestion route.
+Pulling a newer kit onto the machine is the skill manager's job; this verb only
+syncs the repo to whatever kit is installed. So when `behind`, the verb routes
+to `npx skills update governance --global` and stops short of applying — it
+does not download or run upstream code.
 
 Do **not** attempt a downgrade automatically. Downgrades have to be
 explicit (`--allow-downgrade`, future flag) — silently rolling a runtime
@@ -111,8 +160,11 @@ of footgun this verb exists to prevent.
 
 ### Step 3 — Inventory the managed files
 
-Build the list of files this verb owns. Each entry pairs the kit asset
-with the install destination, derived from `install.yaml`:
+`kit-plan` already built this inventory — `files[]` pairs each kit asset
+(`src`) with its install destination (`dest`), derived from the manifest
+fields, and carries the destination's `marker` state, `dest_version`, and
+plan-status `status`. Use it directly; the table below documents what those
+pairs are:
 
 | Source (in kit) | Destination (in repo) | Marker |
 |---|---|---|
@@ -122,6 +174,12 @@ with the install destination, derived from `install.yaml`:
 | `assets/governance.yml` | `<ci_workflow>` | `governance-kit:managed kit-version=<v>` in first 3 lines |
 | `assets/freshness.conf` | `<tests_dir>/freshness.conf` (only if the file already exists — `kit update` does not seed it) | None — user-tunable config; skip on diff |
 | `assets/integrity.conf` | `<tests_dir>/integrity.conf` (only if the file already exists — `kit update` does not seed it) | None — user-tunable config; skip on diff |
+
+The hook dispatchers are kit-owned too, but `kit-plan` does not list them as
+file pairs — they are regenerated wholesale in Step 5 (`generate_hooks_for_strategy`)
+rather than copied from a static asset, so the plan reports `hook_strategy`
+instead. The two `*.conf` files above are likewise outside `files[]` (no
+marker, seed-only).
 
 **Marker shape.** The ownership marker is a `# governance-kit:managed`
 comment within the file's leading comment block: line 2 for shebang
@@ -285,6 +343,24 @@ Append the issue anchor the repo's `commit-message-format` directive
 requires (`(#N)`). If the user did not name an issue, ask for it as a
 blocking input — same discipline as every other writer in this skill.
 
+**Export `AGENT_ISSUE='#N'` for the commit.** This subject is delivered
+via a HEREDOC (below), not a `-m "<subject>"` flag — so the subject never
+lands in `git`'s argv. The `agent-steering-accounting` and
+`agent-token-accounting` pre-commit hooks infer the issue anchor by walking
+that argv for a `(#N)` token; with a HEREDOC there is nothing to walk, and
+they block the commit asking for `AGENT_ISSUE`. (This is *not* a regex
+mismatch with `commit-message-format` — that directive and the hooks accept
+the identical `(#N)` shape, including subjects like `… (+packs) (#N)`; the
+gap is purely that argv-based inference can't see a HEREDOC subject.) So
+prefix the commit:
+
+```sh
+AGENT_ISSUE='#N' git commit -F - <<'EOF'
+chore(governance): kit update <old> → <new> (#N)
+…
+EOF
+```
+
 The commit body should include:
 - The kit version delta.
 - A bullet list of files updated, skipped, and unmanaged-skip.
@@ -318,6 +394,9 @@ Skipped (unmanaged): <files without the line-2 marker + per-file user
 Hook dispatcher:  regenerated | unchanged
 Smoke test:       pass | fail (exit <code>): <first failing directive>
 Packs:            up-to-date | <N> updated | not checked (use --with-packs)
+Upstream:         not checked (use --check-upstream) | current (latest <v>) |
+                  behind by <N> (latest <v>) — refresh: npx skills update
+                  governance --global, then re-run | not reachable (offline?)
 Committed:        <short-sha> <conventional-commit subject>
                   (or `would-commit:` under `--dry-run`, or `none` for a
                   no-op / refusal)
@@ -329,8 +408,13 @@ For the documented short-circuit branches:
 
 - **Up-to-date no-op** — every row is `none` except `From → To:` (which
   reads `<v> → <v> (up-to-date)`), `Smoke test:` (`pass`), `Packs:` (the
-  `--with-packs`-aware sentinel), `Committed:` (`none`), and `Next:`
-  (`none` — the user has nothing to push).
+  `--with-packs`-aware sentinel), `Upstream:` (the `--check-upstream`-aware
+  sentinel), `Committed:` (`none`), and `Next:` (`none` — the user has nothing
+  to push). `Assumptions:` **must** carry the skill-provenance line (see above)
+  — this is the one branch where "up-to-date" can be a false negative, so the
+  report has to name what it actually compared against. With `--check-upstream`
+  the `Upstream:` row turns that caveat into a measured `current` / `behind by
+  <N>` instead.
 - **Refusal** (`no recoverable pin`, `no-downgrade`, dirty tree without
   `--force`) — emit `From → To:` with the detected delta, set every
   action row to `none`, and put the refusal reason and recovery path
@@ -338,7 +422,7 @@ For the documented short-circuit branches:
 
 ## Required final output
 
-Same 10-field block as Step 8 above. There is no shorter "summary"
+Same 11-field block as Step 8 above. There is no shorter "summary"
 variant — the verb either emits the full block or it has not finished.
 
 ---

--- a/governance/references/VERBS.md
+++ b/governance/references/VERBS.md
@@ -34,7 +34,7 @@ full rearchitecture context.
 
 - **Aliases a user might type:** `governance kit update`, `update governance-kit`, `pull the new kit version`, `sync run.sh from the kit`, `the kit was published — update this repo`.
 - **Precondition:** repo must have governance installed (`.governance/` and at least one kit-owned file present). Reads the version pin from `install.yaml.kit_version`; if the manifest is missing or the field is absent, scans per-file `kit-version=` markers and takes the min. Refuses only when neither manifest nor any versioned marker is found — that means there is no recoverable version pin.
-- **Flags:** `--with-packs` (also chain `pack update` for every `source: gh` entry), `--dry-run`, `--force` (override the dirty-working-tree refusal).
+- **Flags:** `--with-packs` (also chain `pack update` for every `source: gh` entry), `--check-upstream` (read-only check of whether the installed skill is behind the latest published `kit/vX.Y.Z` — a signal only; never fetches-and-applies, routes to the skill manager), `--dry-run`, `--force` (override the dirty-working-tree refusal).
 - **Authoritative flow:** [UPDATE_FLOW.md](UPDATE_FLOW.md) Steps 1–8.
 - **Disjoint from `pack update`.** Updates the kit-runtime files (`run.sh`, `lib.sh`, `enable-governance.sh`, `governance.yml`, hook dispatchers) and the `kit_version` pin in `install.yaml`. For directive-content updates use `pack update`. Use both with `kit update --with-packs`.
 - **No silent downgrades.** A manifest stamp newer than the kit on PATH stops the verb.

--- a/packs/core/directives/version-consistency/check.sh
+++ b/packs/core/directives/version-consistency/check.sh
@@ -28,7 +28,10 @@ MANIFEST=".governance/install.yaml"
 [[ -f "$MANIFEST" ]] || directive_end   # no-op: nothing installed to validate
 
 manifest_field() {  # scalar value of a top-level key, quotes/comments stripped
-    sed -nE "s/^$1:[[:space:]]*\"?([^\"#[:space:]]*)\"?.*/\1/p" "$MANIFEST" | head -1
+    # Accept either quote style — YAML permits both, and older-`init` repos
+    # single-quote `kit_version: '0.3'`. Stripping only `"` left the quotes in
+    # the value, so it never matched the bare `kit-version=` marker (#170).
+    sed -nE "s/^$1:[[:space:]]*['\"]?([^'\"#[:space:]]*)['\"]?.*/\1/p" "$MANIFEST" | head -1
 }
 
 expected="$(manifest_field kit_version)"
@@ -60,7 +63,7 @@ for f in "${managed[@]}"; do
     [[ -n "$v" ]] || continue   # unmanaged / bare marker — out of this directive's scope
     checked=$((checked + 1))
     if [[ "$v" != "$expected" ]]; then
-        violation "$f is stamped kit-version=$v but .governance/install.yaml pins kit_version=$expected — run 'governance kit update' or re-stamp so every managed file agrees"
+        violation "$f is stamped kit-version='$v' but .governance/install.yaml pins kit_version='$expected' — run 'governance kit update' or re-stamp so every managed file agrees"
     fi
 done
 

--- a/packs/core/directives/version-consistency/evals/test.sh
+++ b/packs/core/directives/version-consistency/evals/test.sh
@@ -34,6 +34,18 @@ stage_all
 commit_quiet "fixture: consistent stamps"
 EVAL_LABEL="$EVAL_ID" expect_pass "$CHECK"
 
+# pass — manifest pins kit_version with single quotes (older-init bootstrap).
+# YAML permits both quote styles; the parser must strip either, else `expected`
+# keeps the quotes and never matches the bare `kit-version=` marker. Regression
+# guard for the self-equal-looking violation in issue #170 (finding A).
+sed -i.bak "s/^kit_version:.*/kit_version: '$KITV'/" .governance/install.yaml && rm -f .governance/install.yaml.bak
+stage_all
+commit_quiet "fixture: single-quoted kit_version"
+EVAL_LABEL="$EVAL_ID single-quoted pin" expect_pass "$CHECK"
+
+# restore double-quoted pin for the remaining cases
+sed -i.bak "s/^kit_version:.*/kit_version: \"$KITV\"/" .governance/install.yaml && rm -f .governance/install.yaml.bak
+
 # fail — one managed file drifts to a different kit version
 write_marked .github/workflows/governance.yml "0.0"
 stage_all

--- a/receipts/issue-170-kit-update-staleness.md
+++ b/receipts/issue-170-kit-update-staleness.md
@@ -7,16 +7,22 @@ Closes [#170](https://github.com/Duaility/governance-kit/issues/170).
 ## Checklist
 
 - [x] (A) version-consistency accepts single-quoted kit_version, with a regression eval
-- [ ] (1) up-to-date report names its provenance and points at refreshing the skill
-- [ ] (2) opt-in check-upstream reports how far behind the installed skill is, signal-only
-- [ ] (B) kit-plan helper makes the delta, reconstruction, and inventory reproducible
-- [ ] (C) document AGENT_ISSUE for HEREDOC commits in the kit update flow
-- [ ] re-pin the stale up-to-date-repo eval fixture to KIT_VERSION, with a drift guard
-- [ ] bash scripts/test.sh clean
+- [x] (1) up-to-date report names its provenance and points at refreshing the skill
+- [x] (2) opt-in check-upstream reports how far behind the installed skill is, signal-only
+- [x] (B) kit-plan helper makes the delta, reconstruction, and inventory reproducible
+- [x] (C) document AGENT_ISSUE for HEREDOC commits in the kit update flow
+- [x] re-pin the stale up-to-date-repo eval fixture to KIT_VERSION, with a drift guard
+- [x] bash scripts/test.sh clean
 
 ## What changed
 
 - (A) version-consistency accepts single-quoted kit_version, with a regression eval — **`packs/core/directives/version-consistency/check.sh`**: `manifest_field()`'s `sed` stripped only `"`, so a manifest pinning `kit_version: '0.3'` (the form older `init` emitted; the current writer uses double quotes, and there is no migration) left the single quotes in the captured value. `expected` became `'0.3'` and never matched a bare `kit-version=0.3` marker — every managed file then failed with a `… is stamped kit-version=0.3 but … pins kit_version='0.3'` violation whose two values look identical in the rendered error. The parser now accepts either quote style (`['\"]?…[^'\"#[:space:]]*…['\"]?`, verified on GNU + BSD `sed`), and the violation message quotes both values so any residual quote/whitespace mismatch is visible. **`packs/core/directives/version-consistency/evals/test.sh`** gains a "single-quoted pin" case that rewrites the fixture manifest to `kit_version: '<v>'` and asserts the check still passes (it failed before the fix).
+
+- (1) up-to-date report names its provenance and points at refreshing the skill — **`governance/references/UPDATE_FLOW.md`**: the up-to-date branch (Step 2 + Step 8 report + the no-op bullet) now requires an `Assumptions:` line stating that `up-to-date` is resolved only from the locally installed skill, not the published kit, and pointing at `npx skills update governance --global`. Locked in with a new assertion on eval 2 (**`governance/evals/kit-update/evals.json`**).
+- (2) opt-in check-upstream reports how far behind the installed skill is, signal-only — **`governance/assets/packs/lib/kitverb.py`** gains `kit-upstream`: a read-only `git ls-remote` against the kit's upstream that resolves the latest `kit/vX.Y.Z` tag and reports `current` / `behind` (with `releases_behind` + the refresh command) / `ahead` / `unknown` (offline). Surfaced through `governance kit update --check-upstream` as a new `Upstream:` report row (`UPDATE_FLOW.md`), documented in **`governance/SKILL.md`** and **`governance/references/VERBS.md`**. It never fetches-and-applies — when behind it routes to the skill manager and stops.
+- (B) kit-plan helper makes the delta, reconstruction, and inventory reproducible — **`governance/assets/packs/lib/kitverb.py`** `kit-plan` resolves the recorded/reconstructed `installed_kit_version`, the version `delta`, and the managed-file inventory (marker state + plan-status hint) as one pure JSON-emitting call. `UPDATE_FLOW.md` Steps 1–3 now consume it instead of the hand-assembled bash arrays + min-reduction the consumer previously ran by hand. The apply primitives (`stamp_managed_marker`, `generate_hooks_for_strategy`, `write_installed_manifest`) are unchanged — only the fragile *plan* computation moved into a tested helper.
+- (C) document AGENT_ISSUE for HEREDOC commits in the kit update flow — **`governance/references/UPDATE_FLOW.md`** Step 7 now prefixes the commit with `AGENT_ISSUE='#N'` and explains why (the accounting hooks read the subject from `git`'s argv, which a HEREDOC commit doesn't populate), explicitly noting this is not a regex mismatch with `commit-message-format`.
+- re-pin the stale up-to-date-repo eval fixture to KIT_VERSION, with a drift guard — **`governance/evals/kit-update/files/up-to-date-repo/.governance/install.yaml`** + **`README.md`** re-pinned to the kit's current `KIT_VERSION` (was `0.3`, README said `0.2`); the eval-2 narrative is now version-agnostic, and **`scripts/test-kitverb.py`** adds a guard asserting the fixture pin equals `KIT_VERSION` so the next kit bump fails loudly instead of rotting. New test layer wired into **`scripts/test.sh`**.
 
 ## Out of scope
 
@@ -28,6 +34,9 @@ Closes [#170](https://github.com/Duaility/governance-kit/issues/170).
 
 - `bash packs/core/directives/version-consistency/evals/test.sh` → all cases pass, including the new "single-quoted pin" case. Confirmed the case fails against the pre-fix parser.
 - Parser checked directly on both GNU `sed` and macOS BSD `/usr/bin/sed` under bash 3.2 for single-quoted, double-quoted, and unquoted `kit_version` (all yield the bare value).
+- `bash scripts/test.sh` clean — all kit-internal layers pass, including the new `test-kitverb.py` (16 cases: kit-plan delta/reconstruction/inventory, the upstream tag-parse/status helpers, and the up-to-date-fixture drift guard).
+- `kit-plan` run against all six `governance/evals/kit-update/files/*` fixtures yields the expected `delta` for each (forward / up-to-date / downgrade / pre-tracking / no-recoverable-pin / reconstructed).
+- `kit-upstream` smoke against the live repo returns `current` (latest published `kit/v0.3.5` == installed); a bad `--repo` degrades to `unknown` without blocking.
 
 ## Decisions
 

--- a/receipts/issue-170-kit-update-staleness.md
+++ b/receipts/issue-170-kit-update-staleness.md
@@ -1,0 +1,35 @@
+# issue-170 — `kit update` reports "up-to-date" against a stale skill; version-consistency single-quote bug; flow reproducibility
+
+Closes [#170](https://github.com/Duaility/governance-kit/issues/170).
+
+`governance kit update` resolves "the latest kit version" only from the locally installed skill (`packctl.py kit-version` → `kit.yaml`). When the installed skill is itself behind the published kit, the verb confidently reports `kit: up-to-date` and exits — the single most confusing failure mode of a routine "pull the latest kit", because everything *looks* current. This issue addresses that headline problem plus three separable findings filed alongside it (A: a single-quote parser bug in `version-consistency`; B: no reproducible driver for the hand-executed flow; C: a claimed anchor-inference/`commit-message-format` regex mismatch).
+
+## Checklist
+
+- [x] (A) version-consistency accepts single-quoted kit_version, with a regression eval
+- [ ] (1) up-to-date report names its provenance and points at refreshing the skill
+- [ ] (2) opt-in check-upstream reports how far behind the installed skill is, signal-only
+- [ ] (B) kit-plan helper makes the delta, reconstruction, and inventory reproducible
+- [ ] (C) document AGENT_ISSUE for HEREDOC commits in the kit update flow
+- [ ] re-pin the stale up-to-date-repo eval fixture to KIT_VERSION, with a drift guard
+- [ ] bash scripts/test.sh clean
+
+## What changed
+
+- (A) version-consistency accepts single-quoted kit_version, with a regression eval — **`packs/core/directives/version-consistency/check.sh`**: `manifest_field()`'s `sed` stripped only `"`, so a manifest pinning `kit_version: '0.3'` (the form older `init` emitted; the current writer uses double quotes, and there is no migration) left the single quotes in the captured value. `expected` became `'0.3'` and never matched a bare `kit-version=0.3` marker — every managed file then failed with a `… is stamped kit-version=0.3 but … pins kit_version='0.3'` violation whose two values look identical in the rendered error. The parser now accepts either quote style (`['\"]?…[^'\"#[:space:]]*…['\"]?`, verified on GNU + BSD `sed`), and the violation message quotes both values so any residual quote/whitespace mismatch is visible. **`packs/core/directives/version-consistency/evals/test.sh`** gains a "single-quoted pin" case that rewrites the fixture manifest to `kit_version: '<v>'` and asserts the check still passes (it failed before the fix).
+
+## Out of scope
+
+- **The AGENT_ISSUE-for-HEREDOC heads-up in the other flow docs.** `INIT_FLOW.md`, `RESET_FLOW.md`, `UNINSTALL_FLOW.md`, and `DIRECTIVE_AMEND_FLOW.md` all instruct HEREDOC commits without the `AGENT_ISSUE='#N'` note that finding C adds to `UPDATE_FLOW.md`. The same gap applies, but this issue is scoped to the `kit update` flow; the systemic doc sweep is a separate change.
+- **A monolithic `kit update` apply driver.** Finding B's broadest reading is a single entry point that also performs the diff-before-exec, the per-file confirmation, and the apply (`cp` + stamp + hook-regen + manifest write). That contradicts the kit's architecture (granular pure helpers + prose orchestration, as in `packverb.py`) and would re-implement a large interactive surface. The apply primitives already exist as helpers; only the *plan* computation was fragile, so that is what `kit-plan` covers.
+- **Auto-fetch-and-apply of a newer kit inside `kit update`.** `--check-upstream` is signal-only. Pulling a newer kit onto the machine stays the skill manager's job (`npx skills update governance --global`): a self-fetching verb would make the running flow apply assets/manifest contracts it predates (silent version skew) and bypass the skill manager's pinned, lock-verified install path.
+
+## Verification
+
+- `bash packs/core/directives/version-consistency/evals/test.sh` → all cases pass, including the new "single-quoted pin" case. Confirmed the case fails against the pre-fix parser.
+- Parser checked directly on both GNU `sed` and macOS BSD `/usr/bin/sed` under bash 3.2 for single-quoted, double-quoted, and unquoted `kit_version` (all yield the bare value).
+
+## Decisions
+
+- **(C) is a misdiagnosis, fixed as documentation, not code.** The issue claims the steering populator's anchor regex disagrees with `commit-message-format`. It does not: `\(#([1-9][0-9]*)\)` matches `… (+packs) (#232)` on bash 3.2 (verified empirically), and `commit-message-format`'s `HEADER_RE` accepts the same subject. The real cause is that the accounting pre-commit hooks recover the subject from `git`'s argv, and a HEREDOC/`-F` commit puts no subject there — so inference legitimately can't see it and asks for `AGENT_ISSUE`. So the fix is to document `AGENT_ISSUE='#N'` in Step 7 and correct the framing, not to touch any regex.
+- **Re-pinning the `up-to-date-repo` fixture is a necessary, in-scope side effect.** `scripts/release.sh` deliberately skips `governance/evals/*`, so the kit's 0.3 → 0.3.5 bump silently left that fixture pinned at 0.3 (its README even said 0.2). Eval 2's "up-to-date" case had therefore become a forward update — incoherent with finding 1, which targets the up-to-date branch. Re-pinned to track `KIT_VERSION`, made the narrative version-agnostic, and added a `test-kitverb.py` drift guard so the next bump fails loudly instead of rotting.

--- a/scripts/test-kitverb.py
+++ b/scripts/test-kitverb.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Contract tests for kitverb.py — the `kit-plan` deterministic core.
+
+Covers the version-delta resolution, manifest reconstruction, and the
+managed-file inventory/status logic that UPDATE_FLOW.md Steps 1–3 depend on
+(issue #170, finding B), plus a drift guard that fails loudly if the
+up-to-date eval fixture stops matching the kit's KIT_VERSION (the latent rot
+that turned eval 2's up-to-date case into a forward update once the kit bumped
+0.3 → 0.3.5).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_LIB = ROOT / "governance" / "assets" / "packs" / "lib"
+KITVERB_PATH = PACK_LIB / "kitverb.py"
+
+
+def load_kitverb():
+    sys.path.insert(0, str(PACK_LIB))
+    spec = importlib.util.spec_from_file_location("kitverb_under_test", KITVERB_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load {KITVERB_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+KITVERB = load_kitverb()
+KIT_VERSION = KITVERB.KIT_VERSION
+OLDER = "0.0.1"          # always below any real kit version
+NEWER = "999.0"          # always above
+
+
+def kit_plan(root: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(KITVERB_PATH), "kit-plan", str(root)],
+        cwd=ROOT, check=False, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, f"kit-plan failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _marked(version: str | None) -> str:
+    """A managed runtime file: shebang + marker on line 2 (versioned or bare)."""
+    marker = "# governance-kit:managed"
+    if version is not None:
+        marker += f" kit-version={version}"
+    return f"#!/usr/bin/env bash\n{marker}\nplaceholder\n"
+
+
+def make_repo(tmp: Path, *, manifest: str | None, files: dict[str, str] | None = None) -> Path:
+    root = Path(tmp)
+    (root / ".governance").mkdir(parents=True, exist_ok=True)
+    if manifest is not None:
+        (root / ".governance" / "install.yaml").write_text(manifest)
+    for rel, content in (files or {}).items():
+        dest = root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+    return root
+
+
+BASE_MANIFEST = (
+    'version: "3"\n'
+    "tests_dir: .governance\n"
+    "ci_workflow: .github/workflows/governance.yml\n"
+    "enable_governance_script: scripts/enable-governance.sh\n"
+    "hook_strategy: githooks\n"
+)
+
+
+def test_delta_forward_when_installed_below_kit() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f'kit_version: "{OLDER}"\n')
+        plan = kit_plan(root)
+        assert plan["delta"] == "forward"
+        assert plan["installed_kit_version"] == OLDER
+        assert plan["manifest_source"] == "install.yaml"
+
+
+def test_delta_up_to_date_when_installed_equals_kit() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f'kit_version: "{KIT_VERSION}"\n')
+        assert kit_plan(root)["delta"] == "up-to-date"
+
+
+def test_delta_downgrade_when_installed_above_kit() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f'kit_version: "{NEWER}"\n')
+        assert kit_plan(root)["delta"] == "downgrade"
+
+
+def test_pre_tracking_when_manifest_present_without_kit_version() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST)  # no kit_version line
+        plan = kit_plan(root)
+        assert plan["delta"] == "pre-tracking"
+        assert plan["installed_kit_version"] is None
+
+
+def test_no_recoverable_pin_when_no_manifest_and_no_markers() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        # No manifest; runtime files carry only the bare marker (no kit-version=).
+        root = make_repo(tmp, manifest=None, files={
+            ".governance/run.sh": _marked(None),
+            ".governance/lib.sh": _marked(None),
+        })
+        plan = kit_plan(root)
+        assert plan["delta"] == "no-recoverable-pin"
+        assert plan["manifest_source"] == "absent"
+
+
+def test_reconstruct_takes_min_of_markers_when_manifest_absent() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=None, files={
+            ".governance/run.sh": _marked("0.2"),
+            ".governance/lib.sh": _marked("0.1"),       # min → reconstructed pin
+        })
+        plan = kit_plan(root)
+        assert plan["manifest_source"] == "reconstructed"
+        assert plan["installed_kit_version"] == "0.1"
+        assert plan["delta"] == "forward"
+        assert set(plan["reconstructed_from"]) == {".governance/run.sh", ".governance/lib.sh"}
+
+
+def test_single_quoted_kit_version_is_read() -> None:
+    # Robustness mirror of finding A: older-init repos single-quote the pin.
+    # The Python reader uses a real YAML parser, so both quote styles work.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f"kit_version: '{KIT_VERSION}'\n")
+        assert kit_plan(root)["installed_kit_version"] == KIT_VERSION
+
+
+def test_inventory_status_hints() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f'kit_version: "{OLDER}"\n', files={
+            ".governance/run.sh": _marked(KIT_VERSION),        # versioned == kit → skip
+            ".governance/lib.sh": _marked(OLDER),              # versioned older → apply
+            ".github/workflows/governance.yml": _marked(None),  # bare marker → apply
+            "scripts/enable-governance.sh": "#!/usr/bin/env bash\nno marker here\n",  # → unmanaged
+        })
+        files = {f["key"]: f for f in kit_plan(root)["files"]}
+        assert files["run.sh"]["status"] == "skip"
+        assert files["lib.sh"]["status"] == "apply"
+        assert files["ci_workflow"]["status"] == "apply"
+        assert files["enable_governance_script"]["status"] == "unmanaged"
+
+
+def test_inventory_status_add_when_dest_missing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, manifest=BASE_MANIFEST + f'kit_version: "{OLDER}"\n')  # no files
+        files = {f["key"]: f for f in kit_plan(root)["files"]}
+        assert files["run.sh"]["status"] == "add"
+        assert files["run.sh"]["exists"] is False
+
+
+SAMPLE_LS_REMOTE = "\n".join([
+    "a1b2c3\trefs/tags/kit/v0.3.5",
+    "d4e5f6\trefs/tags/kit/v0.4.0",
+    "d4e5f6\trefs/tags/kit/v0.4.0^{}",     # annotated-tag deref duplicate
+    "778899\trefs/tags/kit/v0.4.1",
+    "aabbcc\trefs/tags/core/v0.4.0",        # non-kit axis — ignored
+    "ddeeff\trefs/heads/main",              # non-tag — ignored
+])
+
+
+def test_parse_kit_tags_extracts_dedupes_and_filters() -> None:
+    assert KITVERB.parse_kit_tags(SAMPLE_LS_REMOTE) == ["0.3.5", "0.4.0", "0.4.1"]
+
+
+def test_parse_kit_tags_empty_when_no_kit_tags() -> None:
+    assert KITVERB.parse_kit_tags("aabbcc\trefs/tags/core/v0.4.0\n") == []
+
+
+def test_upstream_status_behind_counts_newer_releases() -> None:
+    st = KITVERB.upstream_status(["0.3.5", "0.4.0", "0.4.1"], "0.3.5")
+    assert st["status"] == "behind"
+    assert st["latest_published"] == "0.4.1"
+    assert st["releases_behind"] == 2
+
+
+def test_upstream_status_current_when_installed_is_latest() -> None:
+    st = KITVERB.upstream_status(["0.3.5", "0.4.0", "0.4.1"], "0.4.1")
+    assert st["status"] == "current"
+    assert st["releases_behind"] == 0
+
+
+def test_upstream_status_ahead_when_installed_above_latest() -> None:
+    st = KITVERB.upstream_status(["0.3.5", "0.4.0"], "0.9.0")
+    assert st["status"] == "ahead"
+    assert st["releases_behind"] == 0
+
+
+def test_upstream_status_unknown_when_no_published_tags() -> None:
+    st = KITVERB.upstream_status([], "0.3.5")
+    assert st["status"] == "unknown"
+    assert st["latest_published"] is None
+
+
+def test_up_to_date_fixture_pin_tracks_kit_version() -> None:
+    # Drift guard: scripts/release.sh skips governance/evals/*, so a kit bump
+    # that forgets this fixture silently turns eval 2's up-to-date case into a
+    # forward update. Keep the pin equal to the kit's KIT_VERSION.
+    import yaml  # noqa: PLC0415 - test-only dep, provided by the suite runner.
+    fixture = ROOT / "governance/evals/kit-update/files/up-to-date-repo/.governance/install.yaml"
+    pin = yaml.safe_load(fixture.read_text())["kit_version"]
+    assert str(pin) == KIT_VERSION, (
+        f"up-to-date fixture pins kit_version={pin!r} but the kit is {KIT_VERSION!r} — "
+        "re-pin governance/evals/kit-update/files/up-to-date-repo/ to match a kit release"
+    )
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 - tiny stdlib-only harness.
+            failures += 1
+            print(f"not ok - {name}: {exc}", file=sys.stderr)
+        else:
+            print(f"ok - {name}")
+    raise SystemExit(1 if failures else 0)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,6 +7,8 @@
 # Layers:
 #   1. test-packctl.py        — packctl.py library + CLI (preset, validation)
 #   2. test-packverb.py       — packverb.py (refs, capability glob, lockfile, catalog)
+#   2b. test-kitverb.py       — kitverb.py (kit-plan: version delta, manifest
+#                               reconstruction, managed-file inventory/status)
 #   3. test-install-sh.sh     — install.sh helpers (copy_tree_without_evals,
 #                               install_directive_folder, install_directive_assets,
 #                               write_installed_manifest flag matrix)
@@ -59,6 +61,10 @@ run_layer "packctl: validate_pack_dir matrix (Python)" \
 run_layer "packverb (Python)" \
     uv run --quiet --isolated --with PyYAML python "$ROOT/scripts/test-packverb.py" \
     || failed_layers+=("test-packverb.py")
+
+run_layer "kitverb: kit-plan delta/reconstruction/inventory (Python)" \
+    uv run --quiet --isolated --with PyYAML python "$ROOT/scripts/test-kitverb.py" \
+    || failed_layers+=("test-kitverb.py")
 
 run_layer "install.sh helpers (bash)" \
     bash "$ROOT/scripts/test-install-sh.sh" \


### PR DESCRIPTION
Closes #170.

`governance kit update` resolved "the latest kit version" only from the locally installed skill, so a stale skill made the verb confidently report `kit: up-to-date` while a newer kit existed upstream — the issue's headline failure mode. This PR makes that boundary legible and the flow's mechanics reproducible, and clears the three findings filed alongside it.

### Two commits

**1. `fix(governance): accept single-quoted kit_version in version-consistency`** (finding A)
`version-consistency`'s `manifest_field()` stripped only double quotes, so an older-`init` repo pinning `kit_version: '0.3'` produced a self-equal-looking violation. Now accepts either quote style (verified on GNU + BSD `sed`) and quotes both values in the message. + regression eval.

**2. `feat(governance): kit-plan + upstream staleness check for kit update`** (findings 1, B, C + option 2)
- **Headline (1):** the up-to-date report now names that the verdict is relative to the *installed skill*, not the published kit, and points at `npx skills update governance --global`.
- **`kit-plan` (B):** a pure, tested helper (`kitverb.py`) that resolves the version delta, reconstructs the pin from markers, and builds the managed-file inventory as JSON. `UPDATE_FLOW.md` Steps 1–3 consume it instead of hand-assembled bash — no new monolithic driver; the apply primitives already exist.
- **`--check-upstream` (option 2):** opt-in, read-only `git ls-remote` reporting how far behind the installed skill is. **Signal-only** — never fetches-and-applies; routes to the skill manager. Avoids making the running flow apply a kit it predates and avoids bypassing the skill manager's pinned install path.
- **Finding C** turned out to be a misdiagnosis: the anchor regex *does* accept `… (+packs) (#N)`. The real gap is that HEREDOC commits leave no subject in `git`'s argv, so `UPDATE_FLOW.md` Step 7 now documents `AGENT_ISSUE='#N'`.
- Re-pinned the stale `up-to-date-repo` eval fixture to `KIT_VERSION` (it had silently become a forward case) + a drift-guard test.

### Verification
- `bash .governance/run.sh` → all 17 directives pass.
- `bash scripts/test.sh` clean, including the new `test-kitverb.py` (16 cases).
- `kit-plan` verified against all six eval fixtures; `kit-upstream` smoke returns `current` against the live repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)