### PR TITLE
chore(governance): resync kit v0.7.2 and backfill architecture CONSTITUTION subsections (#231)

### DIFF
--- a/.governance/install.yaml
+++ b/.governance/install.yaml
@@ -3,8 +3,8 @@ generated_at: 2026-04-30T00:00:00Z
 owner: duaility
 repo: governance-kit
 kit_version: "0.7.2"
-kit_ref: gh:duaility/governance-kit/kit@kit/v0.7.1
-kit_sha: 260cd4d73a3a0ab6d9c2285d1cfe01c77231b675
+kit_ref: gh:duaility/governance-kit/kit@kit/v0.7.2
+kit_sha: f4d8b23c7c890c9a2323d2e3b98156a8cc33a6fc
 hook_strategy: githooks
 constitution: true
 ci_workflow: .github/workflows/governance.yml

--- a/.governance/packs.lock
+++ b/.governance/packs.lock
@@ -15,7 +15,7 @@ packs:
   sha: bfe847bcbffa30f60f5b74603015ba990b6cab01
   subpath: packs/architecture
   min_governance_kit: '0.3'
-  installed_at: '2026-06-12T15:53:53Z'
+  installed_at: '2026-06-12T16:48:59Z'
   directives:
   - no-legacy-fallbacks
   - no-path-bifurcation

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -27,6 +27,20 @@ If a specific change cannot satisfy a directive, document the deviation in the P
 
 Directives are grouped by the pack that ships them — the constitution displays the same `<owner>/<pack>` namespace the directives install into.
 
+### no-legacy-fallbacks
+
+- **Directive**: A change must not introduce backward-compatibility shims or legacy fallback paths. When behaviour changes, change it — do not keep the old path alive behind a version check, a feature flag, a `try/except ImportError`, a `getattr(obj, "new", obj.old)`, or a "for backward compatibility" branch. Migrate callers; delete the old path in the same change.
+- **Rationale**: This is the single most-repeated human correction to agent-authored code. The model's prior is to preserve the old behaviour "just in case," so it regenerates the fallback every time a one-off fix is applied. Each retained shim is a second code path that must be tested, reasoned about, and eventually removed — and the removal never comes. In a V0 codebase with no stability promise, a legacy fallback is pure carrying cost. This invariant is about *intent*, not syntax, so grep cannot enforce it: a fallback can be written without any tell-tale identifier, and an innocent word like "compatible" is not one. It is adjudicated by the LLM-judge sweep, off the commit path.
+- **Enforced by**: `.governance/packs/governance-kit/architecture/directives/no-legacy-fallbacks/triage.sh` (candidate triage) → the sweep engine (`.governance/sweep.py`) adjudicates each candidate hunk against this rubric and reports findings in the daily `governance-sweep` digest issue. This directive never blocks a commit, a push, or a PR.
+- **Exceptions**: A fallback genuinely required by an external contract (a public API consumed by code outside this repo, a documented deprecation window) is legitimate — say so in the code with a comment that names *what* it is compatible with and *until when*, so the absence of justification is itself the signal. A Chesterton's-fence retention with no stated reason is exactly what this directive exists to surface.
+
+### no-path-bifurcation
+
+- **Directive**: A change must not bifurcate a code path that should be unified. Do not introduce parallel implementations of the same operation — dual dispatch (an `if transport == "ipc" … elif "http"` fork), a local-only fast path that special-cases what the remote path does generally, or a "local must mirror remote" behaviour that quietly diverges. One operation, one path: branch on data, not on a second copy of the logic.
+- **Rationale**: "Don't bifurcate — unify the path" and "local must mirror remote — no local-only special-casing" are recurring human corrections. A bifurcated path doubles the surface that must be kept in sync, and the two halves *will* drift: a fix lands on the path the author was looking at, the other rots. The pull toward a separate fast/local/legacy path is strong precisely because each one looks locally reasonable; the cost is global and shows up later as "works locally, breaks in prod." This is about architectural *shape*, not any single token, so grep cannot see it — a fork can be spelled a hundred ways. It is adjudicated by the LLM-judge sweep, off the commit path.
+- **Enforced by**: `.governance/packs/governance-kit/architecture/directives/no-path-bifurcation/triage.sh` (candidate triage) → the sweep engine (`.governance/sweep.py`) adjudicates each candidate hunk against this rubric and reports findings in the daily `governance-sweep` digest issue. This directive never blocks a commit, a push, or a PR.
+- **Exceptions**: A genuine, irreducible difference between environments (a platform that truly lacks a capability, a performance path with a measured, documented win) can warrant a branch — name the reason in the code so the divergence is deliberate and reviewable, not incidental. A fork with no stated reason is exactly what this directive exists to surface.
+
 ## governance-kit/foundation
 
 ### required-docs

--- a/receipts/issue-231.md
+++ b/receipts/issue-231.md
@@ -1,0 +1,9 @@
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-890521f2-58e-1781282925-1 | claude-code | 890521f2-58e6-451f-a846-ec28dc708794 | #231 | claude-opus-4-8 | 2763 | 13678 | 16008 | 69 | 16510 | 0.1090 | chore(governance): advance .governance kit pin to kit/v0.7.2 (#231) |

--- a/receipts/issue-231.md
+++ b/receipts/issue-231.md
@@ -7,3 +7,4 @@
 | cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | claude-code-890521f2-58e-1781282925-1 | claude-code | 890521f2-58e6-451f-a846-ec28dc708794 | #231 | claude-opus-4-8 | 2763 | 13678 | 16008 | 69 | 16510 | 0.1090 | chore(governance): advance .governance kit pin to kit/v0.7.2 (#231) |
+| claude-code-26e113fd-ac2-1781283140-1 | claude-code | 26e113fd-ac20-48cd-a283-29c811470091 | #231 | claude-opus-4-8 | 3823 | 203007 | 42350911 | 204597 | 411427 | 27.5783 | chore(governance): backfill architecture CONSTITUTION subsections via pack re-ap |


### PR DESCRIPTION
Closes #231.

Completes the cycle: pins this repo's kit to **v0.7.2** (carries the #227/#228 CONSTITUTION-upsert fix), then re-applies the architecture pack so the v0.7.2 engine backfills the `no-legacy-fallbacks` + `no-path-bifurcation` subsections into `CONSTITUTION.md` (they were installed in #222 before the upsert fix existed).

## Commits
1. `chore(governance): advance .governance kit pin to kit/v0.7.2`
2. `chore(governance): backfill architecture CONSTITUTION subsections via pack re-apply` — `constitution_upserted: [no-legacy-fallbacks, no-path-bifurcation]`; `packs.lock` change is just `installed_at`.

`bash .governance/run.sh` green (21 directives).

## Known refinement (not blocking)
The generic `upsert_directive_subsection` placed the two directives ungrouped under `## Directives`, not under a `## governance-kit/architecture` pack header like init produces for other packs. The GDD invariant (every directive ↔ a constitution entry) holds; pack-grouping-aware placement is a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)