### PR TITLE
chore(governance): advance .governance kit pin v0.4.0 → v0.6.0 (#216)

### DIFF
--- a/.governance/install.yaml
+++ b/.governance/install.yaml
@@ -3,8 +3,8 @@ generated_at: 2026-04-30T00:00:00Z
 owner: duaility
 repo: governance-kit
 kit_version: "0.6.0"
-kit_ref: gh:duaility/governance-kit/governance@kit/v0.4.0
-kit_sha: c2680e0c15f222a26bde6a073ae9a1d541a828f7
+kit_ref: gh:duaility/governance-kit/kit@kit/v0.6.0
+kit_sha: adf959096dff0855c4743141d6c004453619277f
 hook_strategy: githooks
 constitution: true
 ci_workflow: .github/workflows/governance.yml

--- a/COSTS.md
+++ b/COSTS.md
@@ -322,3 +322,6 @@ Schema:
 | claude-code-8acdd4a1-71c-1781265411 | claude-code | 8acdd4a1-71c4-4383-92c9-50ec253cf5cc | #213 | claude-opus-4-8 | 393 | 2220 | 375165 | 1275 | 3888 | 0.2353 | chore(release): docs v0.2.0 → v0.2.1 -m governance: allow-commit-message-format  |
 | claude-code-8acdd4a1-71c-1781265509 | claude-code | 8acdd4a1-71c4-4383-92c9-50ec253cf5cc | #213 | claude-opus-4-8 | 16 | 4448 | 1011703 | 2799 | 7263 | 0.6037 | chore(release): commits v0.2.0 → v0.2.1 -m governance: allow-commit-message-form |
 | claude-code-8acdd4a1-71c-1781265606 | claude-code | 8acdd4a1-71c4-4383-92c9-50ec253cf5cc | #213 | claude-opus-4-8 | 0 | 0 | 0 | 0 | 0 | 0.0000 | chore(release): audit v0.2.0 → v0.3.0 -m governance: allow-commit-message-format |
+| claude-code-c51a7dd9-bcc-1781267431 | claude-code | c51a7dd9-bcc9-4f49-babc-55d0d5ab7beb | #216 | claude-opus-4-8 | 35594 | 281287 | 6197359 | 91048 | 407929 | 7.3109 |  |
+| claude-code-c51a7dd9-bcc-1781267601 | claude-code | c51a7dd9-bcc9-4f49-babc-55d0d5ab7beb | #216 | claude-opus-4-8 | 409 | 32329 | 1271201 | 17086 | 49824 | 1.2669 |  |
+| claude-code-c51a7dd9-bcc-1781267732 | claude-code | c51a7dd9-bcc9-4f49-babc-55d0d5ab7beb | #216 | claude-opus-4-8 | 12 | 20547 | 743022 | 10743 | 31302 | 0.7686 |  |

--- a/receipts/issue-216-advance-kit-pin-to-v0-6-0.md
+++ b/receipts/issue-216-advance-kit-pin-to-v0-6-0.md
@@ -1,0 +1,68 @@
+# issue-216 — advance .governance kit pin v0.4.0 → v0.6.0
+
+Closes #216.
+
+## Checklist
+
+- [x] Record corrected kit pin in install.yaml at kit/v0.6.0
+- [x] Confirm same-version up-to-date delta (no runtime file rewrites)
+- [x] Verify governance suite passes
+
+## What changed
+
+Ran `governance update` against the repo's pinned kit (the thin-shim →
+`bootstrap.py` → delegated-engine path). Resolution reported
+`direction: same` / `delta: up-to-date`: the runtime managed files
+(`run.sh`, `lib.sh`, the hook dispatcher) and `install.yaml`'s
+`kit_version` were already stamped `0.6.0` by the `kit/v0.6.0` release
+commits, so `kit-apply` rewrote nothing.
+
+The one stale value was the orchestration pin, corrected by the delegated
+`kit-pin` engine — **Record corrected kit pin in install.yaml at
+kit/v0.6.0**:
+
+- `kit_ref`: `gh:duaility/governance-kit/governance@kit/v0.4.0` →
+  `gh:duaility/governance-kit/kit@kit/v0.6.0` (also drops the
+  pre-thin-shim `governance@` path for the current `kit@` layout)
+- `kit_sha`: `c2680e0c15f222a26bde6a073ae9a1d541a828f7` →
+  `adf959096dff0855c4743141d6c004453619277f`
+
+`.governance/install.yaml` is the only file touched.
+
+## Out of scope
+
+Pack pins. `packs.lock` stays at `v0.2.0` for every bundled pack — the
+by-design Lane-1 one-release lag (foundation/docs/commits `v0.2.1`,
+audit `v0.3.0` were just published). A separate post-release
+`governance pack update` catches those up and re-materializes the
+vendored consumed tree; this change is the **kit axis only**.
+
+## Verification
+
+**Confirm same-version up-to-date delta (no runtime file rewrites)** — the
+delegated engine reported `up-to-date` and listed all four managed files
+under `skipped`:
+
+```sh
+uv run --quiet --isolated --with PyYAML python \
+  "$KIT_LIB/kitverb.py" kit-plan "$(pwd)"
+# delta: up-to-date; run.sh/lib.sh/ci_workflow/enable_governance_script → skip
+```
+
+**Verify governance suite passes** with the re-pinned manifest:
+
+```sh
+bash .governance/run.sh
+# ✓ governance: all 21 directive(s) passed
+```
+
+## Decisions
+
+- **Kit-axis only, by user direction.** Offered kit-pin-only vs.
+  `--with-packs`; the user chose kit pin only, so pack pins were left at
+  the Lane-1 lag rather than advanced in the same change.
+- **Same-version pin correction, not a forward update.** Because the
+  release commits had already re-stamped the runtime files to `0.6.0`,
+  the kit move resolved as `direction: same`. The fix is purely the
+  `kit_ref`/`kit_sha` record (`kit-pin`); no managed file changed, so no
+  `kit-version=` marker moved.


### PR DESCRIPTION
Closes #216.

## What changed

The committed `.governance/` (Lane 1) is an honest customer of the last release. The `kit/v0.6.0` release commits already re-stamped the runtime managed files (`run.sh`, `lib.sh`, hook dispatcher) and `install.yaml`'s `kit_version` to `0.6.0` — but the orchestration pin `kit_ref`/`kit_sha` was left on the pre-thin-shim `governance@kit/v0.4.0` (sha `c2680e0c`).

Ran `governance update` through the delegated engine (`kit-resolve` → `kit-apply` → `kit-pin`). It resolved `direction: same` / `delta: up-to-date`, so no runtime file was rewritten — the only change is the corrected pin in `.governance/install.yaml`:

- `kit_ref`: `gh:duaility/governance-kit/governance@kit/v0.4.0` → `gh:duaility/governance-kit/kit@kit/v0.6.0` (also drops the pre-thin-shim `governance@` path for the current `kit@` layout)
- `kit_sha`: `c2680e0c…` → `adf95909…`

`COSTS.md` carries the auto-populated token-accounting row for the commit.

## Scope

**Kit axis only.** Pack pins (`packs.lock` @ `v0.2.0`) stay at the by-design Lane-1 one-release lag — foundation/docs/commits `v0.2.1` and audit `v0.3.0` were just published; a separate `governance pack update` catches those up and re-materializes the vendored consumed tree.

## Reviewer notes

- The commit body carries a targeted `allow-doc-integrity CONSTITUTION.md` waiver for the known macOS Mode-A frozen-section `grep: out of memory` false-positive on the Evolution Log's large single-line entries. CONSTITUTION.md is untouched in this change; Mode-B `run.sh` passes clean.

## Verification

```sh
bash .governance/run.sh
# ✓ governance: all 21 directive(s) passed
```