### PR TITLE
fix(sweep): ensure the governance-sweep digest label exists before filing (#235)

### DIFF
--- a/kit/assets/dot-governance/sweep.py
+++ b/kit/assets/dot-governance/sweep.py
@@ -351,6 +351,21 @@ def discover_sweep_directives(root: Path) -> list[Path]:
     return out
 
 
+def _ensure_sweep_label(root: Path) -> bool:
+    """Idempotently create the digest label; True iff it exists afterwards.
+
+    The label is part of the engine's state contract — resume (_last_end_sha)
+    and dedupe (_open_digest_pairs) both query by it — but nothing in the
+    install path creates it, so the first run on a fresh repo must. The sweep
+    workflow's `issues: write` grant covers the labels API, so this works with
+    the built-in GITHUB_TOKEN; "already exists" is the idempotent success case.
+    """
+    res = _gh(root, "label", "create", SWEEP_LABEL,
+              "--description", "Digest issues filed by the governance semantic sweep",
+              "--color", "5319E7")
+    return res.returncode == 0 or "already exists" in (res.stderr or "")
+
+
 def _last_end_sha(root: Path) -> str | None:
     """Resume point: the end-SHA recorded in the most recent sweep digest."""
     res = _gh(root, "issue", "list", "--label", SWEEP_LABEL, "--state", "all",
@@ -490,7 +505,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("sweep run: no new findings — no digest filed")
         return 0
     title = f"Governance sweep: {len(finding_markers)} finding(s) in {rng[:40]}"
-    res = _gh(root, "issue", "create", "--label", SWEEP_LABEL,
+    # A digest filed unlabeled loses resume/dedupe, but a digest not filed at
+    # all loses the findings — so a label we can't create only degrades.
+    label_args = ["--label", SWEEP_LABEL]
+    if not _ensure_sweep_label(root):
+        print(f"sweep run: could not create label '{SWEEP_LABEL}'; filing the digest "
+              "unlabeled — the next run will not resume or dedupe from it",
+              file=sys.stderr)
+        label_args = []
+    res = _gh(root, "issue", "create", *label_args,
               "--title", title, "--body", body)
     if res.returncode != 0:
         print(f"sweep run: gh issue create failed: {res.stderr}", file=sys.stderr)

--- a/kit/references/SWEEP_FLOW.md
+++ b/kit/references/SWEEP_FLOW.md
@@ -92,7 +92,11 @@ What `run` does:
 - **Digest.** One issue per run, labelled `governance-sweep`: sections per
   directive (file/line/quote/why/confidence), a footer stating the commit range
   and hunks triaged vs. adjudicated vs. dropped for budget, and the end-SHA
-  marker that the next run resumes from.
+  marker that the next run resumes from. The engine creates the label
+  idempotently before filing (the workflow's `issues: write` grant covers the
+  labels API); if creation fails anyway, it files the digest unlabeled with a
+  warning rather than dropping the findings — that one digest just won't feed
+  resume/dedupe.
 
 ## Provider / transport
 

--- a/receipts/issue-235-sweep-digest-label.md
+++ b/receipts/issue-235-sweep-digest-label.md
@@ -1,0 +1,60 @@
+# Issue 235: Ensure the governance-sweep digest label exists before filing
+
+## Checklist
+
+- [x] Add `_ensure_sweep_label` to kit/assets/dot-governance/sweep.py — idempotent `gh label create`, "already exists" counts as success.
+- [x] Call it in `cmd_run` before `gh issue create`; on failure, file the digest unlabeled with a stderr warning instead of failing the run.
+- [x] Add scripts/test-sweep.py covering the three filing scenarios plus a dry-run guard, with a stubbed `gh` on PATH.
+- [x] Wire the new layer into scripts/test.sh.
+- [x] Document the on-demand label creation in kit/references/SWEEP_FLOW.md.
+
+## What changed
+
+The failure: `sweep run` files its digest under the `governance-sweep` label, but nothing in the install path creates that label — neither the sweep variant of workflow seeding nor the architecture pack's install. On any repo without the label, the first sweep run fails at the very last step with `could not add label: 'governance-sweep' not found`, after having spent its whole adjudication budget. This hit this repo's own sweep lane on 2026-06-12 (workflow runs 27429758065 and 27429945813); the lane only went green after the label was created by hand. Every fresh consumer repo installing a `surface: sweep` directive would hit the same wall on its first scheduled run.
+
+**Add `_ensure_sweep_label` to kit/assets/dot-governance/sweep.py — idempotent `gh label create`, "already exists" counts as success.** The label is not cosmetic: `_last_end_sha` (resume point) and `_open_digest_pairs` (dedupe) both query issues by it, so it is part of the engine's state contract — and the engine is the only component positioned to guarantee it. Installs can happen offline or before the repo has a GitHub remote, so creating the label at install time would bifurcate the path (online installs seeded, offline installs still broken); creating it lazily at first filing is the single path that works everywhere. The helper runs `gh label create governance-sweep` with a fixed description/color; exit 0 or a stderr containing "already exists" both count as the label existing. The sweep workflow's `issues: write` permission covers the labels API, so this works with the built-in `GITHUB_TOKEN` — no new grants.
+
+**Call it in `cmd_run` before `gh issue create`; on failure, file the digest unlabeled with a stderr warning instead of failing the run.** Losing resume/dedupe for one digest beats losing the findings: a digest must reach humans even when the label API is closed off (e.g. a token without the grant). The warning text states the consequence — the next run will not resume or dedupe from the unlabeled digest — so a degraded run is diagnosable from the workflow log alone. The `--dry-run` and `--no-gh` paths return before any of this, so they touch neither labels nor issues.
+
+**Add scripts/test-sweep.py covering the three filing scenarios plus a dry-run guard, with a stubbed `gh` on PATH.** The layer runs the real CLI against a throwaway repo with one sweep directive (echo judge, keyword fixture) and a stub `gh` that logs every invocation. Pinned: label creatable → `label create` precedes `issue create` and the digest is filed labeled; label pre-existing → filed labeled, no warning; label uncreatable (HTTP 403) → filed unlabeled, warning on stderr, exit 0; `--dry-run` → no `gh label`/`gh issue` calls at all.
+
+**Wire the new layer into scripts/test.sh.** Added after the shipped-runtime layer (sweep.py is itself a shipped runtime asset), invoked like the other Python layers so the pre-commit test gate and CI both run it.
+
+**Document the on-demand label creation in kit/references/SWEEP_FLOW.md.** The Digest bullet now states that the engine creates the label idempotently before filing and what the unlabeled fallback costs.
+
+## Decisions
+
+- Treat a stderr containing "already exists" from `gh label create` as success rather than pre-checking with `gh label list`: one round-trip instead of two, and the create-then-tolerate shape is race-free when two runs start concurrently.
+- On an uncreatable label, file unlabeled and exit 0 rather than failing the run. The digest is the product; the label is plumbing. The degradation is loud (stderr warning naming the consequence) and self-healing on the next run that can create the label.
+- No `--force` on `gh label create`: a repo that customized the label's color/description keeps its customization; we only need existence.
+
+## Out of scope
+
+- Creating the label at install time (workflow seeding or `pack add`). That would only cover online installs and would duplicate the responsibility the engine now owns; the lazy ensure covers every path including repos created from templates.
+- Hand-editing the vendored `.governance/sweep.py`. Lane 1 catches up at the next release via the real `pack update`/kit re-sync verbs.
+- Retrying or backing off on the GitHub Models 429/413 inference errors observed in the same failed runs. Different failure mode, separately observable in digests as un-adjudicated rows.
+
+## Verification
+
+```sh
+uv run --quiet --isolated python scripts/test-sweep.py   # 4/4 filing-contract tests pass
+bash scripts/test.sh                                     # all kit-internal layers pass, incl. the new sweep layer
+bash .governance/run.sh                                  # full directive suite passes
+```
+
+## Notes
+
+- The label was created by hand on Duaility/governance-kit on 2026-06-12 to unblock the lane, so this repo's own sweeps no longer exercise the create path; the test layer does.
+- The fallback's warning text states the consequence ("the next run will not resume or dedupe from it") so a degraded run is diagnosable from the workflow log alone.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-79210124-ca4-1781283952-1 | claude-code | 79210124-ca48-4092-8400-6ee340e194d0 | #235 | claude-opus-4-8 | 5526 | 28196 | 32016 | 300 | 34022 | 0.2274 | fix(sweep): ensure the governance-sweep digest label exists before filing (#235) |
+| claude-code-d14bbc13-65c-1781284056-1 | claude-code | d14bbc13-65c2-471a-ae23-6e624fdf51f6 | #235 | claude-fable-5 | 41865 | 216762 | 7031313 | 66768 | 325395 | 13.4979 | fix(sweep): ensure the governance-sweep digest label exists before filing (#235) |
+| claude-code-d14bbc13-65c-1781284251-1 | claude-code | d14bbc13-65c2-471a-ae23-6e624fdf51f6 | #235 | claude-fable-5 | 409 | 25780 | 1171297 | 15764 | 41953 | 2.2858 | fix(sweep): ensure the governance-sweep digest label exists before filing (#235) |

--- a/scripts/test-sweep.py
+++ b/scripts/test-sweep.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Contract tests for the sweep engine's digest-filing path (issue #235).
+
+`sweep run` files its digest under SWEEP_LABEL, which doubles as the engine's
+state key (resume + dedupe both query by it) — but nothing in the install path
+creates the label, so the engine must. These tests run the real CLI against a
+throwaway repo with a stub `gh` on PATH and pin the three filing scenarios:
+label creatable → filed labeled; label pre-existing → filed labeled; label
+uncreatable → filed unlabeled with a warning, run still succeeds.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SWEEP = ROOT / "kit" / "assets" / "dot-governance" / "sweep.py"
+
+GIT_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+GH_STUB = """\
+#!/usr/bin/env bash
+# Stub gh: log every invocation, answer per the scenario file next to this script.
+dir="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\\n' "$*" >> "$dir/gh-calls.log"
+scenario="$(cat "$dir/gh-scenario")"
+case "$1 $2" in
+  "label create")
+    case "$scenario" in
+      ok) exit 0 ;;
+      exists) echo 'label with name "governance-sweep" already exists' >&2; exit 1 ;;
+      denied) echo 'HTTP 403: Resource not accessible by integration' >&2; exit 1 ;;
+    esac ;;
+  "issue list") echo "[]" ;;
+  "issue create") echo "https://example.test/issues/1" ;;
+esac
+exit 0
+"""
+
+
+def git(root: Path, *argv: str) -> None:
+    subprocess.run(["git", "-C", str(root), "-c", "user.email=t@t", "-c", "user.name=t",
+                    "-c", "commit.gpgsign=false", *argv],
+                   check=True, env=GIT_CLEAN_ENV, capture_output=True)
+
+
+def _fixture_repo(base: Path) -> Path:
+    """A repo with one sweep directive whose echo judge always finds a violation."""
+    root = base / "repo"
+    d = root / ".governance" / "packs" / "acme" / "shape" / "directives" / "no-shims"
+    (d / "evals").mkdir(parents=True)
+    (d / "directive.yaml").write_text(
+        "category: architecture\nrecommended: true\nsummary: no shims\n"
+        "surface: sweep\nhook: none\nengine: llm\nmodel_tier: high\n")
+    (d / "triage.sh").write_text("#!/usr/bin/env bash\necho 'f.txt:1'\n")
+    (d / "constitution.md").write_text("### no-shims\n\n- **Directive**: no shims.\n")
+    (d / "evals" / "echo-keywords.txt").write_text("shim\n")
+    (root / "f.txt").write_text("a legacy shim kept for compatibility\n")
+    git(root, "init", "-q", ".")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "seed")
+    return root
+
+
+def _run_sweep(base: Path, root: Path, scenario: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = base / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+    (bin_dir / "gh-scenario").write_text(scenario)
+    log = bin_dir / "gh-calls.log"
+    if log.exists():
+        log.unlink()
+    env = dict(GIT_CLEAN_ENV, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("MODELS_TOKEN", None)
+    res = subprocess.run(
+        [sys.executable, str(SWEEP), "run", "--root", str(root), "--judge", "echo"],
+        capture_output=True, text=True, env=env)
+    calls = log.read_text().splitlines() if log.exists() else []
+    return res, calls
+
+
+def _issue_create_call(calls: list[str]) -> str:
+    hits = [c for c in calls if c.startswith("issue create")]
+    assert len(hits) == 1, f"expected exactly one issue create, got: {calls}"
+    return hits[0]
+
+
+def test_filing_creates_missing_label_then_files_labeled() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture_repo(Path(tmp))
+        res, calls = _run_sweep(Path(tmp), root, "ok")
+        assert res.returncode == 0, res.stderr
+        label_idx = next(i for i, c in enumerate(calls)
+                         if c.startswith("label create governance-sweep"))
+        create_idx = calls.index(_issue_create_call(calls))
+        assert label_idx < create_idx, f"label must be ensured before filing: {calls}"
+        assert "--label governance-sweep" in _issue_create_call(calls)
+
+
+def test_filing_treats_existing_label_as_success() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture_repo(Path(tmp))
+        res, calls = _run_sweep(Path(tmp), root, "exists")
+        assert res.returncode == 0, res.stderr
+        assert "--label governance-sweep" in _issue_create_call(calls)
+        assert "could not create label" not in res.stderr
+
+
+def test_filing_falls_back_to_unlabeled_when_label_uncreatable() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture_repo(Path(tmp))
+        res, calls = _run_sweep(Path(tmp), root, "denied")
+        assert res.returncode == 0, res.stderr
+        assert "could not create label" in res.stderr
+        assert "--label" not in _issue_create_call(calls)
+
+
+def test_dry_run_never_touches_labels() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture_repo(Path(tmp))
+        bin_dir = Path(tmp) / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(GH_STUB)
+        gh.chmod(0o755)
+        (bin_dir / "gh-scenario").write_text("ok")
+        env = dict(GIT_CLEAN_ENV, PATH=f"{bin_dir}:{os.environ['PATH']}")
+        res = subprocess.run(
+            [sys.executable, str(SWEEP), "run", "--root", str(root),
+             "--judge", "echo", "--dry-run"],
+            capture_output=True, text=True, env=env)
+        assert res.returncode == 0, res.stderr
+        log = bin_dir / "gh-calls.log"
+        calls = log.read_text().splitlines() if log.exists() else []
+        assert not any(c.startswith("label create") or c.startswith("issue create")
+                       for c in calls), calls
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"not ok - {name}: {exc}", file=sys.stderr)
+        else:
+            print(f"ok - {name}")
+    raise SystemExit(1 if failures else 0)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,6 +24,8 @@
 #                               SKIP_GOVERNANCE handling
 #   5. test-runtime.sh        — runtime files shipped to consumer repos
 #                               (dot-governance/run.sh + lib.sh)
+#   5b. test-sweep.py         — sweep.py digest-filing contract (ensure the
+#                               governance-sweep label, unlabeled fallback)
 #   6. test-schema-split.sh   — install.yaml + packs.lock cross-file invariants
 #                               (no packs[] in install.yaml; every source kind
 #                               recorded in packs.lock with the right fields)
@@ -105,6 +107,10 @@ run_layer "hooks.sh dispatcher generation (bash)" \
 run_layer "shipped runtime: run.sh + lib.sh (bash)" \
     bash "$ROOT/scripts/test-runtime.sh" \
     || failed_layers+=("test-runtime.sh")
+
+run_layer "sweep engine: digest filing + label ensure (Python)" \
+    uv run --quiet --isolated python "$ROOT/scripts/test-sweep.py" \
+    || failed_layers+=("test-sweep.py")
 
 run_layer "schema split: install.yaml + packs.lock (bash)" \
     bash "$ROOT/scripts/test-schema-split.sh" \


### PR DESCRIPTION
Closes #235.

`sweep run` files its digest under the `governance-sweep` label, which is also the engine's state key — resume (`_last_end_sha`) and dedupe (`_open_digest_pairs`) both query issues by it. But nothing in the install path creates the label, so the first sweep on any fresh repo died at the filing step (`could not add label: 'governance-sweep' not found`) after spending its whole adjudication budget. This hit our own lane on 2026-06-12 (runs 27429758065, 27429945813) and would hit every fresh consumer repo.

## What changed

- **`kit/assets/dot-governance/sweep.py`** — new `_ensure_sweep_label` runs `gh label create governance-sweep` idempotently before filing ("already exists" counts as success; the workflow's `issues: write` grant covers the labels API, so the built-in `GITHUB_TOKEN` suffices). If creation still fails, the digest is filed **unlabeled with a stderr warning** instead of failing the run — losing resume/dedupe for one digest beats losing the findings.
- **`scripts/test-sweep.py`** (new layer, wired into `scripts/test.sh`) — runs the real CLI against a throwaway repo with a stubbed `gh` on PATH. Pins: label creatable → ensured before filing, filed labeled; label pre-existing → filed labeled; label uncreatable → filed unlabeled, exit 0; `--dry-run` → no label/issue calls.
- **`kit/references/SWEEP_FLOW.md`** — documents the on-demand label creation and the fallback's cost.
- **`receipts/issue-235-sweep-digest-label.md`** — receipt.

Touches `kit/` source only; the vendored `.governance/sweep.py` catches up at release time (Lane 1).

## Verification

- `uv run --quiet --isolated python scripts/test-sweep.py` — 4/4 pass
- `bash scripts/test.sh` — all kit-internal layers pass
- Full governance suite ran green in the pre-commit hook for this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)