### PR TITLE
docs: restructure README and docs site around the Governance Kit framing (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,77 @@
-# governance-kit
+<div align="center"><pre>
+ ██████╗  ██████╗ ██╗   ██╗███████╗██████╗ ███╗   ██╗ █████╗ ███╗   ██╗ ██████╗███████╗
+██╔════╝ ██╔═══██╗██║   ██║██╔════╝██╔══██╗████╗  ██║██╔══██╗████╗  ██║██╔════╝██╔════╝
+██║  ███╗██║   ██║██║   ██║█████╗  ██████╔╝██╔██╗ ██║███████║██╔██╗ ██║██║     █████╗
+██║   ██║██║   ██║╚██╗ ██╔╝██╔══╝  ██╔══██╗██║╚██╗██║██╔══██║██║╚██╗██║██║     ██╔══╝
+╚██████╔╝╚██████╔╝ ╚████╔╝ ███████╗██║  ██║██║ ╚████║██║  ██║██║ ╚████║╚██████╗███████╗
+ ╚═════╝  ╚═════╝   ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝╚══════╝
 
-**Declare the repo state you want. Let agents converge on it.**
+                                 ██╗  ██╗██╗████████╗
+                                 ██║ ██╔╝██║╚══██╔══╝
+                                 █████╔╝ ██║   ██║
+                                 ██╔═██╗ ██║   ██║
+                                 ██║  ██╗██║   ██║
+                                 ╚═╝  ╚═╝╚═╝   ╚═╝
 
-governance-kit turns your repo's rules into a versioned constitution — a declarative description of the state the repository must stay in. Agents read it, checks compare it against reality on every commit, and every agent-authored change leaves a git-native audit trail.
+                     The governance layer for AI coding agents
+</pre></div>
 
-Conforms to the [Agent Skills](https://agentskills.io) format. Installs into [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), Cursor, OpenCode, and 40+ skills-compatible agents via [`npx skills`](https://github.com/vercel-labs/skills). MIT-licensed.
+<p align="center"><strong>rules with tests · enforced on every commit · audit trail for every agent change · six bundled packs · MIT</strong></p>
 
-> [!NOTE]
-> **Built for agent-heavy engineering teams.** If you're spec-driving features for an agent to implement, [spec-kit](https://github.com/github/spec-kit) is the right fit. governance-kit is the layer above — keeping the rules your agent must satisfy on every commit from drifting out of sync with the code, the tests, or each other.
+<p align="center">
+  <a href="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml"><img src="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml/badge.svg" alt="governance"></a>
+  <a href="https://github.com/Duaility/governance-kit/actions/workflows/dogfood-smoke.yml"><img src="https://github.com/Duaility/governance-kit/actions/workflows/dogfood-smoke.yml/badge.svg" alt="dogfood smoke"></a>
+  <a href="https://github.com/Duaility/governance-kit/tags"><img src="https://img.shields.io/github/v/tag/Duaility/governance-kit?filter=kit%2Fv*&label=kit" alt="kit version"></a>
+  <a href="https://agentskills.io"><img src="https://img.shields.io/badge/Agent%20Skills-compatible-blueviolet.svg" alt="Agent Skills"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="#get-started-60-seconds">Install</a> ·
+  <a href="#why">Why</a> ·
+  <a href="#proof--this-repo-governs-itself">Proof</a> ·
+  <a href="#whats-bundled">Packs</a> ·
+  <a href="#documentation">Docs</a> ·
+  <a href="AGENTS.md">Contributing</a>
+</p>
+
+<p align="center"><sub>
+  <b>AI agents:</b> start at <a href="AGENTS.md"><code>AGENTS.md</code></a> — the rules you must satisfy live in <a href="CONSTITUTION.md"><code>CONSTITUTION.md</code></a>.
+</sub></p>
 
 ---
 
-## Why governance-driven development?
+Governance Kit turns your repo's rules into a versioned constitution — a declarative description of the state the repository must stay in. Agents read it, checks compare it against reality on every commit, and every agent-authored change leaves a git-native audit trail.
 
-Coding agents do the engineering work now. The hard part is no longer just telling one agent what to do in one session; it is keeping the repository understandable across many branches, many agents, and many handoffs.
+Installs into [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), Cursor, OpenCode, and 40+ agents via [`npx skills`](https://github.com/vercel-labs/skills). Conforms to the [Agent Skills](https://agentskills.io) format.
 
-governance-kit treats governance as repo state:
+## What it does
 
-- **Desired state** lives in `CONSTITUTION.md`: directives, rationale, enforcement paths, exceptions, and an evolution log.
-- **Current state** is the working tree, staged diff, commit message, PR state, receipts, and ledgers.
-- **Reconciliation** happens through `.governance/run.sh` and hook dispatchers. A failed directive names the gap and its rationale; the agent fixes the repo, reruns the check, and repeats until reality matches the declared state.
-- **Abstractions** keep humans out of low-level ceremony. You reason about directives, packs, receipts, and ledgers instead of scattered hook scripts, chat transcripts, and one-off agent instructions.
+- **Constitution** — `CONSTITUTION.md` declares the state your repo must satisfy: directives, rationale, exceptions, evolution log
+- **Executable directives** — every rule carries a `check.sh`; a pre-commit hook and CI compare declared state to reality on every commit
+- **Packs** — concern-scoped directive bundles, versioned and pinned; the check code is vendored into your repo for in-diff review
+- **Audit chain** — every agent-authored change leaves a trail: issue → receipt → commit → token cost
+- **Steering record** — per-commit tallies of how much human correction the work needed
+- **Sweep lane** — LLM-judged architectural rules grep can't reach, off the commit path, advisory-only
+- **Lifecycle verbs** — `init` · `update` · `pack` · `directive` · `reset` · `uninstall`; your agent drives all of them
 
-That gives a practical steering surface. Your guidance has to reach the next agent, on the next branch, without you. governance-kit's answer is a **constitution**: a versioned set of directives every agent reads on every commit, plus per-turn redirects you did not promote into a directive, recorded as steering rows on each issue's receipt.
+## Why
 
-It also gives a practical visibility surface. When agents ship the diffs, you need a readable trail, not a stack of PRs. Every agent-authored commit can leave a git-native record — `CONSTITUTION.md` (rules + evolution log) plus the per-issue receipts, which now carry the per-commit token cost and human-steering rows under an `## Accounting` section. You read the repo's state record, not the chat history.
+When coding agents take control, the problems change. You're no longer debugging one agent's output in one session — you're keeping a repository coherent across many branches, many agents, many handoffs, where your guidance has to reach the next agent without you. OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article names this problem set from running an agent-first codebase — and the stance that follows: **humans steer, agents execute**. Governance Kit was designed against exactly those problems:
+
+| The agent-first failure mode | The design answer |
+|---|---|
+| Monolithic instruction files "rot instantly" — a single blob can't be mechanically checked, "so drift is inevitable" | A constitution where **every rule ships its executable test**. Doc freshness, link integrity, and record tampering are themselves directives — the rules can't decay silently. |
+| Agents "replicate patterns that already exist in the repository — even uneven or suboptimal ones" | **Enforce invariants, not implementations.** Directives describe state; hooks + CI re-evaluate every one on every commit. The [sweep lane](#the-sweep-lane) runs the scan-for-deviations, file-targeted-issues garbage-collection loop. |
+| Knowledge in chat threads and people's heads is "not accessible to the system" | **Git-native ledgers.** Rationale, evolution log, receipts, steering rows — every rule, exception, and correction lands in the repo, readable by the next agent run. |
+| "Our bottleneck became human QA capacity" | **You review receipts, not diffs.** Each issue's receipt crosswalks claims to changes and verification, with a token price tag and a steering tally attached. |
+| Context is scarce — "a giant instruction file crowds out the task" | **Progressive disclosure, enforced.** A failing check injects one directive's id + rationale at exactly the moment it's violated — not a 500-line prompt on every turn. |
+
+The article describes the practices; Governance Kit packages them as an installable, versioned kit — and adds the accounting layer (cost + steering per commit) that tells you how well the harness is working.
+
+## How it works (30 seconds)
+
+Governance Kit treats governance as repo state and reconciles it on every commit:
 
 ```mermaid
 flowchart LR
@@ -40,62 +87,144 @@ flowchart LR
     G -->|"pass"| OK([Ready to merge])
 ```
 
-Agents do the work. The constitution describes the state the repo must satisfy. The directives keep both sides honest — a frontier-model agent reading a directive's rationale generalizes to cases the author never encoded; you read the ledgers as the state record for what the agent fleet just shipped.
+- **A directive is an invariant, not a step** — rule, rationale, test, and log entry land as one commit and can't silently diverge
+- **A failed check names the gap and the why** — an agent reading the rationale generalizes to cases the author never encoded
+- **You read ledgers, not transcripts** — receipts and the evolution log are the record of what your agent fleet shipped
 
-The stance in one line: **describe the state, continuously check reality, and let agents reconcile the difference.**
+One line: **describe the state, continuously check reality, and let agents reconcile the difference.**
 
-## Visibility
-
-If you're trusting agents to ship code, you need to see exactly what they were told, what they did against each issue, what it cost, and how much you had to steer them. Four git-native artifacts:
-
-- **Directive provenance** (`CONSTITUTION.md`). Every line is git-blameable to the commit that introduced it and the test that enforces it. The **Evolution Log** at the bottom of the file carries a dated, human-readable summary of every amendment. Because the CLI verbs require the check, the rationale, and the log entry to land together, policy and enforcement can't silently diverge.
-- **Per-issue receipts** (`receipts/issue-<N>-*.md`). One receipt per issue, with `## Checklist`, `## What changed`, `## Out of scope`, and `## Verification` sections. Every `- [x]` checklist item must crosswalk into `## What changed` or `## Verification` — the trust boundary that prevents silent box-flipping. The receipt is what a reviewer reads instead of the diff. It also holds the accounting (below).
-- **Token cost** (the receipt's `## Accounting` section). Every agent-authored commit carries token + cost trailers (`Token-Input`, `Token-Output`, `Cost-USD`, …) and a matching cost row under `### Costs` in the issue's receipt (`receipts/issue-<N>.md`), joined by a stable `Cost-Key` that survives squash-merges. Every change has a price tag.
-- **Human steering** (the receipt's `## Accounting` section). Every commit carries summary trailers (`Steer-Count`, `Steer-Types`, `Steer-Tiers`) tallying the rows it appends under `### Steering` in the issue's receipt — one row per detected human-steering event (interrupt or redirect). See at a glance which commits ran on autopilot and which needed your hand on the wheel.
-
-These compose into a chain — **issue → receipt → commit → cost** — and breaking any link fails the next push. The whole chain — traceability, token cost, steering, and the record-integrity that keeps it tamper-proof — ships in the [`governance-kit/audit`](#whats-bundled) pack and lands in the `standard` preset. Steering accounting (`agent-steering-accounting`) is `always_install: true` — mandatory in every install (it records human correction text verbatim — redact via the directive's classifier hook rather than skipping it).
-
-## Quickstart
+## Get started (60 seconds)
 
 ```sh
-# Install the skill into your agent (see Lifecycle for scope options)
+# 1 — install the skill into every skills-compatible agent on your machine
 npx skills add Duaility/governance-kit
 
-# In a fresh repo, launch your agent and ask it to bootstrap
+# 2 — in a fresh repo, ask your agent to bootstrap
 claude
-> governance init
+> governance init      # writes CONSTITUTION.md, .governance/, a pre-commit hook, the bundled packs
+
+# 3 — watch the gate fire
+git commit -m "stuff"
 ```
 
-`npx skills` auto-detects [skill/SKILL.md](skill/SKILL.md) — the published **thin shim** (installer doc + one stdlib-only fetch script — two files, issue #198) — and symlinks it into every skills-compatible runtime on your machine (`~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, …). The **kit** (rules, packs, templates, every other verb) is fetched from the released `kit/vX.Y.Z` tag at install time and pinned per repo. `governance install` bootstraps `CONSTITUTION.md`, `.governance/`, a pre-commit hook, and the bundled `governance-kit/*` concern packs.
-
-Make a bad commit to see the gate fire:
-
-```sh
-$ git commit -m "stuff"
+```
 [FAIL] commit-message-format — pending commit — 'stuff' does not match
        Conventional Commits with an issue suffix (<type>(scope)?: <subject> (#123))
 ```
 
-The agent reads the id + rationale and self-corrects on the next attempt.
+The agent reads the directive id + rationale and self-corrects on the next attempt.
 
-## How it ships
+What you installed is a thin shim — two files. The kit itself (rules, packs, templates, every other verb) is fetched from the released `kit/vX.Y.Z` tag and pinned per repo. See [Lifecycle](#lifecycle).
 
-### Verbs
+## Proof — this repo governs itself
 
-```
-governance init                                        # bootstrap a repo
-governance kit update [--with-packs|--dry-run|--force] # re-sync runtime files to a new kit version
-governance pack {list,search,add,update,remove,create} # pack lifecycle (community + repo-local)
-governance directive {add,modify,remove} [--pack …]    # atomic directive amendments
-governance reset {--directive <id>|--pack <id>|--all}  # restore drifted directives to the pinned version
-governance uninstall [--dry-run|--soft|--hard]         # tear-down
-```
+- **21 directives gate every commit here** — the same packs `governance init` installs, plus a repo-local pack; two more sweep-lane rules adjudicate merged commits off the commit path
+- **The committed `.governance/` tree is an honest customer of the last release** — pinned at real published tags, moved only by the real `pack update` verb, so every release exercises the update path
+- **A CI smoke lane runs HEAD's directives against a throwaway copy of this repo** — a broken directive surfaces in its own PR, before it ships
 
-Full install / update / uninstall usage for both layers is in [Lifecycle](#lifecycle) below.
+Reproduce: clone this repo and run `bash .governance/run.sh`. The two-lane dogfood setup: [AGENTS.md](AGENTS.md).
 
-### Anatomy of a directive
+## Agent compatibility
 
-Every directive is a self-contained folder. The minimum, here `doc-freshness` from the `governance-kit/docs` pack:
+| Runtime | `npx skills add` | Notes |
+|---|:---:|---|
+| Claude Code | ✅ | symlinked into `~/.claude/skills/` |
+| Codex | ✅ | symlinked into `~/.codex/skills/` |
+| Cursor | ✅ | symlinked into `~/.cursor/skills/` |
+| OpenCode | ✅ | |
+| 40+ other runtimes | ✅ | anything that reads the [Agent Skills](https://agentskills.io) format |
+
+The skill itself is a two-file shim; every verb executes from the kit version the target repo pins — so every runtime drives identical behavior, and updating the kit never requires reinstalling the skill.
+
+## When to use · When to skip
+
+**Great fit if you…**
+
+- run agent-heavy teams where the rules must survive handoffs across branches, sessions, and agents
+- want every agent-authored change to carry a price tag and a steering record
+- want rules, their tests, and their history to evolve as one reviewable commit
+
+**Skip it if you…**
+
+- are spec-driving one feature at a time — that's [spec-kit](https://github.com/github/spec-kit); Governance Kit is the layer above
+- only want hook execution — pre-commit / husky already do that, and every `check.sh` lifts into them directly ([NATIVE_TESTS.md](kit/references/NATIVE_TESTS.md))
+- write all code by hand, solo, and don't need an audit trail
+
+<details>
+<summary><b>Integrations — run the checks from the toolchain you already have</b></summary>
+
+`governance init` installs only the universal bash runner — zero dependencies. Native wrappers are an additive opt-in ([NATIVE_TESTS.md](kit/references/NATIVE_TESTS.md)):
+
+| Your setup | Hook in with |
+|---|---|
+| Bare git | `governance init` wires the hook dispatchers for you |
+| CI | the seeded governance workflow re-runs every directive on every PR |
+| pytest | a test module that shells out to each `check.sh` — violations appear in the normal test report |
+| jest / vitest · go test | same pattern, per-framework snippets in the doc |
+| husky · pre-commit.com · lefthook | call `bash .governance/run.sh` from the hook they manage |
+
+</details>
+
+## What's bundled
+
+Six concern packs ship in-tree and install with `governance init` at your chosen preset (`minimal` / `standard` / `strict`):
+
+| Pack | Covers | Preset |
+|---|---|---|
+| `governance-kit/foundation` | Required docs, kit-version sync, repo hygiene | minimal–standard |
+| `governance-kit/security` | Secrets hygiene, workflow permissions, pinned actions | minimal |
+| `governance-kit/docs` | Internal link integrity, doc freshness | minimal–standard |
+| `governance-kit/commits` | Conventional Commits + issue suffix, TODO and suppression discipline | standard–strict |
+| `governance-kit/audit` | The agent audit chain — receipts, cost, steering, record integrity | standard |
+| `governance-kit/architecture` | Sweep-lane architectural rules, LLM-adjudicated | strict (opt-in) |
+
+Full catalog: [DIRECTIVES_CATALOG.md](kit/references/DIRECTIVES_CATALOG.md).
+
+<details>
+<summary><b>Every directive, with presets</b></summary>
+
+### General-purpose directives
+
+| Pack | Directive | What it enforces | Preset |
+|---|---|---|---|
+| `foundation` | `required-docs` | `README.md`, `LICENSE`, `SECURITY.md`, `ARCHITECTURE.md` exist with non-empty bodies. | minimal |
+| `foundation` | `kit-version-sync` | The single kit-version pin agrees with every managed-file stamp. | standard |
+| `foundation` | `repo-hygiene` | No merge markers, oversized files, build artefacts, or debug statements. | minimal |
+| `security` | `secrets-hygiene` | No high-confidence secret patterns (AWS keys, GitHub tokens, Stripe live keys, …) in tracked files; `.env` gitignored. | minimal |
+| `security` | `token-permissions` | GitHub Actions workflows declare a least-privilege `permissions:` block. | minimal |
+| `security` | `pinned-dependencies` | Third-party actions are pinned to a full commit SHA. | minimal |
+| `docs` | `internal-doc-links` | Internal markdown links resolve; opt-in, every doc stays reachable from a root. | minimal |
+| `docs` | `doc-freshness` | Opted-in docs carry an in-window `last-verified` date marker. | standard |
+| `commits` | `commit-message-format` | Conventional Commits with an issue suffix (`<type>(scope)?: <subject> (#N)`). | standard |
+| `commits` | `no-orphan-todos` | Every `TODO` / `FIXME` references an issue. | strict |
+| `commits` | `no-unjustified-suppressions` | Every lint / type-checker suppression (`@ts-ignore`, `# noqa`, …) references an issue. | strict |
+
+### The audit chain
+
+| Pack | Directive | What it enforces | Preset |
+|---|---|---|---|
+| `audit` | `issue-templates` | `.github/ISSUE_TEMPLATE/` carries `config.yml` (blank issues off), `proposal.yml`, `bug.yml` with the required handoff fields. | standard |
+| `audit` | `issues-tracked` | `QUALITY.md` exists at repo root with `## Open` and `## Resolved` sections. | standard |
+| `audit` | `receipt-per-issue` | Every `receipts/*.md` has a unique `issue-<N>` filename token, the four required sections, and each `- [x]` checklist item crosswalks into `## What changed` or `## Verification`. | standard |
+| `audit` | `commit-issue-receipt-match` | Every non-merge commit's issue anchor (`(#N)` or `Issue: #N`) matches an `issue-<N>` token on a touched receipt. | standard |
+| `audit` | `agent-token-accounting` | Every commit carries token + cost trailers and a matching cost row in the issue's receipt, keyed by `Cost-Key`. | standard |
+| `audit` | `agent-steering-accounting` | Every commit stamps `Steer-Count` / `Steer-Types` / `Steer-Tiers` and appends steering rows to the issue's receipt. **`always_install: true`** — records human correction text verbatim; redact via the directive's classifier hook rather than skipping it. | standard |
+| `audit` | `doc-integrity` | **`always_install: true`** — system-of-record documents are tamper-proof: receipts freeze once on the trunk, frozen sections (`QUALITY.md` Resolved, the Evolution Log) keep their baseline lines verbatim. Branch-authored content stays editable until it merges. | standard |
+| `audit` | `toolchain-config-protection` | A commit changing lint / format / type-check / CI / hook config carries a `governance: allow-toolchain-config <reason>` body line. | standard |
+
+### Sweep-lane directives
+
+| Pack | Directive | What it enforces | Preset |
+|---|---|---|---|
+| `architecture` | `no-legacy-fallbacks` | No backward-compat shims or legacy fallback paths in agent-authored changes. | strict |
+| `architecture` | `no-path-bifurcation` | No bifurcated code paths — unify dual dispatch and local-vs-remote special-casing. | strict |
+
+</details>
+
+<details>
+<summary><b>Anatomy of a directive</b></summary>
+
+Every directive is a self-contained folder — one `git mv` relocates the whole thing:
 
 ```
 doc-freshness/
@@ -104,8 +233,6 @@ doc-freshness/
 ├── constitution.md   # Directive / Rationale / Enforced by / Exceptions
 └── evals/test.sh     # pass + fail fixtures
 ```
-
-Directives that need more carry optional siblings — `lib/` (shared bash/Python), `hooks/<pre-commit|commit-msg|prepare-commit-msg|post-commit|pre-push>.sh` (side-effect scripts wired into the dispatcher by the hook generator), `runtimes/<name>.sh` (per-runtime helpers), and `install-assets/` (templates seeded at bootstrap). All travel with the directive — `git mv` relocates the whole folder. `agent-token-accounting` uses every one of these.
 
 The `constitution.md` carries the *why*:
 
@@ -123,47 +250,39 @@ The `constitution.md` carries the *why*:
 
 A bare hook checks the date format. The rationale tells the next agent — and the next human — what the date is *for*.
 
+Directives that need more carry optional siblings — `lib/` (shared bash/Python), `hooks/` (side-effect scripts wired into the dispatcher), `runtimes/` (per-runtime helpers), `install-assets/` (templates seeded at bootstrap).
+
+**Composition**: directives are invariants on state, not steps in a procedure. There is no `depends_on:`, no graph engine — `.governance/run.sh` re-evaluates every check on every firing, and cascades fall out of re-evaluation: fix what's currently violating, re-run, the next gate fires, converge.
+
+</details>
+
+## The audit chain
+
+If you're trusting agents to ship code, you need to see what they were told, what they did, what it cost, and how much you had to steer. Four git-native artifacts compose into a chain, and breaking any link fails the next push:
+
 ```mermaid
 flowchart LR
-    R[Reads directive<br/>+ rationale] --> W[Writes code]
-    W --> Q{Check on commit}
-    Q -->|pass| OK([Lands])
-    Q -->|"fail — emits<br/>id + rationale"| R
+    I["<b>Issue #N</b><br/>the work order"]
+    R["<b>Receipt</b><br/>claims crosswalked<br/>to evidence"]
+    C["<b>Commit</b><br/>cost + steering<br/>trailers"]
+    CO["<b>Cost row</b><br/>joined by Cost-Key —<br/>survives the squash"]
+
+    I --> R --> C --> CO
+
+    classDef chain fill:#0d4f86,stroke:#0d4f86,color:#ffffff
+    class I,R,C,CO chain
 ```
 
-### Composition
+- **Directive provenance** — every `CONSTITUTION.md` line is git-blameable to the commit and check that introduced it; the Evolution Log summarizes every amendment
+- **Receipts** — one per issue; every checked box must crosswalk into `## What changed` or `## Verification`, so boxes can't flip silently. The reviewer reads the receipt, not the diff
+- **Token cost** — every commit carries cost trailers and a matching row in the issue's receipt; every change has a price tag
+- **Steering** — every commit tallies the human interrupts and redirects it needed; see at a glance which commits ran on autopilot
 
-Directives are invariants on state, not steps in a procedure. Each one describes a condition the repo must satisfy; the runner re-evaluates them all on every firing. `.governance/run.sh` iterates `directives/*/check.sh` alphabetically — no `depends_on:`, no `order:`, no graph engine.
+Ships in the `governance-kit/audit` pack, `standard` preset.
 
-When directive B logically depends on directive A's postcondition — e.g. "PR must have a review" depends on "PR must exist" — B reads the precondition itself and skips-with-info if it's not met. The cascade falls out of re-evaluation: fix what's currently violating, re-run, the next gate fires, fix that, re-run, done.
+## The sweep lane
 
-This is declarative reconciliation applied to a repository. A directive describes the desired state; its check observes current state; the agent takes the mandated action; then `bash .governance/run.sh` surfaces the next gap. Don't chain actions; describe state and let re-evaluation converge.
-
-### Bundled packs
-
-Six concern-scoped packs ship in-tree and install with `governance init`:
-
-| Pack | Directive | What it checks |
-|---|---|---|
-| `governance-kit/foundation` | `required-docs` | Baseline root-level docs and hook scaffolding exist. |
-| `governance-kit/foundation` | `kit-version-sync` | The kit-version pin agrees with every managed-file stamp. |
-| `governance-kit/foundation` | `repo-hygiene` | No merge markers, oversized files, build artefacts, debug statements, or overlong source files. |
-| `governance-kit/security` | `secrets-hygiene` | No plaintext secrets in tracked files; `.env` is gitignored and untracked. |
-| `governance-kit/security` | `token-permissions` | GitHub Actions workflows declare a least-privilege `permissions:` block. |
-| `governance-kit/security` | `pinned-dependencies` | Third-party actions are pinned to a full commit SHA. |
-| `governance-kit/docs` | `internal-doc-links` | Internal markdown links resolve; opt-in, every doc stays reachable from a root. |
-| `governance-kit/docs` | `doc-freshness` | Opted-in docs carry a `<!-- last-verified: YYYY-MM-DD -->` marker within 90 days. |
-| `governance-kit/commits` | `commit-message-format` | Commit messages match `<type>(scope)?: subject (#123)` — Conventional Commits prefix plus a trailing GitHub issue reference. |
-| `governance-kit/commits` | `no-orphan-todos` | Every `TODO` / `FIXME` references an issue. |
-| `governance-kit/commits` | `no-unjustified-suppressions` | Every lint / type-checker suppression references an issue. |
-
-The `governance-kit/audit` pack ships the trustworthy-record-of-agent-work chain — issue → receipt → commit traceability, cost + steering accounting, and tamper-proof record integrity — see [What's bundled](#whats-bundled) below.
-
-Full catalog: [kit/references/DIRECTIVES_CATALOG.md](kit/references/DIRECTIVES_CATALOG.md).
-
-### The sweep lane
-
-Some rules are about *intent* and architectural shape — "don't add a legacy fallback", "don't bifurcate the code path" — the kind a `git grep` fundamentally cannot reach. Those run on a third directive surface, `sweep`, that **never touches the commit path**. A scheduled workflow sweeps the day's commits, triages each with a cheap grep, adjudicates the candidate hunks with an LLM judge under a request budget, and files **one digest issue**. Findings re-enter through the same door as a human correction — issue → agent → PR — so a false positive can never break a gate, because there is no gate to break. The opt-in `governance-kit/architecture` pack ships the first two pilot directives.
+Some rules are about *intent* — "no legacy fallbacks", "don't bifurcate the code path" — the kind a `git grep` fundamentally cannot reach. Those run off the commit path entirely: a scheduled workflow sweeps the day's commits, triages with a cheap grep, adjudicates candidate hunks with a budget-capped LLM judge, and files **one digest issue**. Findings re-enter as issue → agent → PR — a false positive can never break a gate, because there is no gate.
 
 ```mermaid
 flowchart TD
@@ -171,46 +290,80 @@ flowchart TD
     P[Pick commit range<br/>resume from last digest]
     T[Triage with grep<br/>narrow to candidate hunks]
     J{Adjudicate each hunk<br/>budget-capped, one verdict}
-    E[echo stub<br/>deterministic, for CI]
-    G[github-models<br/>real LLM verdict]
     D[File one digest issue<br/>dedupe + confidence filter]
     L([Issue → agent → PR<br/>advisory, never blocks])
 
-    W --> P --> T --> J
-    J -->|"no token — CI / tests"| E
-    J -->|"token — scheduled run"| G
-    E --> D
-    G --> D
-    D --> L
+    W --> P --> T --> J --> D --> L
     D -.->|"next run resumes here"| P
 ```
 
-The judge stays advisory until its digest precision earns a promotion, and a directive pins a model *tier* (not a model id) so an upgrade within a tier can't silently rewrite verdicts. Full walkthrough: [SWEEP_FLOW.md](kit/references/SWEEP_FLOW.md).
+The judge stays advisory until its digest precision earns a promotion, and directives pin a model *tier*, not a model id. Opt-in via the `strict` preset. Full walkthrough: [SWEEP_FLOW.md](kit/references/SWEEP_FLOW.md).
 
 ## Lifecycle
 
-governance-kit has **two layers**, versioned independently on separate axes (the Helm `Chart.version` vs `appVersion` model — see [VERSIONING.md](kit/references/VERSIONING.md)):
-
-- **The kit** — the framework: the runtime (`run.sh`, `lib.sh`), the hook generators, the engines, and the schemas. Released under `kit/vX.Y.Z`. (The published `governance` skill is a fetch-only installer that versions independently and carries no kit code.)
-- **Packs** — the directive *content*: the six `governance-kit/*` concern packs (`foundation`, `security`, `docs`, `commits`, `audit`, `architecture`) ship with the kit; community packs live in their own repos. Each pack versions independently on its own `pack.yaml version`.
-
-`.governance/packs.lock` is the source of truth for **which** packs and versions a repo runs. The directive code itself is **vendored into `.governance/packs/<owner>/<name>/` and committed** — so the checks that enforce your repo are reviewable in your own diffs, and a pack bump shows the real `check.sh` change, not just a SHA. (The lock pins a SHA for integrity; committing the tree adds in-diff auditability — the `go mod vendor` / committed-Helm-`charts/` choice, justified because governance is a trust tool.)
-
-### The kit
-
-**Install** — add the skill to your agent(s) with [`npx skills`](https://github.com/vercel-labs/skills), then bootstrap a repo:
-
-```sh
-npx skills add Duaility/governance-kit -g              # all agents, user-wide
-npx skills add Duaility/governance-kit -a claude-code  # one agent only
-npx skills add Duaility/governance-kit                 # project-scoped, committed to the repo
-
-# then, inside the target repo, ask your agent:
-> governance init                                      # writes CONSTITUTION.md, .governance/, a pre-commit hook, the core pack
+```
+governance init                                        # bootstrap a repo
+governance kit update [--with-packs|--dry-run|--force] # re-sync runtime files to a new kit version
+governance pack {list,search,add,update,remove,create} # pack lifecycle (community + repo-local)
+governance directive {add,modify,remove} [--pack …]    # atomic directive amendments
+governance reset {--directive <id>|--pack <id>|--all}  # restore drifted directives to the pinned version
+governance uninstall [--dry-run|--soft|--hard]         # tear-down
 ```
 
+The mental model — an installer, a product, its content. Like a language toolchain manager:
+
+```mermaid
+flowchart TB
+    S["<b>governance skill — the installer</b><br/>install · update · uninstall"]
+    K["<b>the kit — kit/vX.Y.Z — the product</b><br/>engines · flows · templates · every verb"]
+    P["<b>packs — pack/vX.Y.Z — the content</b><br/>directive code, lock-pinned"]
+    PIN["<b>the repo decides its versions</b><br/>install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin"]
+    RU["≈ rustup<br/>the version manager"]
+    TC["≈ the toolchain<br/>compiler · libs · tools"]
+    LF["≈ the lockfile<br/>pinned dependencies"]
+
+    S -->|"installs · updates"| K
+    K -->|"consumes"| P
+    P ~~~ PIN
+    S -.- RU
+    K -.- TC
+    P -.- LF
+
+    classDef installer fill:#4938a8,stroke:#4938a8,color:#ffffff
+    classDef product fill:#0c7a52,stroke:#0c7a52,color:#ffffff
+    classDef content fill:#9c3a1d,stroke:#9c3a1d,color:#ffffff
+    classDef analogy fill:#44443e,stroke:#44443e,color:#e8e8e3
+    classDef pin fill:#0d4f86,stroke:#0d4f86,color:#ffffff
+    class S installer
+    class K product
+    class P content
+    class RU,TC,LF analogy
+    class PIN pin
+```
+
+The two version axes are independent (the Helm `Chart.version` vs `appVersion` model — [VERSIONING.md](kit/references/VERSIONING.md)): the **kit** is the framework (runtime, hook generators, engines, schemas; tagged `kit/vX.Y.Z`), **packs** are the directive content (each on its own `pack.yaml` version). `.governance/packs.lock` pins what runs; the check code is vendored into `.governance/packs/` and committed, so a pack bump shows the real `check.sh` diff, not just a SHA.
+
+```sh
+# the kit
+npx skills add Duaility/governance-kit -g              # all agents (-a claude-code for one; bare = project-scoped)
+governance kit update [--with-packs]                   # re-sync the runtime files init seeded; prompts per file
+governance uninstall --dry-run                         # preview; --soft keeps pack-seeded docs, --hard removes all
+
+# packs
+governance pack add gh:acme/soc2-pack@v1.2.0           # install a community pack — pin a tag, not a branch
+governance pack update [<pack-id>]                     # re-pin + re-vendor; shows the check-code diff first
+governance pack create <name>                          # scaffold a repo-local pack
+```
+
+- **`kit update` and `pack update` are disjoint** — framework runtime vs directive content; managed files carry a `# governance-kit:managed` marker that flags them safe to regenerate
+- **`uninstall` only deletes what it recognizes as kit-owned** — manifest entries + markers; never your content, unmarked hooks, or uncommitted changes
+- **Community packs** live in their own repos ([PACK_AUTHORING.md](kit/references/PACK_AUTHORING.md)); discovery reads the advisory catalog at [catalog.community.json](kit/assets/catalog.community.json) — currently empty, PRs welcome
+
+> [!IMPORTANT]
+> Don't hand-edit `CONSTITUTION.md` or files under `.governance/`. The `directive {add,modify,remove}` and `reset` verbs keep the check, the rationale, and the evolution log in lockstep — hand-edits drift the constitution out of sync with the tests.
+
 <details>
-<summary>Manual install (no <code>npx</code>, or for hacking on the kit)</summary>
+<summary><b>Manual install (no <code>npx</code>, or for hacking on the kit)</b></summary>
 
 Clone and symlink the skill folder into each runtime you use:
 
@@ -221,131 +374,61 @@ ln -s "$(pwd)/skill" ~/.claude/skills/governance   # Claude Code
 ln -s "$(pwd)/skill" ~/.codex/skills/governance    # Codex
 ```
 
-Edits in the clone flow to every linked runtime live — handy when contributing to governance-kit itself.
+Edits in the clone flow to every linked runtime live — handy when contributing to Governance Kit itself.
 
 </details>
 
-**Update** — two independent things can move; update each on its own:
+## Documentation
 
-```sh
-npx skills add Duaility/governance-kit                 # refresh the installer shim itself (rarely needed)
-governance kit update [--with-packs] [--dry-run] [--force]
-                                                       # inside a repo: re-sync the runtime files init seeded
-                                                       # (run.sh, lib.sh, governance.yml, enable-governance.sh,
-                                                       # hook dispatchers) to the latest published kit release
-```
+| Start here | Go deeper |
+|---|---|
+| [Philosophy](kit/references/PHILOSOPHY.md) — rules over prompts, receipts over plans | [Versioning](kit/references/VERSIONING.md) — two semver axes, tag scheme |
+| [Directives catalog](kit/references/DIRECTIVES_CATALOG.md) — every ready-made check | [Release flow](kit/references/RELEASE_FLOW.md) — how releases are cut |
+| [Pack authoring](kit/references/PACK_AUTHORING.md) — write your own pack | [Sweep flow](kit/references/SWEEP_FLOW.md) — the LLM-judge lane |
+| [Native tests](kit/references/NATIVE_TESTS.md) — port checks to pytest / jest / husky | [Directive amend flow](kit/references/DIRECTIVE_AMEND_FLOW.md) — how amendments land |
+| [AGENTS.md](AGENTS.md) — working in this repo | [Install schema](kit/references/INSTALL_SCHEMA.md) · [lock schema](kit/references/LOCK_SCHEMA.md) |
 
-`kit update` is **disjoint** from `pack update`: it touches the framework runtime, never directive content. It diffs each kit-owned file and prompts per-file before writing; managed files carry a `# governance-kit:managed kit-version=<v>` marker that flags them as safe to regenerate. `--with-packs` chains a `pack update` afterward.
+## Compared to
 
-**Uninstall** — reverse everything `init` did:
+|  | Governs | Blocks a bad commit | Rationale travels with the rule | Agent audit trail |
+|---|---|:---:|:---:|:---:|
+| **Governance Kit** | Repo state — docs, security, commits, receipts, architecture | Yes | Yes — constitution + evolution log | Yes — issue → receipt → commit → cost |
+| pre-commit · husky · lefthook | Hook execution | Yes | No | No |
+| [spec-kit](https://github.com/github/spec-kit) | One feature's spec → implementation | No | Per-spec | No |
+| Agent instruction files alone | What agents are told, not what they do | No | No | No |
 
-```sh
-governance uninstall --dry-run                         # preview (the default when state is ambiguous)
-governance uninstall --soft                            # remove kit-owned files; keep pack-seeded docs (like QUALITY.md)
-governance uninstall --hard                            # remove everything kit-owned
-```
-
-`uninstall` only deletes what it recognizes as kit-owned — manifest entries plus `# governance-kit:managed` markers — and never touches your content, unmarked hooks, or uncommitted changes. To remove the **skill** itself from your machine, delete the symlink your installer created (`npx skills` manages `~/.claude/skills/…`, `~/.codex/skills/…`, etc.).
-
-### Packs
-
-```sh
-governance pack list                                   # what's installed, with versions
-governance pack search [query]                         # browse the community catalog
-governance pack add gh:acme/soc2-pack@v1.2.0           # install a community pack — pin a tag, not a branch
-governance pack update [<pack-id>]                     # re-pin SHA + re-vendor the directive code; diffs before executing
-governance pack remove <pack-id>                       # uninstall a pack (community or repo-local)
-governance pack create <name>                          # scaffold a repo-local pack at .governance/packs/<you>/<name>/
-```
-
-- **Bundled packs.** The six `governance-kit/*` concern packs install with `governance init` at your chosen preset (`minimal` / `standard` / `strict`) and update like any other pack: `governance pack update governance-kit/security`. (`architecture` is the off-commit-path sweep lane — strict-only; see [The sweep lane](#the-sweep-lane).)
-- **Pin tags, not branches.** `@main` silently tracks the moving tip on every update; an immutable tag is a reviewable pin. See [VERSIONING.md](kit/references/VERSIONING.md#tag-scheme).
-- **`add` / `update` vendor the directive code** into `.governance/packs/<owner>/<name>/` and commit it — directives only (author-side `evals/` and `install-assets/` are stripped). `update` shows the diff before it runs, because that diff is check code that will run on your commits.
-- **Community packs** live in their own repos and install via `governance pack add gh:<owner>/<repo>`. Authoring your own: [PACK_AUTHORING.md](kit/references/PACK_AUTHORING.md). Discovery reads the advisory catalog at [catalog.community.json](kit/assets/catalog.community.json) — currently empty; PRs welcome.
-
-> [!IMPORTANT]
-> Don't hand-edit `CONSTITUTION.md` or files under `.governance/`. The `directive {add,modify,remove}` and `reset` verbs keep the check, the rationale, and the evolution log in lockstep — hand-edits drift the constitution out of sync with the tests.
-
-## What's bundled
-
-The kit ships six concern-scoped packs — `governance-kit/{foundation,security,docs,commits,audit,architecture}`. Everything below comes with `governance init` at the chosen preset.
-
-### General-purpose directives
-
-| Pack | Directive | What it enforces | Preset |
-|---|---|---|---|
-| `foundation` | `required-docs` | `README.md`, `LICENSE`, `SECURITY.md`, `ARCHITECTURE.md` exist with non-empty bodies. | minimal |
-| `foundation` | `kit-version-sync` | The single kit-version pin agrees with every managed-file stamp. | standard |
-| `foundation` | `repo-hygiene` | `.gitignore` exists; tracked files stay under the size limit. | minimal |
-| `security` | `secrets-hygiene` | No high-confidence secret patterns (AWS keys, GitHub tokens, Stripe live keys, etc.) committed to the tree. | minimal |
-| `security` | `token-permissions` | `.github/workflows/*.yml` declare a least-privilege `permissions:` block. | minimal |
-| `security` | `pinned-dependencies` | Third-party actions are pinned to a full commit SHA. | minimal |
-| `docs` | `internal-doc-links` | Internal markdown links resolve (`resolve`); opt-in, every doc is reachable from a root (`reachable`). | minimal |
-| `docs` | `doc-freshness` | Docs in `.governance/conf/governance-kit/docs/doc-freshness.conf` carry an in-window `<!-- last-verified: YYYY-MM-DD -->` marker. | standard |
-| `commits` | `commit-message-format` | Conventional Commits with an issue suffix (`<type>(scope)?: <subject> (#N)`). | standard |
-| `commits` | `no-orphan-todos` | Every `TODO`/`FIXME` references an issue. | strict |
-| `commits` | `no-unjustified-suppressions` | Every lint / type-checker suppression (`@ts-ignore`, `# noqa`, …) references an issue. | strict |
-
-### The agent audit chain
-
-The chain — **issue → receipt → commit → cost** — turned into mechanical directives in the `governance-kit/audit` pack: issue→receipt→commit traceability, cost + steering accounting, and the record-integrity that keeps it all tamper-proof. Bundled into `standard` because every commit in this kit's mental model is agent-authored.
-
-| Pack | Directive | What it enforces | Preset |
-|---|---|---|---|
-| `audit` | `issue-templates` | `.github/ISSUE_TEMPLATE/` carries `config.yml` (blank issues off), `proposal.yml`, `bug.yml` with the required handoff fields. | standard |
-| `audit` | `issues-tracked` | `QUALITY.md` exists at repo root with `## Open` and `## Resolved` sections. | standard |
-| `audit` | `receipt-per-issue` | Every `receipts/*.md` has a unique `issue-<N>` filename token, the four required sections, and each `- [x]` checklist item crosswalks into `## What changed` or `## Verification`. | standard |
-| `audit` | `commit-issue-receipt-match` | Every non-merge commit's issue anchor (`(#N)` or `Issue: #N`) matches an `issue-<N>` token on a touched receipt. | standard |
-| `audit` | `agent-token-accounting` | Every commit carries token + cost trailers and a matching cost row in the issue's receipt (`receipts/issue-<N>.md`) keyed by `Cost-Key`. | standard |
-| `audit` | `agent-steering-accounting` | Every commit stamps `Steer-Count` / `Steer-Types` / `Steer-Tiers` and appends steering rows to the issue's receipt. **`always_install: true` — mandatory in every install.** Records human correction text verbatim — redact via the directive's classifier hook rather than skipping it. | standard |
-| `audit` | `doc-integrity` | **`always_install: true` — mandatory in every install.** Makes system-of-record documents tamper-proof (standard rules ship in the directive's `defaults.conf`, layered with the `.governance/conf/governance-kit/audit/doc-integrity.conf` overlay): receipts immutable once on the trunk (now also carrying the per-issue accounting rows), the legacy `COSTS.md`/`STEERING.md` sealed as frozen-files, and frozen sections (`QUALITY.md` Resolved, the Evolution Log) keep their baseline lines verbatim. Branch-authored content stays editable until it merges. | standard |
-| `audit` | `toolchain-config-protection` | A commit changing lint / format / type-check / CI / hook config carries a `governance: allow-toolchain-config <reason>` body line. | standard |
-
-### Sweep-lane directives
-
-Off-commit-path, LLM-adjudicated directives (issue #142). They never gate a commit — a scheduled judge sweeps merged commits and files a digest issue. Opt-in via `strict`; enabling the pack also installs the scheduled workflow and the vendored engine. See [The sweep lane](#the-sweep-lane) and [SWEEP_FLOW.md](kit/references/SWEEP_FLOW.md).
-
-| Pack | Directive | What it enforces | Preset |
-|---|---|---|---|
-| `architecture` | `no-legacy-fallbacks` | No backward-compat shims or legacy fallback paths in agent-authored changes. | strict |
-| `architecture` | `no-path-bifurcation` | No bifurcated code paths — unify dual dispatch and local-vs-remote special-casing. | strict |
-
-## Why not just pre-commit / husky / lefthook?
-
-Those tools run hooks. governance-kit runs hooks **and** carries the rationale, the audit trail, and the evolution history alongside the test. A new maintainer can trace any directive back to its commit and its check. The `check.sh` scripts are plain bash — drop them into pre-commit or husky directly if you only want the enforcement half. See [kit/references/NATIVE_TESTS.md](kit/references/NATIVE_TESTS.md).
+> **Complements, not competitors.** If you're spec-driving features for an agent to implement, spec-kit is the right fit — Governance Kit is the layer above, keeping the rules your agent must satisfy on every commit from drifting out of sync with the code, the tests, or each other. And every `check.sh` is plain bash: drop them into pre-commit or husky directly if you only want the enforcement half ([NATIVE_TESTS.md](kit/references/NATIVE_TESTS.md)).
 
 ## Contributing
 
-See [AGENTS.md](AGENTS.md) for repo layout, how to add directives to the bundled `governance-kit/*` packs, and the dogfooding setup. One-time-per-clone:
-
 ```sh
-./scripts/enable-governance.sh   # sets core.hooksPath=.githooks
+git clone https://github.com/Duaility/governance-kit && cd governance-kit
+./scripts/enable-governance.sh   # one-time per clone — sets core.hooksPath=.githooks
+bash .governance/run.sh          # run the full directive suite
 ```
 
-Worktrees inherit this config — no per-worktree action needed.
+Repo layout, adding directives, and the dogfooding setup: [AGENTS.md](AGENTS.md).
 
-## Releasing
+<details>
+<summary><b>Releasing (maintainers)</b></summary>
 
-The kit and the bundled packs version on **independent** axes (the Helm `Chart.version` vs `appVersion` model), so each is released on its own. Every release is cut by [`scripts/release.sh`](scripts/release.sh) — version lines are written **only** in `chore(release)` commits, never in feature or fix PRs. That is what lets the `kit-version-sync` directive treat any out-of-band edit to a version field as drift.
-
-**Which axis to cut:**
-
-- **`core`** — when a directive-content change has merged: a new/changed/removed directive, a preset edit, or a `check.sh` fix. Bumps the pack version via [`scripts/release.sh`](scripts/release.sh).
-- **`kit`** — when a framework change has merged: runtime files (`run.sh`, `lib.sh`), hook generators, a verb/flag, or a schema/marker-format change. Bumps `kit/assets/kit.yaml` and re-stamps every derived kit-version copy (`SKILL.md` frontmatter, `install.yaml` `kit_version`, the `kit-version=` markers).
-
-Pick the semver level from the [policy table](kit/references/VERSIONING.md#semver-policy).
+Version lines are written **only** by [`scripts/release.sh`](scripts/release.sh) in `chore(release)` commits — any out-of-band edit to a version field is drift the `kit-version-sync` directive catches. Cut the **kit** axis for framework changes, a **pack** axis for directive-content changes; pick the semver level from the [policy table](kit/references/VERSIONING.md#semver-policy).
 
 ```sh
-bash scripts/release.sh <kit|PACK> <X.Y.Z> --dry-run   # preview the plan from any branch — bump, re-stamps, tag, CHANGELOG
-bash scripts/release.sh security 0.2.0                  # cut a pack release (one invocation per changed pack)
-bash scripts/release.sh kit 0.6.0                       # cut a kit release
-bash scripts/release.sh <kit|PACK> <X.Y.Z> --push       # cut and push the branch + tag in one step
+bash scripts/release.sh <kit|PACK> <X.Y.Z> --dry-run   # preview — bump, re-stamps, tag, CHANGELOG
+bash scripts/release.sh security 0.2.0                 # cut a pack release
+bash scripts/release.sh kit 0.6.0 --push               # cut a kit release and push branch + tag
 ```
 
-A real run preflights — it refuses unless you are on `main` with a clean tree, the target is valid semver strictly greater than current, the tag doesn't already exist, and `bash .governance/run.sh` is green. It then bumps the single source of truth, re-derives every stamp (kit axis only), regenerates the `CHANGELOG.md` section from the Conventional Commits since the last matching tag, makes the `chore(release)` commit through the hook path, and creates the prefixed annotated tag (`kit/vX.Y.Z` / `<pack>/vX.Y.Z`). Each pack tags on its own axis and is released lazily — only the pack(s) whose subtree changed get a new tag. Pushing the tag triggers [`release.yml`](.github/workflows/release.yml), which lifts the matching CHANGELOG section into a GitHub Release.
+A real run preflights (`main`, clean tree, semver-greater target, green suite), regenerates the CHANGELOG section, commits through the hook path, and creates the prefixed annotated tag. Pushing the tag triggers [release.yml](.github/workflows/release.yml), which lifts the CHANGELOG section into a GitHub Release. Full procedure: [RELEASE_FLOW.md](kit/references/RELEASE_FLOW.md).
 
-Full procedure and invariants: [RELEASE_FLOW.md](kit/references/RELEASE_FLOW.md). Axes, semver policy, and the tag scheme consumers pin against: [VERSIONING.md](kit/references/VERSIONING.md).
+</details>
+
+## Community
+
+- **[Issues](https://github.com/Duaility/governance-kit/issues)** — bugs and proposals; blank issues are off, and the templates carry the agent-handoff fields the audit chain expects
+- **[Community pack catalog](kit/assets/catalog.community.json)** — the advisory index `governance pack search` reads; currently empty, PRs welcome
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/docs/concepts/audit-chain.mdx
+++ b/docs/concepts/audit-chain.mdx
@@ -1,48 +1,57 @@
 ---
-title: 'The audit chain & ledgers'
-summary: 'issue → receipt → commit → cost, turned into mechanical directives over four git-native, append-only artifacts built for agent-authored commits.'
+title: 'The audit chain'
+summary: 'issue → receipt → commit → cost, turned into mechanical directives over git-native, tamper-evident artifacts built for agent-authored commits.'
 ---
 
-# The audit chain & ledgers
+# The audit chain
 
-If you trust agents to ship code, you need to see what they were told, what they did against each issue, what it cost, and how often you had to grab the wheel. The audit chain turns that into mechanical directives over four git-native, append-only artifacts.
+If you trust agents to ship code, you need to see what they were told, what they did against each issue, what it cost, and how often you had to grab the wheel. The audit chain turns that into mechanical directives over git-native, tamper-evident artifacts.
 
 ## The chain
 
 ```mermaid
 flowchart LR
-  I["Issue"] --> R["Receipt"] --> C["Commit"] --> Co["Cost"]
+    I["<b>Issue #N</b><br/>the work order"]
+    R["<b>Receipt</b><br/>claims crosswalked<br/>to evidence"]
+    C["<b>Commit</b><br/>cost + steering<br/>trailers"]
+    CO["<b>Cost row</b><br/>joined by Cost-Key —<br/>survives the squash"]
+
+    I --> R --> C --> CO
+
+    classDef chain fill:#0d4f86,stroke:#0d4f86,color:#ffffff
+    class I,R,C,CO chain
 ```
 
-Every link is enforced by a directive in the `standard` preset; breaking any link fails the next push:
+Every link is enforced by a directive in the `governance-kit/audit` pack (the `standard` preset); breaking any link fails the next push:
 
 | Link | Directive | What it enforces |
 |---|---|---|
 | Issues exist & are structured | `issue-templates`, `issues-tracked` | Issue forms with handoff fields; a `QUALITY.md` board with `## Open` / `## Resolved` |
 | Work attests itself | `receipt-per-issue` | One receipt file per issue with the required sections and a crosswalked checklist |
 | Commits anchor to work | `commit-issue-receipt-match` | Every commit's `(#N)` anchor matches a receipt it touches |
-| Work carries its price | `agent-token-accounting` | Token + cost trailers on every commit, matching a `COSTS.md` row |
-| Steering is visible | `agent-steering-accounting` | `Steer-*` trailers tallying rows in `STEERING.md` |
-| The record can't be rewritten | `doc-integrity` | Receipts and ledgers are append-only / frozen once on the trunk |
+| Work carries its price | `agent-token-accounting` | Token + cost trailers on every commit, matching a cost row in the issue's receipt |
+| Steering is visible | `agent-steering-accounting` | `Steer-*` trailers tallying steering rows in the issue's receipt |
+| The record can't be rewritten | `doc-integrity` | Receipts freeze once on the trunk; frozen sections keep their baseline lines verbatim |
 
 ## Receipts: attestation over promise
 
-A plan says what the model *intends*; a receipt says what it *did*, in a form a reviewer can check. One receipt per issue, at `receipts/issue-<N>-<slug>.md`, with four required sections:
+A plan says what the model *intends*; a receipt says what it *did*, in a form a reviewer can check. One receipt per issue, at `receipts/issue-<N>-<slug>.md`, with four required sections — plus an `## Accounting` section that carries the issue's cost and steering rows:
 
 ```markdown
 ## Checklist        # mirrors the GitHub issue's acceptance items
 ## What changed     # the actual changes, by file/behavior
 ## Out of scope     # explicitly not done
 ## Verification     # how each claim was checked
+## Accounting       # ### Costs and ### Steering rows, appended per commit
 ```
 
 The trust boundary: **every `- [x]` checklist item must crosswalk** — its text must appear in `## What changed` or `## Verification`. An agent cannot flip a box without writing down what it did and how that was verified. The receipt is what a reviewer reads instead of the raw diff.
 
 `commit-issue-receipt-match` then ties commits to receipts: each non-merge commit needs an issue anchor (`(#N)` in the subject or `Issue: #N` trailer) matching an `issue-<N>` token on a receipt the commit touches.
 
-## COSTS.md: every change has a price tag
+## Cost accounting: every change has a price tag
 
-`agent-token-accounting` requires eight trailers on every non-merge commit:
+`agent-token-accounting` requires the token/cost trailers on every non-merge commit:
 
 ```
 Agent: claude-code
@@ -55,7 +64,7 @@ Cost-Key: claude-01HXYZab-1713800000
 Cost-USD: 2.7932
 ```
 
-…and a matching row in the append-only `COSTS.md` ledger:
+…and a matching row under `### Costs` in the issue's receipt:
 
 ```
 | cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
@@ -64,17 +73,17 @@ Cost-USD: 2.7932
 The layering is the interesting part. Naive anchors all break: PR-level accounting is too late, commit SHAs disappear under squash-merge, transcripts are ephemeral. So:
 
 - **Trailers** carry branch-time provenance on the commit itself.
-- **The ledger row** is the durable record.
-- **`Cost-Key`** is the stable join key present in both — it survives the squash because it lives in the message body and the ledger, not in a SHA.
-- The directive cross-checks trailer ↔ ledger on every commit.
+- **The receipt row** is the durable record.
+- **`Cost-Key`** is the stable join key present in both — it survives the squash because it lives in the message body and the receipt, not in a SHA.
+- The directive cross-checks trailer ↔ receipt on every commit.
 
 Token columns distinguish *new work* from cache traffic (`new-work = input + cache-create + output`; cache reads are excluded), and `Cost-USD` is computed from the runtime-reported model via a rates table — real dollars, not vibes.
 
 The trailers are *stamped* by the directive's own `prepare-commit-msg` populator (reading the runtime's usage data) and *verified* by its check — write and read paths kept separate.
 
-## STEERING.md: where the human grabbed the wheel
+## Steering accounting: where the human grabbed the wheel
 
-`agent-steering-accounting` records **human steering events** — interrupts and corrections — as rows in an append-only `STEERING.md`:
+`agent-steering-accounting` records **human steering events** — interrupts and corrections — as rows under `### Steering` in the issue's receipt:
 
 ```
 | steer-key | session | issue | type | tier | user-reason | commit |
@@ -96,23 +105,23 @@ This directive (and `doc-integrity`) is `always_install: true` — the audit mod
 
 ## doc-integrity: the record cannot be quietly rewritten
 
-An audit trail you can edit is not an audit trail. `doc-integrity` makes the system-of-record documents tamper-evident, driven by standard rules in its `defaults.conf` (layered with the `.governance/conf/doc-integrity.conf` overlay) with three rule shapes:
+An audit trail you can edit is not an audit trail. `doc-integrity` makes the system-of-record documents tamper-evident, driven by standard rules in its `defaults.conf` (layered with the `.governance/conf/governance-kit/audit/doc-integrity.conf` overlay) with three rule shapes:
 
 | Rule | Semantics |
 |---|---|
-| `frozen-files <glob>` | Once a matching file is on the trunk, it is immutable. New files are fine. (Receipts.) |
-| `append-only <file>` | The trunk version must remain a byte-prefix of the current version. (`COSTS.md`, `STEERING.md`.) |
+| `frozen-files <glob>` | Once a matching file is on the trunk, it is immutable. New files are fine. (Receipts — which now carry the accounting rows — and the sealed legacy `COSTS.md` / `STEERING.md` ledgers.) |
+| `append-only <file>` | The trunk version must remain a byte-prefix of the current version. |
 | `frozen-section <file> <heading>` | Lines under the heading survive verbatim; the rest of the file is free. (`QUALITY.md` Resolved, the Evolution Log.) |
 
 Everything is measured against the *trunk baseline* — branch-authored content stays editable until it merges, then freezes. Exceptions are path-scoped waivers in the commit body.
 
-## Reading the ledgers
+## Reading the record
 
 The payoff is that oversight becomes *reading*, not *re-deriving*:
 
 - `git log` headlines show cost and steering at a glance (`Token-Total`, `Cost-USD`, `Steer-Count`).
-- `COSTS.md` answers "what did this feature cost?" with grep.
-- `STEERING.md` answers "where do agents go off the rails?" — input for the next directive.
+- A receipt's `### Costs` rows answer "what did this issue cost?" with grep.
+- Its `### Steering` rows answer "where do agents go off the rails?" — input for the next directive.
 - `receipts/` answers "what exactly landed for issue #N, and how was it verified?"
 
-Next: [Versioning & releases](/concepts/versioning) — how the kit and the packs evolve without breaking the repos that pin them.
+Next: [The sweep lane](/concepts/sweep-lane) — the off-commit-path lane for the rules grep can't reach.

--- a/docs/concepts/constitution.mdx
+++ b/docs/concepts/constitution.mdx
@@ -46,7 +46,7 @@ summary: One-line description shown in the menu
 surface: repo-state        # or: change-set
 hook: pre-commit           # pre-commit | commit-msg | prepare-commit-msg
                            #   | post-commit | pre-push | none (CI-only)
-always_install: true       # optional; reserved to governance-kit/core
+always_install: true       # optional; reserved to the bundled governance-kit/* packs
 requires_hook_strategy: githooks   # optional environment filter
 reads:                     # optional capability declaration (path globs)
   - .github/workflows/**
@@ -119,7 +119,7 @@ Amendment rights follow the owning pack's provenance (from `.governance/packs.lo
 | Owning pack source | `directive add/modify` | `directive remove` |
 |---|---|---|
 | `gh` (community) | Refused — use `pack update` / `pack remove` | Refused — use `pack remove` |
-| kit core | Refused — kit-managed | Allowed — the repo opts out |
+| bundled (`governance-kit/*`) | Refused — pack-managed | Allowed — the repo opts out |
 | `local` (repo-local) | **Allowed** — this is what `directive *` is for | Allowed |
 
 Hand-authored rules live in a **repo-local pack** (created automatically on first `directive add`, or explicitly with `pack create`). Pack-sourced directives that have drifted — edited by hand, corrupted — are restored with [`governance reset`](/reference/verbs), which puts them back to the *pinned* SHA without touching hand-authored ones.

--- a/docs/concepts/limitations.mdx
+++ b/docs/concepts/limitations.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Limitations'
+summary: 'Honest constraints — what the commit path can and cannot enforce, what the sweep lane does not promise, what the accounting depends on, and the V0 stability posture.'
+---
+
+# Limitations
+
+Knowing where the edges are is part of the trust story. These are the constraints, stated plainly.
+
+## The commit path enforces only what bash can decide
+
+Commit-path checks must be **deterministic, fast, and offline** — same repo state, same verdict, no network, target under a second. That ceiling is deliberate (a flaky hook is a skipped hook), but it means:
+
+- Rules that need external state (an API, a ticket system, a database) cannot be commit-path directives.
+- Rules about *intent and architectural shape* are beyond grep — they belong to the [sweep lane](/concepts/sweep-lane), which is advisory by design.
+
+## Local hooks are a convenience, not the contract
+
+`SKIP_GOVERNANCE=1` and `--no-verify` exist, on purpose, for local hotfixes. The contract is CI: every directive re-runs on every PR. If your threat model requires that no non-compliant commit can ever be *created* locally, Governance Kit does not provide that — it guarantees non-compliant work cannot *merge*.
+
+## The sweep lane is advisory and model-dependent
+
+- Verdicts come from an LLM judge: calibrated against fixtures with a precision floor, budget-capped, and pinned to a capability tier — but not deterministic the way a grep is.
+- A scheduled sweep needs a model-API token in CI; without one, only the deterministic echo stub runs (useful for tests, not for enforcement).
+- Findings arrive as a digest issue, not a blocked commit. Promotion to a gate is a future, per-directive decision contingent on precision history.
+
+## The accounting depends on runtime cooperation
+
+- Token and steering trailers are stamped by populators reading **the runtime's usage data**. Runtimes that don't expose usage need an adapter; without one, those directives report the gap rather than inventing numbers.
+- The audit chain assumes the squash-merge setting **keeps commit bodies** — squashing to blank bodies strips the trailers the trunk checks verify.
+- Steering accounting records human correction text **verbatim**. If that text can contain sensitive content, redact via the directive's classifier hook — the directive is `always_install` and should not simply be switched off.
+
+## One issue, one PR, one receipt
+
+Receipts freeze once they reach the trunk. The workflow this enforces is deliberately simple — issue → PR → receipt — and multi-PR epics that keep amending one receipt are not supported. Cut the work so each PR closes its issue.
+
+## V0 posture
+
+Governance Kit is pre-1.0. The two semver axes are honored (see [Versioning](/concepts/versioning)) and updates are diff-before-exec, but there is no long-term stability promise yet: names, layouts, and schemas can change between minor versions, with `kit update` as the migration path.
+
+## What it is not
+
+- **Not a linter** — formatting opinions belong in formatters; directives encode governance.
+- **Not a spec tool** — [spec-kit](https://github.com/github/spec-kit)-style workflows answer "what should this feature do?"; Governance Kit answers "what must every commit satisfy?". They compose.
+- **Not an agent firewall** — it shapes and audits what agents commit; it does not sandbox what they execute.

--- a/docs/concepts/packs.mdx
+++ b/docs/concepts/packs.mdx
@@ -19,7 +19,7 @@ Three kinds, distinguished by provenance:
 
 | Kind | Where it's authored | Lockfile `source` | Example |
 |---|---|---|---|
-| **Core** | Bundled with the kit | `gh` | `governance-kit/core` — installs with `init`, always selected |
+| **Bundled** | Ships with the kit | `gh` | `governance-kit/{foundation,security,docs,commits,audit,architecture}` — the concern packs offered at `init` |
 | **Community** | Its own GitHub repo | `gh` | `acme/soc2-pack` — installed via `pack add gh:acme/soc2-pack@v1.2.0` |
 | **Repo-local** | Your repo, by hand or via `directive add` | `local` | `<your-org>/<your-repo>` — no upstream, skipped by `pack update` |
 
@@ -34,7 +34,7 @@ gh:<owner>/<repo>[/<subpath>][@<rev>]
 ```
 
 - `subpath` points at the directory containing `pack.yaml` (monorepo support).
-- `rev` is a branch, tag, or 40-char SHA. **Pin tags, not branches** — `@main` silently tracks the moving tip on every update; `@core/v0.4.0` is an immutable, reviewable pin. Whatever you pin, it is resolved to a commit SHA at add time.
+- `rev` is a branch, tag, or 40-char SHA. **Pin tags, not branches** — `@main` silently tracks the moving tip on every update; an immutable tag like `@commits/v0.2.0` is a reviewable pin. Whatever you pin, it is resolved to a commit SHA at add time.
 
 Fetched packs land in a SHA-addressed, immutable shared cache (`~/.governance/cache/packs/<pack>@<sha>/`); hitting a cached SHA skips the network entirely.
 
@@ -99,9 +99,9 @@ Both are plan/apply with per-directive diffs and explicit confirmation.
 A pack's `pack.yaml` declares named presets — `minimal`, `standard`, `strict` — each listing directive ids (with `extends:` for union). At `init`, the install set is computed as:
 
 ```
-install = always_install(core) ∪ preset_selection ∪ user_selections
+install = always_install(bundled) ∪ preset_selection ∪ user_selections
 ```
 
-across all selected packs, with cross-pack directive-id collisions rejected (the directive namespace is flat). `always_install: true` is reserved to `governance-kit/core` — used for the two directives the audit model depends on unconditionally (`doc-integrity`, `agent-steering-accounting`).
+across all selected packs, with cross-pack directive-id collisions rejected (the directive namespace is flat). `always_install: true` is reserved to the bundled `governance-kit/*` packs — used for the two directives the audit model depends on unconditionally (`doc-integrity`, `agent-steering-accounting`).
 
 Next: [The runtime](/concepts/runtime) — what actually happens when you type `git commit`.

--- a/docs/concepts/sweep-lane.mdx
+++ b/docs/concepts/sweep-lane.mdx
@@ -1,0 +1,78 @@
+---
+title: 'The sweep lane'
+summary: 'The off-commit-path enforcement lane for semantic rules — a scheduled grep triage, a budget-capped LLM judge, and one digest issue that re-enters as ordinary work.'
+---
+
+# The sweep lane
+
+Greppability is a directive's enforcement ceiling. A `check.sh` is bash + `git grep` — perfect for *syntactic* invariants (forbidden imports, banned identifiers, file-shape rules), useless for the *semantic* ones about **intent and architectural shape**: "remove the legacy fallback", "don't bifurcate the code path", "local must mirror remote". Those are exactly the corrections humans keep making to agent-authored code.
+
+The **sweep** surface is a third enforcement lane for those invariants — one that **never touches the commit path**.
+
+```mermaid
+flowchart TD
+    W[Scheduled workflow<br/>daily cron — off the commit path]
+    P[Pick commit range<br/>resume from last digest]
+    T[Triage with grep<br/>narrow to candidate hunks]
+    J{Adjudicate each hunk<br/>budget-capped, one verdict}
+    D[File one digest issue<br/>dedupe + confidence filter]
+    L([Issue → agent → PR<br/>advisory, never blocks])
+
+    W --> P --> T --> J --> D --> L
+    D -.->|"next run resumes here"| P
+```
+
+## Why off the commit path
+
+A false positive on the commit path is catastrophic: one wrong block → `--no-verify` → *every* directive, including the solid greps, is bypassed. Put the judge on a schedule instead and that failure mode dissolves rather than needing to be solved — a noisy verdict costs a triage, not the gate's authority. Determinism and latency relax from hard requirements to hygiene.
+
+This mirrors the harness-engineering split: mechanical linters enforce structure synchronously; background tasks scan for semantic deviations on a schedule and open targeted work items. There is **no blocking path at all** — promoting a sweep directive to a gate is a separate future decision, contingent on the directive's digest-precision history.
+
+Findings re-enter the repo through the same door as a human correction: **issue → agent → PR**.
+
+## The directive contract
+
+A sweep directive is the same self-contained folder as any other, with three differences. `surface: sweep` is what `run.sh` and the hook generator key off to ignore it entirely — it is invisible to pre-commit and the PR governance job by construction:
+
+```yaml
+category: ArchitecturalShape
+surface: sweep          # the third surface, alongside repo-state | change-set
+hook: none
+engine: llm
+model_tier: high        # a capability tier, not a model id
+summary: "No backward-compat shims or legacy fallback paths."
+```
+
+The folder carries:
+
+- **`triage.sh`** instead of `check.sh` — a cheap grep pre-filter. The engine sets a git range; the script prints `path:line` candidate locations. Empty output costs zero inference requests. Triage is never the verdict: over-inclusion is fine (the judge rejects false smoke); under-inclusion is the real risk, so patterns stay broad.
+- **`constitution.md`** — the Directive + Rationale already authored for humans doubles as the judge's rubric. No new authoring format.
+- **`evals/violating/` + `evals/clean/`** — calibration fixtures, plus an eval that runs the real judge against them with a precision/recall floor. No eval, no ship.
+
+## The engine
+
+A kit-owned, stdlib-only engine (vendored as `.governance/sweep.py`) does the work in a plain cron with nothing but system Python:
+
+- **Range** — commits since the last sweep. State lives in the previous digest issue (an HTML-comment marker records the end SHA), so there is no committed state file. First runs fall back to a time window.
+- **Triage** — each sweep directive's `triage.sh` over the range, narrowing a day of commits to candidate hunks.
+- **Adjudication** — each hunk gets one structured verdict (`pass`, violations with file/line/quote/why, confidence) under a request budget. In CI and tests, a deterministic echo stub stands in for the model.
+- **Digest** — one issue per run, deduplicated and confidence-filtered, never one issue per finding.
+
+## Guardrails
+
+- **Advisory until proven.** A sweep directive stays advisory until its digest precision earns a promotion — and promotion is a deliberate decision, not a default.
+- **Tier, not model id.** Directives pin a capability *tier*; an upgrade within a tier can't silently rewrite verdicts.
+- **Budget-capped.** Each run adjudicates under an explicit request budget; triage keeps the candidate set small enough that the budget means something.
+
+## What ships today
+
+The opt-in `governance-kit/architecture` pack (the `strict` preset) carries the pilot directives:
+
+| Directive | What it watches for |
+|---|---|
+| `no-legacy-fallbacks` | Backward-compat shims and legacy fallback paths in agent-authored changes. |
+| `no-path-bifurcation` | Bifurcated code paths — dual dispatch, local-vs-remote special-casing. |
+
+Enabling the pack also installs the scheduled workflow and the vendored engine.
+
+Next: [Versioning & releases](/concepts/versioning) — how the kit and the packs evolve without breaking the repos that pin them.

--- a/docs/concepts/versioning.mdx
+++ b/docs/concepts/versioning.mdx
@@ -5,16 +5,16 @@ summary: 'Two independent semver axes — the kit (framework) and the packs (con
 
 # Versioning & releases
 
-governance-kit versions **two independent things on two independent semver axes** — the Helm `Chart.version` vs `appVersion` model. Understanding the split explains most of the lifecycle verbs.
+Governance Kit versions **two independent things on two independent semver axes** — the Helm `Chart.version` vs `appVersion` model (see the [toolchain-manager mental model](/guide/mental-models#2-an-installer-a-product-its-content)). Understanding the split explains most of the lifecycle verbs.
 
 ## The two axes
 
 | Axis | What it covers | Source of truth | Tag scheme |
 |---|---|---|---|
 | **Kit** (framework) | The `governance` skill, the runtime (`run.sh`, `lib.sh`), hook generators, schemas, verbs | `kit/assets/kit.yaml` | `kit/vX.Y.Z` |
-| **Pack** (content) | Directive code — checks, constitution snippets, presets | Each pack's `pack.yaml` | `<pack>/vX.Y.Z` (e.g. `core/v0.4.0`) |
+| **Pack** (content) | Directive code — checks, constitution snippets, presets | Each pack's `pack.yaml` | `<pack>/vX.Y.Z` (e.g. `security/v0.2.0`) |
 
-They move independently: the core pack can ship a check fix without the framework moving, and the framework can add a verb without any directive changing. One contract ties them: a pack's `min_governance_kit` must be ≤ the installed kit version.
+They move independently: a bundled pack can ship a check fix without the framework moving, and the framework can add a verb without any directive changing. One contract ties them: a pack's `min_governance_kit` must be ≤ the installed kit version.
 
 A repo therefore carries **two pins**:
 
@@ -42,18 +42,18 @@ Schema versions — `install.yaml version: "3"`, `packs.lock version: "2"` — a
 
 ## Version stamps and the consistency directive
 
-Kit-owned files in a target repo carry the marker `# governance-kit:managed kit-version=<v>`. The `version-consistency` directive asserts that **every marker agrees with `install.yaml`'s `kit_version`** — a half-applied update or a hand-edited runtime file shows up as drift, with `governance kit update` as the repair path.
+Kit-owned files in a target repo carry the marker `# governance-kit:managed kit-version=<v>`. The `kit-version-sync` directive asserts that **every marker agrees with `install.yaml`'s `kit_version`** — a half-applied update or a hand-edited runtime file shows up as drift, with `governance kit update` as the repair path.
 
 Markers are deliberately **dateless**: re-stamping the same version is a byte-identical no-op, which keeps updates idempotent.
 
 ## How releases are cut
 
-Version lines are written **only** by `scripts/release.sh`, in `chore(release)` commits — feature and fix PRs never touch a version field. That invariant is what lets `version-consistency` treat any out-of-band version edit as drift.
+Version lines are written **only** by `scripts/release.sh`, in `chore(release)` commits — feature and fix PRs never touch a version field. That invariant is what lets `kit-version-sync` treat any out-of-band version edit as drift.
 
 ```sh
-bash scripts/release.sh <kit|core> <X.Y.Z> --dry-run   # preview from any branch
-bash scripts/release.sh core 0.5.0                     # cut a core pack release
-bash scripts/release.sh kit 0.5.0 --push               # cut + push branch and tag
+bash scripts/release.sh <kit|PACK> <X.Y.Z> --dry-run   # preview from any branch
+bash scripts/release.sh security 0.2.0                 # cut a pack release (one per changed pack)
+bash scripts/release.sh kit 0.6.0 --push               # cut + push branch and tag
 ```
 
 A real run:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "name": "governance-kit",
-  "description": "Governance-driven development: declare the repo state you want in a versioned CONSTITUTION.md, ship every rule with an executable test, and let agents converge on it.",
+  "name": "Governance Kit",
+  "description": "Governance Kit is the governance layer for AI coding agents: every rule ships with an executable test, every commit is checked, and every agent-authored change leaves a git-native audit trail.",
   "theme": "mint",
   "icons": {
     "library": "lucide"
@@ -34,44 +34,67 @@
       }
     ]
   },
-  "redirects": [],
+  "redirects": [
+    {
+      "source": "/guide/getting-started",
+      "destination": "/guide/quickstart"
+    }
+  ],
   "navigation": {
     "languages": [
       {
         "language": "en",
         "tabs": [
           {
-            "tab": "Guide",
+            "tab": "Documentation",
             "groups": [
               {
                 "group": "Get started",
                 "pages": [
                   "index",
                   "guide/introduction",
-                  "guide/getting-started",
+                  "guide/quickstart",
+                  "guide/installation",
                   "guide/mental-models"
                 ]
-              }
-            ]
-          },
-          {
-            "tab": "Inner workings",
-            "groups": [
+              },
               {
-                "group": "How it works",
+                "group": "The constitution",
                 "pages": [
                   "concepts/constitution",
-                  "concepts/packs",
-                  "concepts/runtime",
-                  "concepts/audit-chain",
-                  "concepts/versioning"
+                  "concepts/runtime"
                 ]
-              }
-            ]
-          },
-          {
-            "tab": "Reference",
-            "groups": [
+              },
+              {
+                "group": "Packs",
+                "pages": [
+                  "concepts/packs"
+                ]
+              },
+              {
+                "group": "The audit chain",
+                "pages": [
+                  "concepts/audit-chain"
+                ]
+              },
+              {
+                "group": "The sweep lane",
+                "pages": [
+                  "concepts/sweep-lane"
+                ]
+              },
+              {
+                "group": "Integrations",
+                "pages": [
+                  "reference/native-tests"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "pages": [
+                  "guide/configuration"
+                ]
+              },
               {
                 "group": "Reference",
                 "pages": [
@@ -79,8 +102,20 @@
                   "reference/directive-catalog",
                   "reference/schemas",
                   "reference/authoring-directives",
-                  "reference/authoring-packs",
-                  "reference/native-tests"
+                  "reference/authoring-packs"
+                ]
+              },
+              {
+                "group": "Architecture",
+                "pages": [
+                  "concepts/versioning",
+                  "concepts/limitations"
+                ]
+              },
+              {
+                "group": "Help",
+                "pages": [
+                  "guide/troubleshooting"
                 ]
               }
             ]

--- a/docs/guide/configuration.mdx
+++ b/docs/guide/configuration.mdx
@@ -1,0 +1,48 @@
+---
+title: 'Configuration'
+summary: 'How directives are tuned — pack-owned defaults, user-owned overlays under .governance/conf/, env-tunable limits, and presets.'
+---
+
+# Configuration
+
+Directives are tuned through two layers with a clear ownership split: the **pack owns the defaults**, the **repo owns the overlay**. Nothing is configured by editing check code.
+
+## The two layers
+
+| Layer | File | Owner | When it changes |
+|---|---|---|---|
+| **Defaults** | `<directive>/defaults.conf`, vendored with the directive | The pack author | Refreshed on `governance pack update` |
+| **Overlay** | `.governance/conf/<owner>/<pack>/<directive-id>.conf` | You | Hand-edited, committed like any file |
+
+`defaults.conf` is the one pack-owned config artifact: the live default values (scalar `KEY=value` rows and/or list rows) **and** their documentation, together. The overlay is seeded at install from a generic stub and is yours from then on — pack updates never touch it.
+
+Checks read the merged result through the shared `lib.sh` helpers (`conf_get` for scalars, `conf_list` for lists), so every directive resolves configuration the same way: overlay first, defaults as fallback.
+
+```
+.governance/conf/
+└── governance-kit/
+    ├── docs/
+    │   ├── doc-freshness.conf          # which docs opt into the freshness marker
+    │   └── internal-doc-links.conf     # reachability roots (opt-in)
+    └── audit/
+        └── doc-integrity.conf          # extra frozen-file / append-only rules
+```
+
+## Common knobs
+
+- **Opt-in doc lists** — `doc-freshness` checks only the docs listed in its overlay; `internal-doc-links`' `reachable` sub-check is a no-op until you declare roots.
+- **Rule lists** — `doc-integrity` ships standard rules in its `defaults.conf` (receipts frozen once on the trunk, frozen sections for `QUALITY.md` Resolved and the Evolution Log); the overlay adds repo-specific rules.
+- **Add / drop semantics** — list-valued overlays like `toolchain-config-protection`'s protected paths use a bare line to add a pattern and `!<pattern>` to drop one of the defaults.
+- **Env-tunable limits** — metric checks expose their thresholds as environment variables (`GOVERNANCE_<X>_LIMIT`), e.g. `repo-hygiene`'s file-size and source-length limits.
+
+## Presets are configuration too
+
+Which directives install at all is declared per pack in `pack.yaml` presets (`minimal` / `standard` / `strict`), chosen at `governance init` and adjustable later with `directive add` / `directive remove`. See [Quickstart — choosing a preset](/guide/quickstart#choosing-a-preset) and [Packs](/concepts/packs#presets).
+
+## What not to configure by hand
+
+The lockfile, `CONSTITUTION.md`, and anything carrying the `# governance-kit:managed` marker are written only by the verbs. Overlays under `.governance/conf/` are the deliberate exception — they are *designed* to be hand-edited and committed.
+
+<Note>
+Each directive's exact knobs are documented in its own `defaults.conf` and its constitution subsection's **Exceptions** field. The [directive catalog](/reference/directive-catalog) lists which directives are configurable.
+</Note>

--- a/docs/guide/installation.mdx
+++ b/docs/guide/installation.mdx
@@ -1,0 +1,66 @@
+---
+title: 'Installation'
+summary: 'Install scopes for npx skills, manual symlink install, what lands on disk (the thin shim and the kit cache), and how to remove it all.'
+---
+
+# Installation
+
+The published skill is a **thin shim** — an installer document plus one stdlib-only fetch script. Everything else (rules, packs, templates, every other verb) lives in the kit, fetched from a released `kit/vX.Y.Z` tag at install time and pinned per repo.
+
+## With npx skills
+
+<CodeGroup>
+
+```sh All agents (user-wide)
+npx skills add Duaility/governance-kit -g
+```
+
+```sh One agent
+npx skills add Duaility/governance-kit -a claude-code
+```
+
+```sh Project-scoped
+npx skills add Duaility/governance-kit
+```
+
+</CodeGroup>
+
+`npx skills` auto-detects the skill and symlinks it into every skills-compatible runtime on your machine (`~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, …).
+
+## Manual install
+
+No `npx`, or hacking on the kit itself — clone and symlink the skill folder into each runtime you use:
+
+```sh
+git clone https://github.com/Duaility/governance-kit
+cd governance-kit
+ln -s "$(pwd)/skill" ~/.claude/skills/governance   # Claude Code
+ln -s "$(pwd)/skill" ~/.codex/skills/governance    # Codex
+```
+
+Edits in the clone flow to every linked runtime live.
+
+## What lands where
+
+| Layer | Where | When it moves |
+|---|---|---|
+| **The skill** (shim) | Your runtime's skills directory (symlink) | When you re-run `npx skills add` — rarely needed |
+| **The kit** (product) | A shared cache (`~/.governance/cache/kits/`), fetched per released tag | When a repo's pin advances via `governance kit update` |
+| **The repo surface** | `CONSTITUTION.md`, `.governance/`, hooks, CI workflow in each target repo | Through the verbs — `init`, `pack *`, `directive *`, `reset` |
+
+The skill carries no kit code and versions independently of it. Every verb executes from the kit version the repo pins in `.governance/install.yaml` — so two repos on different kit versions behave exactly as their pins say, regardless of when you installed the skill. Offline with nothing cached, the shim refuses rather than guessing.
+
+## Updating
+
+```sh
+npx skills add Duaility/governance-kit    # refresh the shim itself (rarely needed)
+governance kit update                     # inside a repo: advance the kit pin and re-sync runtime files
+governance pack update                    # inside a repo: advance directive-content pins
+```
+
+`kit update` and `pack update` are disjoint — framework runtime vs directive content. See [Versioning & releases](/concepts/versioning).
+
+## Removing
+
+- **From a repo**: `governance uninstall` reverses everything `init` did — see [Verbs](/reference/verbs).
+- **From your machine**: delete the symlink your installer created (`npx skills` manages `~/.claude/skills/…`, `~/.codex/skills/…`, etc.). The shared kit cache under `~/.governance/cache/` is safe to delete at any time; it re-fetches on demand.

--- a/docs/guide/introduction.mdx
+++ b/docs/guide/introduction.mdx
@@ -1,27 +1,27 @@
 ---
-title: 'What is governance-kit?'
+title: 'What is Governance Kit?'
 summary: 'Governance-driven development — a constitution every agent reads, every commit is checked against, and that evolves as one artifact with its tests.'
 ---
 
-# What is governance-kit?
+# What is Governance Kit?
 
-governance-kit is a toolkit for **governance-driven development (GDD)**: a workflow where your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant.
+Governance Kit is a toolkit for **governance-driven development (GDD)**: a workflow where your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant.
 
 It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex, Cursor, and 40+ skills-compatible runtimes. One skill, one entry point: the `governance` verb surface.
 
 ## The problem it solves
 
-Coding agents author most of the changes now. That shifts the hard problem: it is no longer "tell one agent what to do in one session" — it is **keeping the repository understandable across many branches, many agents, and many handoffs**.
+Coding agents author most of the changes now. That shifts the hard problem: it is no longer "tell one agent what to do in one session" — it is **keeping the repository understandable across many branches, many agents, and many handoffs**. OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article names this failure set from running an agent-first codebase: instruction files that "rot instantly", agents that replicate uneven patterns until the codebase drifts, knowledge trapped in chat threads, and human QA capacity becoming the bottleneck.
 
 Two things stop scaling at agent throughput:
 
 1. **Steering.** Your guidance has to reach the *next* agent, on the *next* branch, without you in the room. Per-turn prompting does not compose — the next agent cannot read your last conversation.
 2. **Visibility.** When agents ship the diffs, you need a readable trail, not a stack of PRs and ephemeral chat transcripts.
 
-governance-kit answers both with repo-native artifacts:
+Governance Kit answers both with repo-native artifacts:
 
 - **A constitution** — `CONSTITUTION.md`, a versioned set of directives every agent reads and every commit is checked against.
-- **Ledgers** — append-only files (`COSTS.md`, `STEERING.md`, `QUALITY.md`, `receipts/`) that record what agents were told, what they did, and what it cost.
+- **Receipts and ledgers** — per-issue receipts (with cost and steering accounting) and the `QUALITY.md` board, recording what agents were told, what they did, and what it cost.
 
 ## The stance in one line
 
@@ -29,10 +29,10 @@ governance-kit answers both with repo-native artifacts:
 
 This is declarative reconciliation — the Kubernetes/Terraform model — applied to a repository:
 
-| | In governance-kit |
+| | In Governance Kit |
 |---|---|
 | **Desired state** | `CONSTITUTION.md` — directives, rationale, exceptions, evolution log |
-| **Current state** | The working tree, staged diff, commit message, receipts, ledgers |
+| **Current state** | The working tree, staged diff, commit message, receipts |
 | **Controller** | `.governance/run.sh` + git hook dispatchers + CI |
 | **Reconciler** | The agent — reads the gap and its rationale, fixes the repo, re-runs |
 
@@ -55,12 +55,12 @@ The `constitution.md` carries the *why*:
 ```markdown
 ### doc-freshness
 
-- **Directive**: Docs opted into `.governance/conf/doc-freshness.conf` carry a
+- **Directive**: Docs opted into the doc-freshness config carry a
   `<!-- last-verified: YYYY-MM-DD -->` marker dated within the last 90 days.
 - **Rationale**: Critical runbooks and onboarding docs decay. A periodic
   "someone re-read this" checkpoint keeps them honest.
-- **Enforced by**: .governance/packs/governance-kit/core/directives/doc-freshness/check.sh
-- **Exceptions**: Remove a doc from `.governance/conf/doc-freshness.conf` to opt it out.
+- **Enforced by**: .governance/packs/governance-kit/docs/directives/doc-freshness/check.sh
+- **Exceptions**: Remove a doc from the config overlay to opt it out.
 ```
 
 A bare hook would only check the date format. The rationale tells the next agent — and the next human — what the date is *for*.
@@ -75,20 +75,20 @@ A bare hook would only check the date format. The rationale tells the next agent
     [spec-kit](https://github.com/github/spec-kit)-style workflows answer *"what should this feature do?"* — per-task, pre-implementation, often disposable. GDD answers *"what must every commit satisfy?"* — persistent, post-implementation, mechanical. They compose: spec-kit steers the agent at runtime; GDD steers it at "compile time."
   </Accordion>
   <Accordion title="Not just hooks" icon="git-branch">
-    pre-commit / husky / lefthook run scripts. governance-kit runs scripts **and** carries the rationale, the audit trail, and the evolution history alongside each test — and its checks are plain bash you can lift out if you only want the enforcement half.
+    pre-commit / husky / lefthook run scripts. Governance Kit runs scripts **and** carries the rationale, the audit trail, and the evolution history alongside each test — and its checks are plain bash you can lift out if you only want the enforcement half.
   </Accordion>
 </AccordionGroup>
 
 ## Where to go next
 
 <Columns cols={3}>
-  <Card title="Getting started" href="/guide/getting-started" icon="rocket">
+  <Card title="Quickstart" href="/guide/quickstart" icon="rocket">
     Install, bootstrap, watch a gate fire.
   </Card>
   <Card title="Mental models" href="/guide/mental-models" icon="brain">
-    The seven ideas everything else builds on.
+    The ideas everything else builds on.
   </Card>
-  <Card title="Inner workings" href="/concepts/constitution" icon="cog">
+  <Card title="The constitution" href="/concepts/constitution" icon="scroll">
     How the pieces fit together.
   </Card>
 </Columns>

--- a/docs/guide/mental-models.mdx
+++ b/docs/guide/mental-models.mdx
@@ -1,18 +1,18 @@
 ---
 title: 'Mental models'
-summary: 'The handful of ideas everything in governance-kit follows from — reconciliation loops, the cardinal rule, rule-layer steering, receipts, and waivers as data.'
+summary: 'The handful of ideas everything in Governance Kit follows from — reconciliation loops, the toolchain-manager model, the cardinal rule, rule-layer steering, receipts, and waivers as data.'
 ---
 
 # Mental models
 
-Everything in governance-kit follows from a handful of ideas. If you internalize this page, the rest of the docs are details.
+Everything in Governance Kit follows from a handful of ideas. If you internalize this page, the rest of the docs are details.
 
 ## 1. The repo is a reconciliation loop
 
 The core model is the one Kubernetes and Terraform use, applied to a repository:
 
 - **Desired state** is declared in `CONSTITUTION.md` — directives with rationale.
-- **Current state** is reality: the working tree, the staged diff, the pending commit message, the ledgers.
+- **Current state** is reality: the working tree, the staged diff, the pending commit message, the receipts.
 - **Checks** compare the two. Every directive is an *invariant on state*, not a step in a procedure.
 - **The agent is the reconciler.** A failed check names the gap and the why; the agent fixes the repo and re-runs until reality matches the declaration.
 
@@ -31,7 +31,42 @@ Because directives are invariants, there is **no dependency graph and no orderin
 Don't chain actions; describe state and let re-evaluation converge.
 </Tip>
 
-## 2. The cardinal rule: rule and test are one artifact
+## 2. An installer, a product, its content
+
+Governance Kit is three layers, and the analogy to a language toolchain manager carries almost all the way:
+
+```mermaid
+flowchart TB
+    S["<b>governance skill — the installer</b><br/>install · update · uninstall"]
+    K["<b>the kit — kit/vX.Y.Z — the product</b><br/>engines · flows · templates · every verb"]
+    P["<b>packs — pack/vX.Y.Z — the content</b><br/>directive code, lock-pinned"]
+    PIN["<b>the repo decides its versions</b><br/>install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin"]
+    RU["≈ rustup<br/>the version manager"]
+    TC["≈ the toolchain<br/>compiler · libs · tools"]
+    LF["≈ the lockfile<br/>pinned dependencies"]
+
+    S -->|"installs · updates"| K
+    K -->|"consumes"| P
+    P ~~~ PIN
+    S -.- RU
+    K -.- TC
+    P -.- LF
+
+    classDef installer fill:#4938a8,stroke:#4938a8,color:#ffffff
+    classDef product fill:#0c7a52,stroke:#0c7a52,color:#ffffff
+    classDef content fill:#9c3a1d,stroke:#9c3a1d,color:#ffffff
+    classDef analogy fill:#44443e,stroke:#44443e,color:#e8e8e3
+    classDef pin fill:#0d4f86,stroke:#0d4f86,color:#ffffff
+    class S installer
+    class K product
+    class P content
+    class RU,TC,LF analogy
+    class PIN pin
+```
+
+The skill is a two-file shim that fetches and honors pins; the kit is the versioned product every verb executes from; packs are the directive content the kit consumes. Each layer versions independently, and the *repo* — not the installer — decides which versions it runs. See [Versioning & releases](/concepts/versioning).
+
+## 3. The cardinal rule: rule and test are one artifact
 
 > If a rule is not executable, it is not a rule — it is a wish.
 
@@ -43,27 +78,27 @@ Every directive in `CONSTITUTION.md` has a matching `check.sh`, and **amendments
 
 — committed together. There is no drift between "what we said the rule is" and "what the repo actually enforces," because they are the same artifact.
 
-A corollary: things that *can't* be mechanically checked are **principles**, not directives. They live in the constitution too, but their enforcement gate is human judgment at PR review. The kit is honest about the boundary.
+A corollary: things that *can't* be mechanically checked are **principles**, not directives. They live in the constitution too, but their enforcement gate is human judgment at PR review. The kit is honest about the boundary — and for the semantic rules in between, there is the off-commit-path [sweep lane](/concepts/sweep-lane).
 
-## 3. Steer at the rule layer, not the turn layer
+## 4. Steer at the rule layer, not the turn layer
 
 Per-turn prompting does not compose. The next agent on the next branch cannot read your last conversation. A directive in `CONSTITUTION.md` reaches every future agent without you being in the room — **once-authored, infinitely-enforced**.
 
-The redirects you *don't* promote into directives aren't lost either: the `STEERING.md` ledger records every human interrupt and correction, per commit. Where humans repeatedly steer is the signal for which rules are missing or misaligned — the rules themselves evolve, not just the prompts.
+The redirects you *don't* promote into directives aren't lost either: every human interrupt and correction is recorded as a steering row in the issue's receipt, per commit. Where humans repeatedly steer is the signal for which rules are missing or misaligned — the rules themselves evolve, not just the prompts.
 
-## 4. Receipts beat plans; ledgers outlive sessions
+## 5. Receipts beat plans; ledgers outlive sessions
 
 Pre-implementation plans are the model's *promise*; post-implementation receipts are its *attestation*. Plans are private to the runtime and get thrown away. Receipts are durable, reviewable, and crosswalk every claim ("I did X") to evidence (where X is verifiable in the diff or the verification steps).
 
-The system of record is a set of **append-only files in the repo** — `CONSTITUTION.md`, `COSTS.md`, `STEERING.md`, `QUALITY.md`, `receipts/` — not chat history, not session transcripts, not runtime-local state. They survive the squash merge, the runtime swap, and the team turnover. The [audit chain](/concepts/audit-chain) wires them together: **issue → receipt → commit → cost**, and breaking any link fails the next push.
+The system of record is a set of **tracked, tamper-evident files in the repo** — `CONSTITUTION.md`, `QUALITY.md`, `receipts/` (each receipt carrying its issue's cost and steering accounting) — not chat history, not session transcripts, not runtime-local state. They survive the squash merge, the runtime swap, and the team turnover. The [audit chain](/concepts/audit-chain) wires them together: **issue → receipt → commit → cost**, and breaking any link fails the next push.
 
-## 5. Verify, don't trust — and make verification cheap
+## 6. Verify, don't trust — and make verification cheap
 
 The agent is treated as a moderately untrusted author whose work crosswalks back to an issue, evidence, and cost. This is not pessimism about agents; it is the posture mature teams already take with humans (CI, review, audit trails). GDD's job is to make that posture *cheap enough to apply at agent throughput*, because human review bandwidth does not scale with agent commit volume.
 
 The same posture applies to the kit's own supply chain: pack code is **pinned by SHA and vendored into your tree**, so the check code that gates your commits is reviewable in your own diffs ([Packs, pins & vendoring](/concepts/packs)).
 
-## 6. Plan / apply, diff-before-exec
+## 7. Plan / apply, diff-before-exec
 
 Every lifecycle verb (`init`, `uninstall`, `reset`, `kit update`, `pack *`) is split into a deterministic **plan** step and an **apply** step:
 
@@ -72,9 +107,9 @@ Every lifecycle verb (`init`, `uninstall`, `reset`, `kit update`, `pack *`) is s
 
 Nothing destructive runs without showing you the exact diff first, and applies either land fully or roll back. Verbs are idempotent — running them against an already-converged repo is a successful no-op. And **no verb touches the network at commit time**: all fetching happens inside user-invoked verbs, never in hooks.
 
-## 7. Exceptions are data, not bypasses
+## 8. Exceptions are data, not bypasses
 
-Real repos need exceptions. governance-kit's answer is the **waiver** — an in-source comment that names the directive and the reason:
+Real repos need exceptions. Governance Kit's answer is the **waiver** — an in-source comment that names the directive and the reason:
 
 ```
 # governance: allow-<directive-id> <reason>
@@ -92,8 +127,8 @@ Waivers are intentional, local, and visible in `git blame` — an auditable reco
 | **Pack** | A versioned bundle of directives, installed and pinned as a unit. |
 | **Preset** | A named directive selection a pack declares (`minimal` / `standard` / `strict`). |
 | **Evolution Log** | Append-only history in `CONSTITUTION.md` recording every governance change with date and author. |
-| **Receipt** | Per-issue attestation file under `receipts/`, crosswalking claims to evidence. |
-| **Ledger** | Append-only system-of-record file (`COSTS.md`, `STEERING.md`, …). |
+| **Receipt** | Per-issue attestation file under `receipts/`, crosswalking claims to evidence and carrying the issue's cost and steering accounting. |
+| **Sweep** | The off-commit-path directive surface: LLM-adjudicated, advisory, filed as digest issues. |
 | **Drift** | Misalignment between things that should agree — constitution vs. test, doc vs. code, lockfile vs. tree. |
 | **System of record** | The tracked files that define how the repo works *now*. |
 
@@ -103,14 +138,15 @@ Waivers are intentional, local, and visible in `git blame` — an auditable reco
 your-repo/
 ├── CONSTITUTION.md              # desired state: directives + rationale + evolution log
 ├── AGENTS.md                    # entry point; carries the "follow the constitution" block
-├── QUALITY.md  COSTS.md  STEERING.md  receipts/   # the ledgers
+├── QUALITY.md  receipts/        # the quality board + per-issue receipts (incl. accounting)
 ├── .governance/
 │   ├── run.sh  lib.sh           # the runner (kit-owned, version-stamped)
-│   ├── install.yaml             # init choices + side-effect receipt
+│   ├── install.yaml             # init choices + side-effect receipt; pins the kit
 │   ├── packs.lock               # pack pin state (id, version, source, sha)
-│   └── packs/<owner>/<name>/directives/<id>/   # vendored check code
+│   ├── conf/<owner>/<pack>/<id>.conf               # user-owned config overlays
+│   └── packs/<owner>/<name>/directives/<id>/       # vendored check code
 ├── .githooks/                   # generated hook dispatchers (or .husky/, …)
-└── .github/workflows/governance.yml            # CI re-enforcement
+└── .github/workflows/governance.yml                # CI re-enforcement
 ```
 
 Next: [The constitution & directives](/concepts/constitution) — how a directive is built, installed, and enforced.

--- a/docs/guide/quickstart.mdx
+++ b/docs/guide/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'Getting started'
-summary: 'Install the skill into your agent, bootstrap a repo with governance init, and watch a governance gate fire.'
+title: 'Quickstart'
+summary: 'Install the skill into your agent, bootstrap a repo with governance init, and watch a governance gate fire — in about 60 seconds.'
 ---
 
-# Getting started
+# Quickstart
 
 Three steps: install the skill into your agent, bootstrap a repo, make a bad commit to watch the gate fire.
 
@@ -16,33 +16,11 @@ Three steps: install the skill into your agent, bootstrap a repo, make a bad com
 
 ## 1. Install the skill
 
-<CodeGroup>
-
-```sh All agents (user-wide)
-npx skills add Duaility/governance-kit -g
-```
-
-```sh One agent
-npx skills add Duaility/governance-kit -a claude-code
-```
-
-```sh Project-scoped
+```sh
 npx skills add Duaility/governance-kit
 ```
 
-</CodeGroup>
-
-`npx skills` auto-detects the skill and symlinks it into every skills-compatible runtime on your machine (`~/.claude/skills/`, `~/.codex/skills/`, …).
-
-<Accordion title="Manual install (no npx, or for hacking on the kit)" icon="wrench">
-```sh
-git clone https://github.com/Duaility/governance-kit
-cd governance-kit
-ln -s "$(pwd)/governance" ~/.claude/skills/governance   # Claude Code
-ln -s "$(pwd)/governance" ~/.codex/skills/governance    # Codex
-```
-Edits in the clone flow to every linked runtime live.
-</Accordion>
+`npx skills` auto-detects the skill and symlinks it into every skills-compatible runtime on your machine. Scope flags, manual install, and what actually lands on disk: [Installation](/guide/installation).
 
 ## 2. Bootstrap a repo
 
@@ -60,7 +38,7 @@ claude
     Detect existing governance artifacts and the hook situation (`.husky/`, `.pre-commit-config.yaml`, or none). Existing installs get an augment-or-overwrite question.
   </Step>
   <Step title="Choose packs and a preset">
-    Pick packs (the `governance-kit/core` pack is always included) and a preset — `minimal`, `standard`, or `strict` — or a custom directive selection.
+    Pick from the bundled `governance-kit/*` concern packs and a preset — `minimal`, `standard`, or `strict` — or a custom directive selection.
   </Step>
   <Step title="Write the surface">
     `CONSTITUTION.md`, the `.governance/` runtime, git hook dispatchers, and a CI workflow (`.github/workflows/governance.yml`).
@@ -77,9 +55,9 @@ claude
 
 | Preset | What you get |
 |---|---|
-| `minimal` | Foundation + security: required docs, secrets hygiene, repo hygiene, hardened workflows, no broken doc links. |
-| `standard` | `minimal` + commit discipline + the full [agent audit chain](/concepts/audit-chain): receipts, issue anchors, token and steering accounting, doc integrity. |
-| `strict` | `standard` + `no-orphan-todos`. |
+| `minimal` | Foundation + security + doc links: required docs, repo hygiene, secrets hygiene, hardened workflows, resolving internal links. |
+| `standard` | `minimal` + commit discipline, kit-version sync, doc freshness, and the full [agent audit chain](/concepts/audit-chain): receipts, issue anchors, token and steering accounting, doc integrity. |
+| `strict` | `standard` + TODO and suppression discipline, plus the opt-in [sweep lane](/concepts/sweep-lane) (`governance-kit/architecture`). |
 
 `standard` is the intended default for agent-heavy repos — it is the preset that turns on the issue → receipt → commit → cost chain.
 

--- a/docs/guide/troubleshooting.mdx
+++ b/docs/guide/troubleshooting.mdx
@@ -1,0 +1,64 @@
+---
+title: 'Troubleshooting'
+summary: 'The common failure shapes and their repair paths — hooks not firing, drifted checks, version-marker mismatches, blocked commits, and local-vs-CI differences.'
+---
+
+# Troubleshooting
+
+Most governance failures are the product working: a directive naming a real gap, with the fix in the message. This page covers the rest — the operational snags.
+
+## Hooks don't fire on a fresh clone
+
+`git config core.hooksPath` is per-clone and doesn't travel with the repo. On the default `githooks` strategy, `init` commits a setup script for exactly this:
+
+```sh
+./scripts/enable-governance.sh   # one-time per clone — sets core.hooksPath=.githooks
+```
+
+Worktrees inherit the config; new clones need the one-liner. CI is unaffected either way — it runs `run.sh` directly.
+
+## A check was hand-edited (or corrupted)
+
+Pack-sourced directive code that has drifted from its pin is restored — not re-downloaded blind, but reset to the exact pinned SHA:
+
+```sh
+governance reset --directive <id>    # one directive
+governance reset --pack <id>         # a whole pack
+```
+
+`reset` shows diffs before writing and never touches hand-authored directives. See [update vs. reset](/concepts/packs#update-vs-reset).
+
+## Version-marker mismatch
+
+A failure naming kit-version markers means a half-applied update or a hand-edited runtime file: some `# governance-kit:managed kit-version=` stamps disagree with `install.yaml`'s pin. The repair path is the verb that owns those files:
+
+```sh
+governance kit update
+```
+
+## A commit is blocked and I disagree with the rule
+
+In order of preference:
+
+1. **Waive it, visibly** — `# governance: allow-<directive-id> <reason>` next to the offending line (or in the commit body, for commit-level directives). Auditable in `git blame`.
+2. **Change the rule** — `governance directive modify <id>` lands the loosened check, the updated rationale, and the evolution-log entry as one commit.
+3. **Skip locally, fix on the branch** — `SKIP_GOVERNANCE=1 git commit ...` for a hotfix. CI will still enforce on the PR; nothing merges non-compliant.
+
+## Local hook passed, CI failed anyway
+
+Commit-policing directives run in two modes: the hook validates the *pending* commit; CI **walks every commit** between the merge base and `HEAD`. A commit created with `--no-verify` earlier on the branch passes locally (the hook never saw it) but fails the CI walker. Repair: amend or rebase the offending commit, or add the commit-level waiver the directive's message names.
+
+## Audit-chain failures, decoded
+
+| Failure | What it means | Fix |
+|---|---|---|
+| `commit-issue-receipt-match` | The commit's `(#N)` anchor doesn't match a receipt it touches | Create/touch `receipts/issue-<N>-*.md` in the same commit |
+| `receipt-per-issue` | A checked box doesn't crosswalk | Restate the claim under `## What changed` or `## Verification` |
+| `agent-token-accounting` | Trailers and the receipt's cost rows disagree | Commit through the hook path so the populator stamps them — don't hand-write trailers |
+| `doc-integrity` | A trunk-frozen record was edited | Revert the edit, or carry the directive's path-scoped waiver in the commit body if the change is legitimate |
+
+## Still stuck
+
+- Run the suite directly for full output: `bash .governance/run.sh <directive-id>`.
+- Check the directive's own rationale and Exceptions field in `CONSTITUTION.md` — the exception surface is documented per rule.
+- File a bug: [github.com/Duaility/governance-kit/issues](https://github.com/Duaility/governance-kit/issues).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,25 +1,25 @@
 ---
-title: 'governance-kit'
-summary: 'governance-kit turns your repo rules into a versioned constitution — every directive ships with an executable test, and agents converge the repo on the declared state.'
+title: 'Governance Kit'
+summary: 'Governance Kit is the governance layer for AI coding agents — every rule ships with an executable test, every commit is checked, and every agent-authored change leaves a git-native audit trail.'
 ---
 
-# governance-kit
+# Governance Kit
 
-> **Declare the repo state you want. Let agents converge on it.**
+> **The governance layer for AI coding agents.**
 
-**governance-kit is governance-driven development (GDD).** Your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant.
+**Governance Kit is governance-driven development (GDD).** Your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant.
 
 It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex, Cursor, and 40+ skills-compatible runtimes. One skill, one entry point: the `governance` verb surface.
 
 <Columns cols={3}>
-  <Card title="Get started" href="/guide/getting-started" icon="rocket">
+  <Card title="Quickstart" href="/guide/quickstart" icon="rocket">
     Install the skill, bootstrap a repo, watch a gate fire.
   </Card>
   <Card title="Mental models" href="/guide/mental-models" icon="brain">
-    The seven ideas everything else is built on.
+    The handful of ideas everything else is built on.
   </Card>
-  <Card title="Inner workings" href="/concepts/constitution" icon="cog">
-    How directives, packs, hooks, and ledgers fit together.
+  <Card title="The audit chain" href="/concepts/audit-chain" icon="link">
+    issue → receipt → commit → cost, made mechanical.
   </Card>
 </Columns>
 
@@ -29,10 +29,10 @@ It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex,
 
 This is declarative reconciliation — the Kubernetes/Terraform model — applied to a repository:
 
-| | In governance-kit |
+| | In Governance Kit |
 |---|---|
 | **Desired state** | `CONSTITUTION.md` — directives, rationale, exceptions, evolution log |
-| **Current state** | The working tree, staged diff, commit message, receipts, ledgers |
+| **Current state** | The working tree, staged diff, commit message, receipts |
 | **Controller** | `.governance/run.sh` + git hook dispatchers + CI |
 | **Reconciler** | The agent — reads the gap and its rationale, fixes the repo, re-runs |
 
@@ -51,14 +51,14 @@ flowchart LR
 
 ## Why it exists
 
-Coding agents author most of the changes now. The hard problem is no longer "tell one agent what to do in one session" — it is keeping the repository understandable across many branches, many agents, and many handoffs. Two things stop scaling at agent throughput, and governance-kit answers both with repo-native artifacts:
+When coding agents take control, the problems change — OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article names the new failure set from running an agent-first codebase. The hard problem is no longer "tell one agent what to do in one session"; it is keeping the repository understandable across many branches, many agents, and many handoffs. Two things stop scaling at agent throughput, and Governance Kit answers both with repo-native artifacts:
 
 <Columns cols={2}>
   <Card title="Steering" icon="compass">
     Your guidance has to reach the *next* agent, on the *next* branch, without you in the room. A directive in `CONSTITUTION.md` does; a chat message doesn't.
   </Card>
   <Card title="Visibility" icon="receipt">
-    When agents ship the diffs, you need a readable trail. Append-only ledgers record what agents were told, what they did, and what it cost.
+    When agents ship the diffs, you need a readable trail. Receipts record what agents were told, what they did, and what it cost.
   </Card>
 </Columns>
 
@@ -71,14 +71,14 @@ Coding agents author most of the changes now. The hard problem is no longer "tel
   <Card title="Packs, pins & vendoring" href="/concepts/packs" icon="package">
     Where directives come from and how they're trusted.
   </Card>
-  <Card title="The audit chain & ledgers" href="/concepts/audit-chain" icon="link">
-    issue → receipt → commit → cost, made mechanical.
+  <Card title="The sweep lane" href="/concepts/sweep-lane" icon="radar">
+    LLM-judged architectural rules, off the commit path.
   </Card>
   <Card title="Verbs" href="/reference/verbs" icon="terminal">
     Every lifecycle operation in one place.
   </Card>
   <Card title="Directive catalog" href="/reference/directive-catalog" icon="list-checks">
-    Everything the core pack ships, by preset.
+    Everything the bundled packs ship, by preset.
   </Card>
   <Card title="Authoring directives" href="/reference/authoring-directives" icon="pen-tool">
     Turn a lesson into a rule the repo enforces forever.

--- a/docs/reference/authoring-packs.mdx
+++ b/docs/reference/authoring-packs.mdx
@@ -117,4 +117,4 @@ Give every directive real pass/fail fixtures in `evals/test.sh` (see [Authoring 
 
 - Publish the repo, tag a release, and tell consumers to pin the tag:
   `governance pack add gh:acme/soc2-pack@v1.2.0`
-- Optionally submit a PR adding your pack to the advisory catalog (`catalog.community.json` in the governance-kit repo) so it shows up in `governance pack search`. The catalog is discovery only — installs work against any ref.
+- Optionally submit a PR adding your pack to the advisory catalog (`catalog.community.json` in the Governance Kit repo) so it shows up in `governance pack search`. The catalog is discovery only — installs work against any ref.

--- a/docs/reference/directive-catalog.mdx
+++ b/docs/reference/directive-catalog.mdx
@@ -1,52 +1,55 @@
 ---
 title: 'Directive catalog'
-summary: 'Everything the kit bundled governance-kit/core pack ships, organized by category and preset.'
+summary: 'Everything the six bundled governance-kit concern packs ship, organized by pack and preset.'
 ---
 
 # Directive catalog
 
-Everything below ships in the kit's one bundled pack, `governance-kit/core`. Community packs bring their own directives; this is what you get out of the box at `governance init`.
+Everything below ships in the kit's six bundled concern packs — `governance-kit/{foundation,security,docs,commits,audit,architecture}`. Community packs bring their own directives; this is what you get out of the box at `governance init`.
 
 ## Presets
 
-| Preset | Directives |
+| Preset | What it adds |
 |---|---|
-| `minimal` | `required-docs`, `secrets-hygiene`, `repo-hygiene`, `workflows-hardened`, `internal-doc-links` |
-| `standard` | *minimal* + `commit-message-format`, `version-consistency`, `doc-freshness`, `toolchain-config-protection`, `issue-templates`, `issues-tracked`, `receipt-per-issue`, `commit-issue-receipt-match`, `doc-integrity`, `agent-token-accounting`, `agent-steering-accounting` |
-| `strict` | *standard* + `no-orphan-todos`, `no-unjustified-suppressions` |
+| `minimal` | `required-docs`, `repo-hygiene`, `secrets-hygiene`, `token-permissions`, `pinned-dependencies`, `internal-doc-links` |
+| `standard` | *minimal* + `kit-version-sync`, `doc-freshness`, `commit-message-format`, and the full audit pack: `issue-templates`, `issues-tracked`, `receipt-per-issue`, `commit-issue-receipt-match`, `agent-token-accounting`, `agent-steering-accounting`, `doc-integrity`, `toolchain-config-protection` |
+| `strict` | *standard* + `no-orphan-todos`, `no-unjustified-suppressions`, and the opt-in `architecture` sweep pack |
 
 <Note>
 `doc-integrity` and `agent-steering-accounting` are `always_install: true` — included in every install regardless of preset.
 </Note>
 
-## Foundation
+## governance-kit/foundation
 
 ### required-docs
 `minimal` · A rolled-up presence check for the system of record: `CONSTITUTION.md`, `AGENTS.md` (with a link to the constitution), `README.md`, `LICENSE`, `SECURITY.md`, `ARCHITECTURE.md` with non-trivial bodies; a CI workflow exists; `.env` keys match `.env.example`; hook scaffolding is in place. Sub-checks are individually waivable.
 
-### version-consistency
+### kit-version-sync
 `standard` · Every kit-managed file's `kit-version=` marker agrees with `install.yaml`'s `kit_version`. Catches half-applied updates and hand-edited runtime files; the repair path is `governance kit update`.
 
-## Security
+### repo-hygiene
+`minimal` · Five sub-checks: no merge-conflict markers; no files over the size limit (default 5 MB); no committed build artifacts (`node_modules/`, `dist/`, `*.pyc`, …); no debug statements (`console.log`, `debugger`, `pdb`); no source files over the line limit (default 500). Limits are env-tunable; waivers are line- or file-level.
+
+## governance-kit/security
 
 ### secrets-hygiene
 `minimal` · Two sub-checks: a heuristic scan for high-confidence secret patterns (AWS, GCP, GitHub, Slack, Stripe, private keys) in tracked files, and `.env` being untracked + gitignored. The remediation order in the docs is deliberate: **rotate first, then remove** — a leaked credential is compromised the moment it is committed.
 
-### workflows-hardened
-`minimal` · Every GitHub Actions workflow declares a `permissions:` block and pins third-party actions to a full 40-char commit SHA, avoiding `pull_request_target` foot-guns.
+### token-permissions
+`minimal` · Every GitHub Actions workflow declares a least-privilege `permissions:` block, avoiding default-token foot-guns.
 
-## System of record
+### pinned-dependencies
+`minimal` · Third-party GitHub Actions are pinned to a full 40-char commit SHA, not a mutable tag.
+
+## governance-kit/docs
 
 ### internal-doc-links
-`minimal` · Rolled-up health of the internal markdown link graph. **`resolve`** (always on): every relative-path link target in a tracked `.md` resolves to a real file. **`reachable`** (opt-in via `.governance/conf/internal-doc-links.conf`): every tracked doc is reachable by following internal links from a declared root — a no-op until you write the config. `resolve` proves your links point somewhere real; `reachable` proves your docs are on the map.
+`minimal` · Rolled-up health of the internal markdown link graph. **`resolve`** (always on): every relative-path link target in a tracked `.md` resolves to a real file. **`reachable`** (opt-in via the `.governance/conf/governance-kit/docs/internal-doc-links.conf` overlay): every tracked doc is reachable by following internal links from a declared root. `resolve` proves your links point somewhere real; `reachable` proves your docs are on the map.
 
 ### doc-freshness
-`standard` · Docs opted into `.governance/conf/doc-freshness.conf` carry a `<!-- last-verified: YYYY-MM-DD -->` marker dated within the last 90 days. A periodic "someone re-read this" checkpoint for runbooks and onboarding docs.
+`standard` · Docs opted into the `.governance/conf/governance-kit/docs/doc-freshness.conf` overlay carry a `<!-- last-verified: YYYY-MM-DD -->` marker dated within the last 90 days. A periodic "someone re-read this" checkpoint for runbooks and onboarding docs.
 
-### doc-integrity
-`always installed` · System-of-record documents are tamper-evident against the trunk baseline. Standard rules ship in the directive's `defaults.conf`, layered with the `.governance/conf/doc-integrity.conf` overlay: `frozen-files` (receipts immutable once merged), `append-only` (`COSTS.md`, `STEERING.md`), `frozen-section` (`QUALITY.md` Resolved, the Evolution Log). Branch content stays editable until it merges.
-
-## Commit hygiene
+## governance-kit/commits
 
 ### commit-message-format
 `standard` · Commit subjects match `<type>(scope)?!?: subject (#123)` — Conventional Commits plus a trailing GitHub issue anchor. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `revert`, `style`.
@@ -57,14 +60,9 @@ Everything below ships in the kit's one bundled pack, `governance-kit/core`. Com
 ### no-unjustified-suppressions
 `strict` · Every lint / type-checker suppression — `eslint-disable*`, `@ts-ignore`, `@ts-expect-error`, `# noqa`, `# type: ignore`, `#[allow(...)]`, `@SuppressWarnings`, … — references an issue on the same line. The checker-silencing sibling of `no-orphan-todos`: muting a check is invisible in a green build unless the suppression names the ticket that owns un-muting it.
 
-## Quality
+## governance-kit/audit
 
-### repo-hygiene
-`minimal` · Five sub-checks: no merge-conflict markers; no files over the size limit (default 5 MB); no committed build artifacts (`node_modules/`, `dist/`, `*.pyc`, …); no debug statements (`console.log`, `debugger`, `pdb`); no source files over the line limit (default 500). Limits are env-tunable; waivers are line- or file-level.
-
-## Agent discipline — the audit chain
-
-See [The audit chain & ledgers](/concepts/audit-chain) for how these compose.
+See [The audit chain](/concepts/audit-chain) for how these compose.
 
 ### issue-templates
 `standard` · `.github/ISSUE_TEMPLATE/` carries proposal and bug forms with the agent-handoff fields, and blank issues are disabled. Seeded from the directive's `install-assets/`.
@@ -73,23 +71,36 @@ See [The audit chain & ledgers](/concepts/audit-chain) for how these compose.
 `standard` · `QUALITY.md` exists at the repo root with `## Open` and `## Resolved` sections — the lightweight quality board the receipts and commits anchor to.
 
 ### receipt-per-issue
-`standard` · Every `receipts/*.md` carries a unique `issue-<N>` filename token and the four required sections, and every checked checklist item crosswalks into `## What changed` or `## Verification`. Receipts **added in the change set** must also carry a `## Decisions` section and at least one fenced, re-runnable command in `## Verification`; pre-existing receipts are grandfathered.
-
-### toolchain-config-protection
-`standard` · A commit that touches linter / formatter / type-checker / CI / git-hook config must carry a `governance: allow-toolchain-config <reason>` body line. Stops the "edit the rule, not the code" move (loosen eslint, relax a ruff `select`, weaken a workflow's `permissions`) from passing silently in a green build. Protected paths default to a multi-ecosystem list in the directive's `defaults.conf`, customizable via the `.governance/conf/toolchain-config-protection.conf` overlay (bare line adds, `!<pattern>` drops a default).
+`standard` · Every `receipts/*.md` carries a unique `issue-<N>` filename token and the required sections, and every checked checklist item crosswalks into `## What changed` or `## Verification`. Receipts **added in the change set** must also carry a `## Decisions` section and at least one fenced, re-runnable command in `## Verification`; pre-existing receipts are grandfathered.
 
 ### commit-issue-receipt-match
 `standard` · Every non-merge commit's issue anchor matches an `issue-<N>` token on a receipt the commit touches — the link that makes "which issue was this for?" mechanical.
 
 ### agent-token-accounting
-`standard` · Every non-merge commit carries the eight token/cost trailers and a matching `COSTS.md` row joined by `Cost-Key`. Ships its own `prepare-commit-msg` populator that stamps the trailers from runtime usage data.
+`standard` · Every non-merge commit carries the token/cost trailers and a matching cost row in the issue's receipt, joined by `Cost-Key`. Ships its own `prepare-commit-msg` populator that stamps the trailers from runtime usage data.
 
 ### agent-steering-accounting
-`always installed` · Every non-merge commit stamps the `Steer-Count` / `Steer-Types` / `Steer-Tiers` summary triple, tallying rows appended to `STEERING.md`. Records human corrections verbatim — redact via its classifier hook rather than disabling it.
+`always installed` · Every non-merge commit stamps the `Steer-Count` / `Steer-Types` / `Steer-Tiers` summary triple, tallying steering rows appended to the issue's receipt. Records human corrections verbatim — redact via its classifier hook rather than disabling it.
+
+### doc-integrity
+`always installed` · System-of-record documents are tamper-evident against the trunk baseline. Standard rules ship in the directive's `defaults.conf`, layered with the `.governance/conf/governance-kit/audit/doc-integrity.conf` overlay: `frozen-files` (receipts immutable once merged; the sealed legacy ledgers), `frozen-section` (`QUALITY.md` Resolved, the Evolution Log), `append-only` available for repo-specific records. Branch content stays editable until it merges.
+
+### toolchain-config-protection
+`standard` · A commit that touches linter / formatter / type-checker / CI / git-hook config must carry a `governance: allow-toolchain-config <reason>` body line. Stops the "edit the rule, not the code" move (loosen eslint, relax a ruff `select`, weaken a workflow's `permissions`) from passing silently in a green build. Protected paths default to a multi-ecosystem list in the directive's `defaults.conf`, customizable via the conf overlay (bare line adds, `!<pattern>` drops a default).
+
+## governance-kit/architecture
+
+The off-commit-path [sweep lane](/concepts/sweep-lane) — `surface: sweep`, LLM-adjudicated, advisory. Opt-in via `strict`; enabling the pack also installs the scheduled workflow and the vendored engine.
+
+### no-legacy-fallbacks
+`strict` · No backward-compat shims or legacy fallback paths in agent-authored changes.
+
+### no-path-bifurcation
+`strict` · No bifurcated code paths — unify dual dispatch and local-vs-remote special-casing.
 
 ## Waivers
 
-All directives honor the in-source waiver format where exceptions make sense:
+All commit-path directives honor the in-source waiver format where exceptions make sense:
 
 ```
 # governance: allow-<directive-id> <reason>

--- a/docs/reference/schemas.mdx
+++ b/docs/reference/schemas.mdx
@@ -28,7 +28,6 @@ agents_md_created: false         # true only when init created the stub
 enable_governance_script: scripts/enable-governance.sh   # githooks strategy only
 install_assets_seeded:           # files seeded by directives' install-assets/
   - QUALITY.md
-  - COSTS.md
 collisions: []                   # hook-collision resolutions, if any
 # path_b: present only when hook_strategy != githooks
 ```
@@ -80,7 +79,7 @@ summary: One-line description for the picker
 surface: repo-state               # repo-state | change-set
 hook: pre-commit                  # pre-commit | commit-msg | prepare-commit-msg
                                   #   | post-commit | pre-push | none (CI-only)
-always_install: true              # optional; reserved to governance-kit/core
+always_install: true              # optional; reserved to the bundled governance-kit/* packs
 requires_hook_strategy: githooks  # optional; skip when strategy is incompatible
 reads:                            # optional capability declaration
   - .github/workflows/**

--- a/docs/reference/verbs.mdx
+++ b/docs/reference/verbs.mdx
@@ -5,7 +5,7 @@ summary: 'The governance skill lifecycle surface — init, kit update, pack *, d
 
 # Verbs
 
-The `governance` skill is the **single writer** for every governance-kit lifecycle operation. One entry point, six verb families:
+The `governance` skill is the **single writer** for every Governance Kit lifecycle operation. One entry point, six verb families:
 
 ```
 governance init                                        # bootstrap a repo
@@ -36,7 +36,7 @@ Bootstraps governance-driven development in a repo. The flow:
     Build the menu from each directive's `directive.yaml`.
   </Step>
   <Step title="Choose">
-    Packs (core is locked on), preset (`minimal` / `standard` / `strict` / custom), then per-category fine-tuning. Final set: `always_install(core) ∪ preset ∪ user selections`.
+    Packs (from the bundled `governance-kit/*` concern packs), preset (`minimal` / `standard` / `strict` / custom), then per-category fine-tuning. Final set: `always_install(bundled) ∪ preset ∪ user selections`.
   </Step>
   <Step title="Infer principles">
     3–5 high-level principles derived from the chosen directives, recorded in the constitution.
@@ -73,7 +73,7 @@ Re-syncs the kit-owned runtime files to a newer kit version. The repo is **pinne
 | `pack search [query]` | Browse the advisory community catalog. |
 | `pack add <ref>` | Fetch `gh:<owner>/<repo>[/<subpath>][@<rev>]`, validate, capability-check every directive, show full diffs, then vendor the directive code, splice constitution subsections, regenerate dispatchers, and pin SHA in the lockfile. |
 | `pack update [<pack-id>]` | Re-fetch each `gh` pack via its stored ref; for drifted SHAs show per-directive diffs, then overwrite, regenerate, re-pin. Repo-local packs are skipped. |
-| `pack remove <pack-id>` | Delete the pack's directive folders, strip its constitution subsections, regenerate dispatchers, prune the lockfile. `governance-kit/core` can't be removed wholesale — opt out of individual core directives with `directive remove`. |
+| `pack remove <pack-id>` | Delete the pack's directive folders, strip its constitution subsections, regenerate dispatchers, prune the lockfile. The bundled packs' `always_install` directives can't be dropped wholesale — opt out of individual bundled directives with `directive remove`. |
 | `pack create <name>` | Scaffold a hand-authored repo-local pack at `.governance/packs/<repo-owner>/<name>/` (a `pack.yaml` with no `source:` and an empty `directives/`). |
 
 ## governance directive *
@@ -82,7 +82,7 @@ Hand-authored amendments via the [atomic triple](/concepts/constitution): direct
 
 - `directive add <id>` — collect the spec (statement, rationale, check logic, exceptions, surface), draft `check.sh` from the template, smoke-test against the live repo, splice the constitution, sync the lockfile, commit.
 - `directive modify <id>` — same flow against an existing repo-local directive; the original rationale is preserved unless the policy intent changes.
-- `directive remove <id>` — delete the folder, strip the subsection, log the removal; also the supported way to opt out of an individual core directive.
+- `directive remove <id>` — delete the folder, strip the subsection, log the removal; also the supported way to opt out of an individual bundled directive.
 - `--pack <owner>/<name>` targets a specific repo-local pack; without it, the repo's own default pack is used (auto-created on first add).
 - Community (`source: gh`) directives are refused — use `pack update` / `pack remove` for those.
 
@@ -106,7 +106,7 @@ Cleanly reverses everything `init` did, using a three-layer source of truth: the
 | Mode | Effect |
 |---|---|
 | `--dry-run` | Print the plan; touch nothing. Default whenever state is ambiguous. |
-| `--soft` (default) | Remove kit-owned files; keep pack-seeded docs (`QUALITY.md`, `COSTS.md`, …) and backups. |
+| `--soft` (default) | Remove kit-owned files; keep pack-seeded docs (`QUALITY.md`, …) and backups. |
 | `--hard` | Remove everything governance touched, including seeded docs and backups. |
 
 Execution order is fixed: hooks (restoring any `.userhook` wraps), `git config core.hooksPath`, the AGENTS.md block (marker-bounded surgery), tree files, Path-B framework entries, seeded docs, backups, and `.governance/` last. It deletes only what it can identify as kit-owned, never your content, and leaves changes unstaged for your own commit. Removing the *skill* from your machine is separate — delete the symlink your installer created.

--- a/receipts/issue-239-readme-docs-restructure.md
+++ b/receipts/issue-239-readme-docs-restructure.md
@@ -1,0 +1,80 @@
+# Issue 239: Restructure README and docs site around the Governance Kit framing
+
+Closes [#239](https://github.com/Duaility/governance-kit/issues/239).
+
+## Checklist
+
+- [x] Rework the README hero, tagline, and badges
+- [x] Add a Why section mapping harness-engineering failure modes to design answers
+- [x] Add mental-model visuals to the README
+- [x] Refactor the docs site nav and pages to the new structure
+- [x] Add the missing docs pages
+- [x] Fix stale pack, ledger, and path references across the docs
+- [x] Rebrand prose to "Governance Kit"
+- [x] Verify the directive suite is green
+
+## What changed
+
+- **Rework the README hero, tagline, and badges.** Replaced the Kubernetes-style "Declare the repo state you want" tagline with a plain-language one, **"The governance layer for AI coding agents."** Added a block ASCII-art hero (GOVERNANCE / KIT), a bold value-prop line, a badge row (governance CI, dogfood-smoke CI, latest `kit/v*` tag, Agent Skills, MIT), an in-page nav row, and an "AI agents: start at AGENTS.md / CONSTITUTION.md" pointer — modeled on the chopratejas/headroom README structure.
+- **Add a Why section mapping harness-engineering failure modes to design answers.** New `## Why` section credits OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article as the stated inspiration and presents a five-row table mapping each named agent-first failure mode (instruction files that rot, agents replicating uneven patterns, knowledge trapped off-system, human-QA bottleneck, context scarcity) to the corresponding design answer, quoting the article's phrasing.
+- **Add mental-model visuals to the README.** Added two Mermaid diagrams with explicit `classDef` colors: the installer/product/content layering with the rustup / toolchain / lockfile analogy in the Lifecycle section, and the issue → receipt → commit → cost chain in The audit chain section.
+- **Refactor the docs site nav and pages to the new structure.** Rewrote `docs/docs.json` into a single Documentation tab grouped Get started → The constitution → Packs → The audit chain → The sweep lane → Integrations → Configuration → Reference → Architecture → Help, renamed `getting-started.mdx` to `quickstart.mdx` (with a redirect), and updated the landing, introduction, mental-models, audit-chain, and reference pages to the new framing and tagline.
+- **Add the missing docs pages.** Created `installation.mdx`, `configuration.mdx`, `troubleshooting.mdx`, `concepts/sweep-lane.mdx`, and `concepts/limitations.mdx`, grounded in the kit's reference docs (SWEEP_FLOW, VERSIONING, NATIVE_TESTS) and the live directive set.
+- **Fix stale pack, ledger, and path references across the docs.** Replaced the dissolved `governance-kit/core` with the six bundled concern packs throughout; reorganized the directive catalog per pack (splitting `workflows-hardened` into `token-permissions` + `pinned-dependencies`, renaming `version-consistency` to `kit-version-sync`); replaced the retired `COSTS.md`/`STEERING.md` ledgers with the receipt-homed `## Accounting` rows; pointed the manual-install symlink at `skill/` instead of the old `governance/`; and pack-qualified the `.governance/conf/` overlay paths.
+- **Rebrand prose to "Governance Kit".** Changed running-text mentions to "Governance Kit" in the README and every docs page, leaving literal identifiers (repo slug `Duaility/governance-kit`, pack ids `governance-kit/*`, the `# governance-kit:managed` marker, file paths, commands) untouched.
+
+## Decisions
+
+- **Address the product as "Governance Kit" in prose, hyphenated lowercase only for identifiers.** A single user-facing name reads better than the package slug in running text; identifiers must stay verbatim because they are matched mechanically (pack ids, markers, paths).
+- **Model both README and docs on the headroom structure rather than inventing one.** It is a proven shape for an agent-facing OSS project: plain hero, Why, Proof, honest fit, progressive disclosure. The Proof section is reframed as the dogfood ("this repo governs itself") since the kit has no benchmark numbers to show.
+- **Diagrams as Mermaid with explicit colors, not images.** Mermaid renders on GitHub and in Mintlify, stays diffable, and needs no binary asset in the tree; the user's reference graphic was reproduced as a colored node graph.
+- **Lean on the kit's own reference docs for the new pages' claims.** Installation, Configuration, Sweep lane, and Limitations restate what SWEEP_FLOW / VERSIONING / NATIVE_TESTS and the directive set already establish, rather than introducing new product behavior.
+
+## Out of scope
+
+- A demo GIF/asciinema recording for the README hero (headroom's strongest asset) — no recording exists yet; the textual gate-fire demo carries it for now.
+- A star-history chart and any third-party badges (Trendshift, codecov) — premature for the repo's current state.
+- Any change to directive behavior, pack contents, the skill, or the kit runtime — this change is documentation only.
+- Rewriting historical receipts or evolution-log entries that reference the former `governance-kit/core` pack or the old ledgers — they describe what was true at the time.
+
+## Verification
+
+```sh
+bash .governance/run.sh                 # full directive suite — all 21 pass
+python3 - <<'PY'                         # docs nav references every page on disk, no orphans
+import json, os
+d = json.load(open('docs/docs.json')); pages=[]
+def walk(o):
+    if isinstance(o, dict):
+        for k,v in o.items(): pages.extend(v) if k=='pages' else walk(v)
+    elif isinstance(o, list):
+        [walk(i) for i in o]
+walk(d['navigation'])
+assert not [p for p in pages if not os.path.exists(f'docs/{p}.mdx')]
+print('nav ok:', len(pages), 'pages')
+PY
+```
+
+- **Verify the directive suite is green** — `bash .governance/run.sh` reports all 21 directives passing (the run shown in the code block above).
+- Brand sweep: `grep -n "governance-kit" README.md docs/**/*.mdx` returns only literal identifiers (pack ids, the managed marker, repo slug, file paths, commands) — no prose mentions.
+- Link integrity is covered by the `internal-doc-links` directive in the suite run above.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-13c6bcbc-bf3-1781288814-1 | claude-code | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | claude-opus-4-8 | 53080 | 1580317 | 37952689 | 420516 | 2053913 | 39.6316 | docs: restructure README and docs site around the Governance Kit framing (#239) |
+
+### Steering
+
+| steer-key | session | issue | type | tier | user-reason | commit |
+| --- | --- | --- | --- | --- | --- | --- |
+| steer-13c6bcbcbf3-1781288813-1 | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | interrupt | structural |  | docs: restructure README and docs site around the Governance Kit framing (#239) |
+| steer-13c6bcbcbf3-1781288813-2 | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | correction | classifier | Deprioritize hero art; demand concise, intent-focused readme reframe | docs: restructure README and docs site around the Governance Kit framing (#239) |
+| steer-13c6bcbcbf3-1781288813-3 | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | correction | classifier | Rejected proposed declarative-state tagline as nonsensical | docs: restructure README and docs site around the Governance Kit framing (#239) |
+| steer-13c6bcbcbf3-1781288813-4 | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | correction | classifier | Challenged whether full headroom doc structure was actually replicated | docs: restructure README and docs site around the Governance Kit framing (#239) |
+| steer-13c6bcbcbf3-1781288813-5 | 13c6bcbc-bf3f-4081-b64e-be9881134245 | #239 | interrupt | structural |  | docs: restructure README and docs site around the Governance Kit framing (#239) |


### PR DESCRIPTION
Closes #239.

## What & why

The README and Mintlify docs predated several large changes (the `core` → six-concern-pack split, receipt-homed accounting, the `skill/` path) and led with Kubernetes-style "declare the repo state" jargon instead of plainly saying what the product is. This reworks both around a proven OSS-README structure (modeled on [chopratejas/headroom](https://github.com/chopratejas/headroom)) and the agent-first framing from OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article — the stated inspiration for the project.

**Documentation only** — no directive, pack, skill, or runtime behavior changes.

### README
- Plain-language hero + tagline ("The governance layer for AI coding agents"), block ASCII art, badge row, nav, and an AI-agents pointer.
- New **Why** section mapping each harness-engineering failure mode (rotting instruction files, agents replicating uneven patterns, off-system knowledge, the human-QA bottleneck, context scarcity) to a design answer.
- Two mental-model diagrams: the installer/product/content layering (rustup / toolchain / lockfile analogy) and the issue → receipt → commit → cost chain.
- Reframed Proof as the dogfood, an honest When-to-use/skip, a Compared-to table, agent-compat matrix, and progressive-disclosure deep-dives.

### Docs site
- Nav refactored to Get started → per-subsystem sections → Integrations → Configuration → Reference → Architecture → Help.
- New pages: Installation, Configuration, Troubleshooting, Sweep lane, Limitations.
- Fixed stale references throughout: `governance-kit/core` → six concern packs, `workflows-hardened` → `token-permissions`/`pinned-dependencies`, `version-consistency` → `kit-version-sync`, retired `COSTS.md`/`STEERING.md` → receipt-homed accounting, old `governance/` path → `skill/`.
- Prose rebranded to **Governance Kit** (literal identifiers left untouched).

## Reviewer notes
- The brand convention: "Governance Kit" in prose, hyphenated lowercase only for identifiers (pack ids, the `# governance-kit:managed` marker, repo slug, paths, commands).
- New docs-page claims are grounded in existing reference docs (SWEEP_FLOW, VERSIONING, NATIVE_TESTS), not new behavior — worth a skim of `limitations.mdx` and `troubleshooting.mdx` to confirm the operational guidance reads right.
- Badge URLs point at `Duaility/governance-kit`; swap the owner if the canonical repo differs.

## Verification
- `bash .governance/run.sh` → all 21 directives pass.
- Docs nav references every page on disk, no orphans (script in the receipt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)