### PR TITLE
ci: harden CI supply-chain hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot keeps the SHA-pinned GitHub Actions and the docs-site npm
+# dependencies current, with an auditable PR per bump. Grouped weekly so the
+# update churn lands in one reviewable PR per ecosystem instead of many.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      docs-site:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "24"
       - run: npm install --no-audit --no-fund
@@ -49,7 +49,7 @@ jobs:
         env:
           DOCS_SITE_BASE_PATH: ${{ env.BASE_PATH }}
           DOCS_SITE_CANONICAL_ORIGIN: ${{ env.ORIGIN }}
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: dist/docs-site
 
@@ -67,4 +67,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+name: Scorecard supply-chain security
+
+# OpenSSF Scorecard — automated supply-chain posture scoring (branch
+# protection, pinned deps, token permissions, etc.). On-brand for a
+# governance/trust tool: we publish our own receipts. Results land in the
+# Security tab (code scanning) and, with publish_results, on the public
+# OpenSSF API for a badge.
+#
+# This workflow is kit-repo-only — NOT a template shipped to target repos.
+# The third-party `ossf/scorecard-action` is SHA-pinned per the
+# workflows-hardened directive; first-party actions are pinned too for
+# repo-wide consistency.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "32 5 * * 1" # weekly, Monday 05:32 UTC
+  push:
+    branches: [main]
+
+# Least-privilege by default; the analysis job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the OpenSSF API
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        with:
+          sarif_file: results.sarif

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default reviewer for every change. Pairs with the `main` branch-protection
+# ruleset's required-review rule. Refine with path-specific owners as the
+# maintainer set grows.
+* @srikanth235

--- a/COSTS.md
+++ b/COSTS.md
@@ -280,3 +280,4 @@ Schema:
 | claude-code-964ef924-112-1781159786 | claude-code | 964ef924-1120-46d6-88d3-46dd2fb93d5b | #186 | claude-opus-4-8 | 55985 | 723900 | 27624082 | 219560 | 999445 | 24.1053 |  |
 | claude-code-2210fdfa-283-1781162031 | claude-code | 2210fdfa-2833-4165-aafb-a1d00f764ac2 | #186 | claude-opus-4-8 | 5744 | 22058 | 32008 | 520 | 28322 | 0.1956 |  |
 | claude-code-964ef924-112-1781162130 | claude-code | 964ef924-1120-46d6-88d3-46dd2fb93d5b | #186 | claude-opus-4-8 | 17659 | 569132 | 4517922 | 18617 | 605408 | 6.3698 |  |
+| claude-code-defe3aa5-6ba-1781163360 | claude-code | defe3aa5-6ba2-4e45-977e-c4a5126bb758 | #188 | claude-opus-4-8 | 5744 | 25406 | 32008 | 670 | 31820 | 0.2203 | ci: harden CI supply-chain hygiene (#188) -m Layer GitHub-native supply-chain hy |

--- a/receipts/issue-188-ci-supply-chain-hardening.md
+++ b/receipts/issue-188-ci-supply-chain-hardening.md
@@ -1,0 +1,84 @@
+# Receipt: harden CI supply-chain hygiene (issue-188)
+
+Strengthen the repo's CI/supply-chain posture with GitHub-native hygiene,
+layered on top of what the `workflows-hardened` directive already enforces
+(third-party SHA-pinning + a `permissions:` block per workflow).
+
+## Checklist
+
+- [x] Pinned first-party actions to commit SHAs
+- [x] `.github/dependabot.yml`
+- [x] `CODEOWNERS`
+- [x] `.github/workflows/scorecard.yml`
+- [x] Live repo settings applied out-of-band
+
+## What changed
+
+- **Pinned first-party actions to commit SHAs** in `.github/workflows/docs.yml`:
+  `actions/checkout` (v4.3.1), `actions/setup-node` (v4.4.0),
+  `actions/upload-pages-artifact` (v3.0.1), `actions/deploy-pages` (v4.0.5).
+  `workflows-hardened` allowlists the `actions/*` namespace, so these were not
+  violations — but GitHub's hardening guidance recommends pinning even
+  first-party actions, and `release.yml` already pins `checkout`. This makes
+  SHA-pinning consistent across every workflow.
+- **`.github/dependabot.yml`** — `github-actions` and `npm` (docs-site)
+  ecosystems, weekly, grouped one-PR-per-ecosystem. Keeps the SHA pins current
+  with an auditable bump trail instead of by-hand updates.
+- **`CODEOWNERS`** — a default reviewer for every path, pairing with the new
+  `main` branch-protection ruleset's require-review rule.
+- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard analysis (weekly +
+  on push to `main` + on branch-protection changes). Publishes to code scanning
+  and the OpenSSF API. The third-party `ossf/scorecard-action` is SHA-pinned
+  (v2.4.3) per `workflows-hardened`; `actions/*` and `github/*` steps are pinned
+  too. Top-level `permissions: read-all`; the job elevates only
+  `security-events: write` + `id-token: write`.
+- **Live repo settings applied out-of-band** (branch-protection ruleset,
+  squash-only merges, secret scanning + push protection, private vulnerability
+  reporting, Dependabot alerts) are detailed in the next section for the audit
+  trail.
+
+## Applied out-of-band (live repo settings, not via this PR)
+
+These are repository settings, applied through `gh api` / `gh repo edit`, and
+are recorded here for the audit trail:
+
+- **Branch-protection ruleset on `main`** (id 17540529, active): require a PR
+  with at least one approval, passing status checks (`governance`, `tests`,
+  `Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (go)`),
+  linear history, no force-push or deletion. Admin role bypasses (`always`) so
+  the direct-to-main release flow via `scripts/release.sh` still works.
+- **Merge settings**: squash-only (merge-commit and rebase-merge disabled),
+  delete-branch-on-merge enabled. Protects the accounting trailers that a
+  merge-commit would strip.
+- **Secret scanning + push protection**, **private vulnerability reporting**,
+  and **Dependabot alerts** enabled.
+
+## Out of scope
+
+- **Build-provenance attestations** (`actions/attest-build-provenance`):
+  `release.yml` only publishes release notes lifted from `CHANGELOG.md` via the
+  `gh` CLI — it ships no built or uploaded artifact, so there is nothing to
+  attest. Revisit if releases ever produce binaries.
+- **Re-templating `scorecard.yml`/`dependabot.yml` into target repos**: these
+  harden this repo only; shipping them as `governance` init assets is a separate
+  feature, not this PR.
+
+## Decisions
+
+- **Pin first-party actions even though `workflows-hardened` allowlists them.**
+  Defense-in-depth: GitHub's own hardening guide recommends pinning all actions,
+  and the repo already half-did this. Consistency over a partial allowlist.
+- **No build-provenance now.** Attesting a non-existent artifact would be
+  ceremony, not provenance.
+- **Admin bypass on the ruleset.** Keeps the sanctioned direct-to-main release
+  path open while making green-PR-with-review the default for everyone else.
+
+## Verification
+
+```sh
+bash .governance/run.sh   # dogfood suite green, incl. workflows-hardened on the
+                          # pinned docs.yml + new scorecard.yml
+```
+
+GitHub Actions linting of the two new/edited workflows runs on this PR; the
+Scorecard workflow itself first executes after merge to `main`.


### PR DESCRIPTION
Closes #188.

Layers GitHub-native supply-chain hygiene on top of the `workflows-hardened` directive (which already enforces third-party SHA-pinning + `permissions:` blocks).

## Files in this PR
- **`docs.yml`** — pinned `actions/checkout`, `setup-node`, `upload-pages-artifact`, `deploy-pages` to commit SHAs. `workflows-hardened` allowlists `actions/*`, so these weren't violations, but GitHub's hardening guide recommends pinning all actions and `release.yml` already pins `checkout` — this makes it consistent.
- **`.github/dependabot.yml`** — `github-actions` + `npm` (docs site), weekly, grouped one-PR-per-ecosystem. Keeps the SHA pins fresh with an audit trail.
- **`CODEOWNERS`** — default reviewer, pairs with the new `main` ruleset's require-review rule.
- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard; third-party `ossf/scorecard-action` SHA-pinned per `workflows-hardened`, least-privilege permissions.

## Applied out-of-band (live repo settings, recorded in the receipt)
- Branch-protection ruleset on `main` (#17540529): require PR + approval + checks (`governance`, `tests`, `Analyze (python|javascript-typescript|go)`), linear history, no force-push; admin bypass so `scripts/release.sh` direct-to-main still works.
- Squash-only merges + delete-branch-on-merge.
- Secret scanning + push protection, private vulnerability reporting, Dependabot alerts.

## Deferred
- Build-provenance attestations — `release.yml` publishes only release notes (no artifact to attest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)