### PR TITLE
fix(packs): seed the sweep lane on pack add, not just init (#223)

### DIFF
--- a/kit/assets/packs/lib/applylib.py
+++ b/kit/assets/packs/lib/applylib.py
@@ -17,11 +17,24 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
 LIB_DIR = Path(__file__).resolve().parent
+KIT_ASSETS = LIB_DIR.parents[1]  # kit/assets
+
+# The sweep lane's vendored assets (issue #142): kit-level files laid down into a
+# target repo whenever a `surface: sweep` directive is installed. Each value is
+# the path parts under KIT_ASSETS. This is the single source of truth, shared by
+# init-apply and pack-apply so the two install paths can never diverge — the
+# no-path-bifurcation invariant the sweep lane itself enforces.
+SWEEP_ASSETS = {
+    ".github/workflows/governance-sweep.yml": ("governance-sweep.yml",),
+    ".governance/sweep.py": ("dot-governance", "sweep.py"),
+}
 
 # Where each hook strategy lands its dispatchers — kept in sync with
 # hooks.sh `generate_hooks_for_strategy`.
@@ -97,6 +110,56 @@ def bash_lib(script: str, *argv: str, lib_dir: Path | None = None) -> subprocess
          "_", str(lib_dir or LIB_DIR), *argv],
         check=False, text=True, capture_output=True,
     )
+
+
+def selects_sweep_directive(packs: list[dict[str, Any]]) -> bool:
+    """True if any directive in `packs` declares `surface: sweep` (issue #142).
+
+    Reading the flat scalar `surface:` line directly keeps this stdlib-only (the
+    apply engines avoid PyYAML in the runtime path), and is enough — surface is a
+    flat scalar. `packs` entries carry `pack_dir` + a `directives` id list, the
+    shape both init-plan and pack-plan emit.
+    """
+    for pack in packs:
+        pack_dir = Path(pack["pack_dir"])
+        for did in pack.get("directives") or []:
+            y = pack_dir / "directives" / did / "directive.yaml"
+            if not y.is_file():
+                continue
+            for raw in y.read_text().splitlines():
+                if re.match(r'^\s*surface:\s*["\']?sweep["\']?\s*(#.*)?$', raw):
+                    return True
+    return False
+
+
+def pending_sweep_assets(root: Path, packs: list[dict[str, Any]]) -> list[str]:
+    """The sweep assets a `surface: sweep` install still needs to lay down — those
+    not already vendored. Empty when no sweep directive is selected, or when every
+    asset is already present (idempotent: a second sweep directive seeds nothing
+    new, and re-running over an existing lane is a no-op)."""
+    if not selects_sweep_directive(packs):
+        return []
+    return [rel for rel in SWEEP_ASSETS if not (root / rel).exists()]
+
+
+def seed_sweep_assets(root: Path, packs: list[dict[str, Any]], kit_version: str) -> list[str]:
+    """Lay down the sweep workflow + engine for a `surface: sweep` install,
+    stamped with `kit_version`, and return the rel paths actually seeded.
+
+    Shared by init-apply and pack-apply so the lane is vendored identically no
+    matter which verb installs the first sweep directive (issue #142). The caller
+    records the returned rels in install.yaml's `install_assets_seeded` ledger so
+    `governance uninstall` reverses them.
+    """
+    rels = pending_sweep_assets(root, packs)
+    for rel in rels:
+        dest = root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(KIT_ASSETS.joinpath(*SWEEP_ASSETS[rel]), dest)
+        bash_lib('stamp_managed_marker "$1" "$2"', str(dest), kit_version)
+        if dest.name == "sweep.py":
+            dest.chmod(0o755)
+    return rels
 
 
 def hook_digests(root: Path, strategy: str) -> dict[str, str]:

--- a/kit/assets/packs/lib/initapply.py
+++ b/kit/assets/packs/lib/initapply.py
@@ -25,13 +25,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
-from applylib import bash_lib, load_decisions, refuse, regen_hooks_step, smoke_test
+from applylib import bash_lib, load_decisions, refuse, regen_hooks_step, seed_sweep_assets, smoke_test
 from initplan import assemble_constitution, collisions
 from packctl import KIT_VERSION
 from packverb import load_lockfile, write_lockfile, _utc_now
@@ -43,24 +42,6 @@ def _copy_stamp(src: Path, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
     bash_lib('stamp_managed_marker "$1" "$2"', str(dest), KIT_VERSION)
-
-
-def _selects_sweep_directive(packs: list[dict[str, Any]]) -> bool:
-    """True if any selected directive declares `surface: sweep` (issue #142).
-
-    Reading the scalar `surface:` line directly keeps this stdlib-only (the engine
-    avoids PyYAML in the runtime path), and is enough — surface is a flat scalar.
-    """
-    for pack in packs:
-        pack_dir = Path(pack["pack_dir"])
-        for did in pack.get("directives") or []:
-            y = pack_dir / "directives" / did / "directive.yaml"
-            if not y.is_file():
-                continue
-            for raw in y.read_text().splitlines():
-                if re.match(r'^\s*surface:\s*["\']?sweep["\']?\s*(#.*)?$', raw):
-                    return True
-    return False
 
 
 def _install_directives(root: Path, packs: list[dict[str, Any]], report: dict[str, Any]) -> tuple[list[str], list[str], list[str]]:
@@ -224,15 +205,11 @@ def cmd_init_apply(args: argparse.Namespace) -> int:
         # lay down the scheduled workflow + the vendored engine so the lane runs
         # in plain CI with no skill and no secret. Both are recorded as seeded
         # assets so `governance uninstall` removes them with everything else.
-        if _selects_sweep_directive(packs):
-            _copy_stamp(KIT_ASSETS / "governance-sweep.yml",
-                        root / ".github" / "workflows" / "governance-sweep.yml")
-            _copy_stamp(KIT_ASSETS / "dot-governance" / "sweep.py", root / ".governance" / "sweep.py")
-            (root / ".governance" / "sweep.py").chmod(0o755)
-            seeded = sorted(set(seeded) | {
-                ".github/workflows/governance-sweep.yml",
-                ".governance/sweep.py",
-            })
+        # Shared with pack-apply via applylib.seed_sweep_assets so the two install
+        # paths vendor the lane identically (no path bifurcation).
+        sweep_rels = seed_sweep_assets(root, packs, KIT_VERSION)
+        if sweep_rels:
+            seeded = sorted(set(seeded) | set(sweep_rels))
             report["seeded_assets"] = seeded
 
         # Hooks + Path-A onboarding.

--- a/kit/assets/packs/lib/packapply.py
+++ b/kit/assets/packs/lib/packapply.py
@@ -41,8 +41,10 @@ from applylib import (
     bash_lib,
     dirty_gate,
     load_decisions,
+    pending_sweep_assets,
     refuse,
     regen_hooks_step,
+    seed_sweep_assets,
     smoke_test,
 )
 from packctl import KIT_VERSION
@@ -119,6 +121,10 @@ def _gate_add_update(plan: dict[str, Any], report: dict[str, Any]) -> int | None
 def _apply_add_update(root: Path, plan: dict[str, Any], decisions: dict[str, str],
                       report: dict[str, Any], dry_run: bool) -> int:
     manifest_path = root / ".governance" / "install.yaml"
+    # Directives actually installed this run (post-decisions), in plan shape, so
+    # the sweep-lane seeding below sees only what really landed — a held-back
+    # sweep directive must not pull in the workflow + engine.
+    applied_for_sweep: list[dict[str, Any]] = []
 
     # up-to-date no-op: every pack's SHA already matches (update mode).
     if plan["mode"] == "update" and all(p.get("action") in ("skip",) for p in plan["packs"]):
@@ -167,6 +173,7 @@ def _apply_add_update(root: Path, plan: dict[str, Any], decisions: dict[str, str
                 return 1
         if not installed_dids:
             continue
+        applied_for_sweep.append({"pack_dir": str(pack_dir), "directives": installed_dids})
         if not dry_run:
             _append_install_assets_seeded(manifest_path, sorted(set(seeded)))
         report["seeded_assets"].extend(sorted(set(seeded)))
@@ -179,6 +186,19 @@ def _apply_add_update(root: Path, plan: dict[str, Any], decisions: dict[str, str
         if not dry_run:
             _lock_upsert(root / ".governance" / "packs.lock", lock_entry)
         report["lock"].append({"id": pack["id"], "sha": pack["sha"], "directives": sorted(installed_dids)})
+
+    # Sweep lane (issue #142): the workflow + engine are kit-level assets, seeded
+    # the moment a `surface: sweep` directive is installed — by init or, now, by
+    # pack add (the parity gap this fixes). Done once after the directive loop
+    # (the assets are kit-level, not per-pack) via the shared helper init uses,
+    # and recorded in the seeded ledger so `governance uninstall` reverses them.
+    if dry_run:
+        report["seeded_assets"].extend(pending_sweep_assets(root, applied_for_sweep))
+    else:
+        sweep_rels = seed_sweep_assets(root, applied_for_sweep, KIT_VERSION)
+        if sweep_rels:
+            _append_install_assets_seeded(manifest_path, sweep_rels)
+            report["seeded_assets"].extend(sweep_rels)
 
     return _finish(root, plan, report, dry_run)
 

--- a/receipts/issue-223.md
+++ b/receipts/issue-223.md
@@ -1,0 +1,19 @@
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Steering
+
+| steer-key | session | issue | type | tier | user-reason | commit |
+| --- | --- | --- | --- | --- | --- | --- |
+| steer-26e113fdac2-1781278982-1 | 26e113fd-ac20-48cd-a283-29c811470091 | #223 | interrupt | structural |  | fix(packs): seed the sweep lane on pack add, not just init (#223) |
+| steer-26e113fdac2-1781278982-2 | 26e113fd-ac20-48cd-a283-29c811470091 | #223 | correction | classifier | Agent bypassed the required receipt step; user insists it always be added | fix(packs): seed the sweep lane on pack add, not just init (#223) |
+| steer-26e113fdac2-1781278982-3 | 26e113fd-ac20-48cd-a283-29c811470091 | #223 | interrupt | structural |  | fix(packs): seed the sweep lane on pack add, not just init (#223) |
+| steer-26e113fdac2-1781278982-4 | 26e113fd-ac20-48cd-a283-29c811470091 | #223 | interrupt | structural |  | fix(packs): seed the sweep lane on pack add, not just init (#223) |
+| steer-26e113fdac2-1781278982-5 | 26e113fd-ac20-48cd-a283-29c811470091 | #223 | interrupt | structural |  | fix(packs): seed the sweep lane on pack add, not just init (#223) |
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-b413d5b2-217-1781278983-1 | claude-code | b413d5b2-2174-4545-b2a4-4a002f67b4e0 | #223 | claude-opus-4-8 | 2581 | 13190 | 16008 | 22 | 15793 | 0.1039 | fix(packs): seed the sweep lane on pack add, not just init (#223) |

--- a/scripts/test-packverb-apply.py
+++ b/scripts/test-packverb-apply.py
@@ -94,6 +94,27 @@ def _write_source_pack(base: Path, pack_id: str = "acme/widgets") -> Path:
     return pack
 
 
+def _write_sweep_source_pack(base: Path, pack_id: str = "acme/shape", did: str = "no-shims") -> Path:
+    """A minimal valid `surface: sweep` source pack (triage.sh, not check.sh)."""
+    pack = base / "shape"
+    ddir = pack / "directives" / did
+    (ddir / "evals").mkdir(parents=True)
+    (pack / "pack.yaml").write_text(
+        f"id: {pack_id}\nname: Shape\nversion: \"0.1\"\nmin_governance_kit: \"0.0.1\"\n"
+        "description: test\nauthor: acme\nsource: gh\n")
+    (ddir / "directive.yaml").write_text(
+        "category: ArchitecturalShape\nrecommended: false\nsummary: no shims.\n"
+        "surface: sweep\nhook: none\nengine: llm\nmodel_tier: high\n")
+    (ddir / "triage.sh").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (ddir / "constitution.md").write_text(
+        f"### {did}\n\n- **Directive**: no shims.\n"
+        f"- **Enforced by**: `.governance/packs/{pack_id}/directives/{did}/triage.sh`\n")
+    (ddir / "evals" / "test.sh").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (ddir / "triage.sh").chmod(0o755)
+    (ddir / "evals" / "test.sh").chmod(0o755)
+    return pack
+
+
 def _make_repo(tmp: Path, *, constitution: str | None = None,
                lock: str | None = None, installed_directive: str | None = None) -> Path:
     root = Path(tmp)
@@ -310,6 +331,47 @@ def test_add_held_back_directive_via_decisions() -> None:
         assert rc == 0, report
         assert report["held_back"] == ["no-console-log"]
         assert not (root / ".governance/packs/acme/widgets").exists()
+
+
+def test_add_vendors_sweep_lane() -> None:
+    # issue #142 parity: `pack add` of a `surface: sweep` directive must lay down
+    # the kit-level sweep workflow + engine and ledger them — exactly as init
+    # does — so the lane is dispatchable when added to an already-initialized
+    # repo. (Before this fix, only init seeded them; pack add left them missing.)
+    with tempfile.TemporaryDirectory() as tmp:
+        src = _write_sweep_source_pack(Path(tmp) / "src")
+        root = _make_repo(Path(tmp) / "repo")
+        packplan.fetch_ref = _stub_fetch(src, "acme/shape", "c" * 40)
+        rc, report = _capture(lambda: packapply.cmd_pack_apply(
+            _ns(mode="add", root=str(root), target="gh:acme/shape")))
+        assert rc == 0 and report["result"] == "applied", report
+        wf = root / ".github/workflows/governance-sweep.yml"
+        eng = root / ".governance/sweep.py"
+        assert wf.is_file() and "kit-version=" in wf.read_text().splitlines()[0]
+        assert eng.is_file() and "kit-version=" in eng.read_text().splitlines()[1]
+        assert os.access(eng, os.X_OK)
+        assert ".github/workflows/governance-sweep.yml" in report["seeded_assets"]
+        assert ".governance/sweep.py" in report["seeded_assets"]
+        ledger = (root / ".governance/install.yaml").read_text()
+        assert ".governance/sweep.py" in ledger
+        assert ".github/workflows/governance-sweep.yml" in ledger
+
+
+def test_add_held_back_sweep_directive_seeds_no_lane() -> None:
+    # The lane is keyed to what actually installs: a held-back sweep directive
+    # must NOT pull in the workflow + engine.
+    with tempfile.TemporaryDirectory() as tmp:
+        src = _write_sweep_source_pack(Path(tmp) / "src")
+        root = _make_repo(Path(tmp) / "repo")
+        packplan.fetch_ref = _stub_fetch(src, "acme/shape", "c" * 40)
+        rc, report = _capture(lambda: packapply.cmd_pack_apply(
+            _ns(mode="add", root=str(root), target="gh:acme/shape",
+                decisions='{"no-shims": "skip"}')))
+        assert rc == 0, report
+        assert report["held_back"] == ["no-shims"]
+        assert not (root / ".governance/sweep.py").exists()
+        assert not (root / ".github/workflows/governance-sweep.yml").exists()
+        assert report["seeded_assets"] == []
 
 
 # --- pack-apply: remove (offline, via CLI) ----------------------------------


### PR DESCRIPTION
Closes #223.

`governance pack add` of a `surface: sweep` directive installed the directives + lock pin but did **not** seed the kit-level sweep assets (`.governance/sweep.py`, `.github/workflows/governance-sweep.yml`) — that logic lived only in `initapply`. So adding a sweep directive to an already-initialized repo left the lane inert (no engine, no workflow for CI). Surfaced while installing the architecture pack (#222): `seeded_assets: []`.

## Change
- New shared `applylib.seed_sweep_assets` (+ `pending_sweep_assets`, `selects_sweep_directive`) owning the single `SWEEP_ASSETS` map.
- `initapply` and `packapply` both call it — one seeding path, no bifurcation (the very invariant the sweep lane enforces).
- Idempotent; ledgered in `install_assets_seeded` (uninstall reverses); respects `--decisions skip`.
- Tests: `test_add_vendors_sweep_lane` + `test_add_held_back_sweep_directive_seeds_no_lane`, mirroring `test_init_apply_vendors_sweep_lane`.

Needs a kit release (v0.8.0) to reach consumers; unblocks #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)