### PR TITLE
refactor(packs): pack-group-aware CONSTITUTION rendering in init and pack upsert (#238)

### DIFF
--- a/kit/assets/packs/lib/docsurgery.py
+++ b/kit/assets/packs/lib/docsurgery.py
@@ -25,6 +25,18 @@ def _heading_re(directive_id: str) -> re.Pattern[str]:
 
 _ANY_HEADING_RE = re.compile(r"^(#{2,3})[ \t]+\S")
 
+# A pack-group header is `## <owner>/<pack>` — a level-2 heading whose only token
+# contains a slash. The other level-2 headings in CONSTITUTION.md (`## Directives`,
+# `## Amendment process`, `## Evolution Log`, …) never do, so this discriminates a
+# pack group from a major section without a hard-coded section list.
+_PACK_HEADER_RE = re.compile(r"^##[ \t]+\S+/\S+[ \t]*$")
+_DIRECTIVES_RE = re.compile(r"^##[ \t]+Directives[ \t]*$")
+_L2_RE = re.compile(r"^##[ \t]+\S")
+
+
+def _pack_header_re(pack_id: str) -> re.Pattern[str]:
+    return re.compile(rf"^##[ \t]+{re.escape(pack_id)}[ \t]*$")
+
 
 def find_subsection(text: str, directive_id: str) -> tuple[int, int] | None:
     """Return the `[start, end)` line-index span of the directive's `### <id>`
@@ -60,39 +72,104 @@ def strip_directive_subsection(text: str, directive_id: str) -> tuple[str, bool]
     return "".join(lines), True
 
 
-def upsert_directive_subsection(text: str, directive_id: str, subsection: str) -> tuple[str, str]:
+def _directives_region_end(lines: list[str]) -> int:
+    """Index of the line that ends the Directives region — the first level-2
+    heading after `## Directives` that is *not* a pack group (e.g. `## Amendment
+    process`), or `len(lines)`. Pack-group headers live inside this region; a new
+    one is created just before it."""
+    dir_start = next((i for i, ln in enumerate(lines) if _DIRECTIVES_RE.match(ln)), None)
+    if dir_start is None:
+        return len(lines)
+    for j in range(dir_start + 1, len(lines)):
+        if _L2_RE.match(lines[j]) and not _PACK_HEADER_RE.match(lines[j]):
+            return j
+    return len(lines)
+
+
+def render_pack_groups(groups: list[tuple[str, list[str]]]) -> str:
+    """Render directive subsections grouped under `## <owner>/<pack>` headers.
+
+    `groups` is `[(pack_id, [subsection, …]), …]` in display order. Each pack
+    emits its `## <pack_id>` header followed by its directive subsections, one
+    blank line between blocks. Shared by `init` assembly and the pack-aware
+    upsert so both produce the same grouped structure.
+    """
+    out: list[str] = []
+    for pack_id, subs in groups:
+        out.append(f"## {pack_id}\n\n")
+        for s in subs:
+            out.append(s.rstrip("\n") + "\n\n")
+    return "".join(out)
+
+
+def upsert_directive_subsection(
+    text: str, directive_id: str, subsection: str, pack_id: str | None = None
+) -> tuple[str, str]:
     """Replace the directive's subsection with `subsection`, or insert it if absent.
 
     Returns `(new_text, action)` where action is `replaced` or `inserted`.
-    Insertion lands at the end of the `## Directives` section (before the next
-    `## ` heading), matching where init appends new directive blocks. `subsection`
-    is normalized to end with exactly one trailing blank line so adjacent blocks
-    stay one blank line apart.
+    `subsection` is normalized to end with exactly one trailing blank line so
+    adjacent blocks stay one blank line apart.
+
+    When `pack_id` is given (`<owner>/<pack>`), the subsection is homed under that
+    pack's `## <owner>/<pack>` header — created at the end of the Directives region
+    if absent — and any stray copy elsewhere in the document is first removed, so
+    a re-pin relocates a previously-ungrouped subsection into its group. When
+    `pack_id` is None, the legacy flat behaviour applies: replace in place, else
+    append at the end of `## Directives`.
     """
     block = subsection.rstrip("\n") + "\n\n"
-    lines = text.splitlines(keepends=True)
-    span = find_subsection(text, directive_id)
-    if span is not None:
-        start, end = span
-        lines[start:end] = [block]
-        return "".join(lines), "replaced"
 
-    # Insert at the end of the `## Directives` section.
-    dir_start = next(
-        (i for i, ln in enumerate(lines) if re.match(r"^##[ \t]+Directives[ \t]*$", ln)),
-        None,
-    )
-    if dir_start is None:
-        # No Directives section — append at end of document.
-        tail = "" if text.endswith("\n") else "\n"
-        return text + tail + "\n" + block, "inserted"
-    insert_at = len(lines)
-    for j in range(dir_start + 1, len(lines)):
-        if re.match(r"^##[ \t]+\S", lines[j]):
-            insert_at = j
-            break
-    lines[insert_at:insert_at] = [block]
-    return "".join(lines), "inserted"
+    if pack_id is None:
+        lines = text.splitlines(keepends=True)
+        span = find_subsection(text, directive_id)
+        if span is not None:
+            start, end = span
+            lines[start:end] = [block]
+            return "".join(lines), "replaced"
+        dir_start = next((i for i, ln in enumerate(lines) if _DIRECTIVES_RE.match(ln)), None)
+        if dir_start is None:
+            # No Directives section — append at end of document.
+            tail = "" if text.endswith("\n") else "\n"
+            return text + tail + "\n" + block, "inserted"
+        insert_at = len(lines)
+        for j in range(dir_start + 1, len(lines)):
+            if _L2_RE.match(lines[j]):
+                insert_at = j
+                break
+        lines[insert_at:insert_at] = [block]
+        return "".join(lines), "inserted"
+
+    # Pack-group-aware: remove any existing copy (wherever it sits — this is what
+    # relocates a previously-ungrouped subsection), then insert under the pack's
+    # header. action reflects whether the directive already had an entry.
+    text, removed = strip_directive_subsection(text, directive_id)
+    action = "replaced" if removed else "inserted"
+    lines = text.splitlines(keepends=True)
+    header = _pack_header_re(pack_id)
+    header_idx = next((i for i, ln in enumerate(lines) if header.match(ln)), None)
+    if header_idx is not None:
+        # Group spans from the header to the next level-2 heading (or EOF).
+        group_end = len(lines)
+        for j in range(header_idx + 1, len(lines)):
+            if _L2_RE.match(lines[j]):
+                group_end = j
+                break
+        # Insert in sorted position by directive id — init emits each pack's
+        # directives `sorted`, so matching that keeps the two paths in lockstep
+        # and makes a re-upsert idempotent rather than churning the order.
+        insert_at = group_end
+        for j in range(header_idx + 1, group_end):
+            m = re.match(r"^###[ \t]+(\S+)", lines[j])
+            if m and m.group(1) > directive_id:
+                insert_at = j
+                break
+        lines[insert_at:insert_at] = [block]
+        return "".join(lines), action
+    # No header yet — create `## <pack_id>` at the end of the Directives region.
+    region_end = _directives_region_end(lines)
+    lines[region_end:region_end] = [f"## {pack_id}\n\n", block]
+    return "".join(lines), action
 
 
 def strip_marker_block(text: str, open_marker: str, close_marker: str) -> tuple[str, str, bool]:

--- a/kit/assets/packs/lib/initapply.py
+++ b/kit/assets/packs/lib/initapply.py
@@ -175,16 +175,19 @@ def cmd_init_apply(args: argparse.Namespace) -> int:
         # seed_directive_conf, inside _install_directives.
         report["conf_seeded"] = conf_seeded
 
-        # CONSTITUTION.md: template + principles + spliced subsections.
-        subsections = []
+        # CONSTITUTION.md: template + principles + subsections grouped by pack.
+        groups: list[tuple[str, list[str]]] = []
         for pack in packs:
+            subs = []
             for did in sorted(pack.get("directives") or []):
                 sub = Path(pack["pack_dir"]) / "directives" / did / "constitution.md"
                 if sub.is_file():
-                    subsections.append(sub.read_text())
+                    subs.append(sub.read_text())
+            if subs:
+                groups.append((pack["id"], subs))
         template = (KIT_ASSETS / "CONSTITUTION.template.md").read_text()
         (root / "CONSTITUTION.md").write_text(
-            assemble_constitution(template, decisions.get("principles") or [], subsections))
+            assemble_constitution(template, decisions.get("principles") or [], groups))
         report["constitution"] = "written"
 
         # AGENTS.md stub (Case 2 — operator handles in-place insertion into an

--- a/kit/assets/packs/lib/initplan.py
+++ b/kit/assets/packs/lib/initplan.py
@@ -53,11 +53,19 @@ def directive_inventory(packs: list[dict[str, Any]]) -> list[dict[str, str]]:
     return out
 
 
-def assemble_constitution(template: str, principles: list[str], subsections: list[str]) -> str:
+def assemble_constitution(
+    template: str, principles: list[str], groups: list[tuple[str, list[str]]]
+) -> str:
     """Template → CONSTITUTION.md: operator principles spliced into Principles,
     each directive's `constitution.md` spliced into Directives (replacing the
-    example), the rest verbatim.
+    example) and grouped under its `## <owner>/<pack>` header, the rest verbatim.
+
+    `groups` is `[(pack_id, [subsection, …]), …]` in display order — the same
+    pack-grouped shape the `pack add`/`update` upsert maintains, so a fresh
+    install and an incrementally-grown CONSTITUTION.md share one structure.
     """
+    from docsurgery import render_pack_groups
+
     lines = template.splitlines(keepends=True)
 
     def find(pat: str) -> int:
@@ -69,11 +77,8 @@ def assemble_constitution(template: str, principles: list[str], subsections: lis
     directives_i = find(r"^##[ \t]+Directives[ \t]*$")
     amendment_i = find(r"^##[ \t]+Amendment process[ \t]*$")
 
-    # Rebuild the Directives section body: heading + spliced subsections.
-    body = "## Directives\n\n"
-    body += "\n".join(s.rstrip("\n") + "\n" for s in subsections)
-    if subsections:
-        body += "\n"
+    # Rebuild the Directives section body: heading + pack-grouped subsections.
+    body = "## Directives\n\n" + render_pack_groups(groups)
     new_lines = lines[:directives_i] + [body] + lines[amendment_i:]
 
     text = "".join(new_lines)

--- a/kit/assets/packs/lib/packapply.py
+++ b/kit/assets/packs/lib/packapply.py
@@ -173,7 +173,7 @@ def _apply_add_update(root: Path, plan: dict[str, Any], decisions: dict[str, str
             # in both modes, so dry-run can report it.
             sub = pack_dir / "directives" / did / "constitution.md"
             if sub.is_file():
-                constitution_upserts.append((did, sub.read_text()))
+                constitution_upserts.append((pack["id"], did, sub.read_text()))
             if dry_run:
                 continue
             cmd = 'install_directive_folder "$1" "$2" "$3"; install_directive_assets "$1" "$2" "$3"'
@@ -219,13 +219,14 @@ def _apply_add_update(root: Path, plan: dict[str, Any], decisions: dict[str, str
     # rulebook gains (add) or refreshes (update) an entry for every directive that
     # gained a test — the GDD invariant (every directive ↔ a constitution entry).
     # init assembles these at bootstrap and `pack remove` strips them; this keeps
-    # add/update symmetric. upsert replaces in place or inserts at the end of
-    # `## Directives`, matching init's placement.
+    # add/update symmetric. The upsert homes each subsection under its pack's
+    # `## <owner>/<pack>` header (creating it if absent, relocating a stray copy),
+    # matching init's pack-grouped placement.
     constitution = root / "CONSTITUTION.md"
     if constitution_upserts and constitution.is_file():
         text = constitution.read_text()
-        for did, subsection in constitution_upserts:
-            text, _action = upsert_directive_subsection(text, did, subsection)
+        for pack_id, did, subsection in constitution_upserts:
+            text, _action = upsert_directive_subsection(text, did, subsection, pack_id)
             report["constitution_upserted"].append(did)
         if not dry_run:
             constitution.write_text(text)

--- a/kit/assets/packs/lib/resetapply.py
+++ b/kit/assets/packs/lib/resetapply.py
@@ -103,7 +103,8 @@ def cmd_reset_apply(args: argparse.Namespace) -> int:
             report["restored"].append(d["id"])
             sub_src = Path(d["subsection_source"])
             if const_text and sub_src.is_file():
-                const_text, action = upsert_directive_subsection(const_text, d["id"], sub_src.read_text())
+                const_text, action = upsert_directive_subsection(
+                    const_text, d["id"], sub_src.read_text(), d.get("pack_id"))
                 report["constitution_changed"].append(f"{d['id']}:{action}")
         elif d["kind"] == "drop":
             shutil.rmtree(root / d["dest"], ignore_errors=True)

--- a/receipts/issue-238.md
+++ b/receipts/issue-238.md
@@ -1,0 +1,9 @@
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-e2c30bd6-be1-1781289660-1 | claude-code | e2c30bd6-be1c-46c3-b070-d5ece5b61a1a | #238 | claude-opus-4-8 | 67367 | 1259133 | 119730959 | 732750 | 2059250 | 86.3906 | refactor(packs): pack-group-aware CONSTITUTION rendering in init and pack upsert |

--- a/scripts/test-docsurgery.py
+++ b/scripts/test-docsurgery.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Unit tests for docsurgery.py — the pure CONSTITUTION.md text transforms shared
+by the lifecycle engines (init assembly, `pack add`/`update`/`remove`, reset).
+
+Split out of test-packverb-apply.py (which owns the pack-plan/apply integration
+tests) so each stays focused and under the file-size limit. These are pure
+string→string transforms — no fetch, no filesystem, no git.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_LIB = ROOT / "kit" / "assets" / "packs" / "lib"
+
+
+def _load(name: str):
+    sys.path.insert(0, str(PACK_LIB))
+    spec = importlib.util.spec_from_file_location(name, PACK_LIB / f"{name}.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+docsurgery = _load("docsurgery")
+
+
+CONST = (
+    "# CONSTITUTION\n\n## Directives\n\n"
+    "### required-docs\n\n- body A\n\n"
+    "### no-console-log\n\n- body B\n\n"
+    "### secrets-hygiene\n\n- body C\n\n"
+    "## Evolution Log\n\n<!-- hint -->\n\n- 2026-01-01 — old\n"
+)
+
+
+def test_strip_subsection_removes_only_target() -> None:
+    out, removed = docsurgery.strip_directive_subsection(CONST, "no-console-log")
+    assert removed
+    assert "### no-console-log" not in out
+    assert "### required-docs" in out and "### secrets-hygiene" in out
+    assert "- body A" in out and "- body C" in out and "- body B" not in out
+
+
+def test_strip_subsection_absent_is_noop() -> None:
+    out, removed = docsurgery.strip_directive_subsection(CONST, "nope")
+    assert not removed and out == CONST
+
+
+def test_strip_subsection_prefix_no_alias() -> None:
+    # `doc` must not match `doc-freshness`.
+    text = "## Directives\n\n### doc-freshness\n\nbody\n"
+    out, removed = docsurgery.strip_directive_subsection(text, "doc")
+    assert not removed and out == text
+
+
+def test_upsert_replaces_in_place() -> None:
+    out, action = docsurgery.upsert_directive_subsection(
+        CONST, "no-console-log", "### no-console-log\n\n- NEW body\n")
+    assert action == "replaced"
+    assert "- NEW body" in out and "- body B" not in out
+    assert out.count("### no-console-log") == 1
+
+
+def test_upsert_inserts_at_end_of_directives() -> None:
+    out, action = docsurgery.upsert_directive_subsection(
+        CONST, "brand-new", "### brand-new\n\n- fresh\n")
+    assert action == "inserted"
+    # lands inside Directives, before Evolution Log
+    assert out.index("### brand-new") < out.index("## Evolution Log")
+
+
+# A constitution with one pack group already present, for the pack-aware upsert.
+_GROUPED = (
+    "# CONSTITUTION\n\n## Directives\n\n"
+    "### ungrouped-one\n\n- u1\n\n"
+    "## governance-kit/foundation\n\n"
+    "### required-docs\n\n- rd\n\n"
+    "## Evolution Log\n\n- 2026-01-01 — seed\n"
+)
+
+
+def test_upsert_pack_creates_header_and_nests() -> None:
+    out, action = docsurgery.upsert_directive_subsection(
+        _GROUPED, "no-shims", "### no-shims\n\n- ns\n", "acme/shapes")
+    assert action == "inserted"
+    assert "## acme/shapes" in out
+    # new pack header sits in the Directives region, before Evolution Log
+    assert out.index("## governance-kit/foundation") < out.index("## acme/shapes") < out.index("## Evolution Log")
+    assert out.index("## acme/shapes") < out.index("### no-shims") < out.index("## Evolution Log")
+
+
+def test_upsert_pack_nests_into_existing_header_sorted() -> None:
+    out, _ = docsurgery.upsert_directive_subsection(
+        _GROUPED, "kit-version-sync", "### kit-version-sync\n\n- kv\n", "governance-kit/foundation")
+    seg = out[out.index("## governance-kit/foundation"):out.index("## Evolution Log")]
+    order = [ln for ln in seg.splitlines() if ln.startswith("### ")]
+    # sorted within the group: kit-version-sync precedes required-docs
+    assert order == ["### kit-version-sync", "### required-docs"], order
+
+
+def test_upsert_pack_relocates_ungrouped_subsection() -> None:
+    # `ungrouped-one` sits bare under `## Directives`; upserting it with its pack
+    # id moves it under the pack header (removing the stray copy), not duplicates.
+    out, action = docsurgery.upsert_directive_subsection(
+        _GROUPED, "ungrouped-one", "### ungrouped-one\n\n- u1 v2\n", "acme/shapes")
+    assert action == "replaced"
+    assert out.count("### ungrouped-one") == 1
+    assert "- u1\n" not in out and "- u1 v2" in out
+    assert out.index("## acme/shapes") < out.index("### ungrouped-one")
+
+
+def test_upsert_pack_is_idempotent() -> None:
+    once, _ = docsurgery.upsert_directive_subsection(
+        _GROUPED, "no-shims", "### no-shims\n\n- ns\n", "acme/shapes")
+    twice, _ = docsurgery.upsert_directive_subsection(
+        once, "no-shims", "### no-shims\n\n- ns\n", "acme/shapes")
+    assert once == twice
+
+
+def test_render_pack_groups_emits_headers_and_blocks() -> None:
+    out = docsurgery.render_pack_groups(
+        [("a/b", ["### r\n\n- R\n", "### h\n\n- H\n"]), ("a/c", ["### s\n\n- S\n"])])
+    assert out == "## a/b\n\n### r\n\n- R\n\n### h\n\n- H\n\n## a/c\n\n### s\n\n- S\n\n"
+
+
+def test_append_evolution_log_after_last_entry() -> None:
+    out = docsurgery.append_evolution_log(CONST, "- 2026-06-10 — new entry")
+    assert out.rstrip().endswith("- 2026-06-10 — new entry")
+    assert "- 2026-01-01 — old" in out
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"not ok - {name}: {exc}", file=sys.stderr)
+        else:
+            print(f"ok - {name}")
+    raise SystemExit(1 if failures else 0)

--- a/scripts/test-init.py
+++ b/scripts/test-init.py
@@ -52,13 +52,28 @@ def test_assemble_constitution_splices_principles_and_subsections() -> None:
     template = (ROOT / "kit/assets/CONSTITUTION.template.md").read_text()
     out = initplan.assemble_constitution(
         template, ["Ship receipts, not promises."],
-        ["### no-console-log\n\n- **Directive**: no console.log.\n"])
+        [("acme/widgets", ["### no-console-log\n\n- **Directive**: no console.log.\n"])])
     assert "Ship receipts, not promises." in out
     assert "### no-console-log" in out
     # the template example directive is replaced, not kept
     assert "### Example — constitution-exists" not in out
     # structure preserved
     assert "## Amendment process" in out and "## Evolution Log" in out
+
+
+def test_assemble_constitution_groups_subsections_by_pack() -> None:
+    template = (ROOT / "kit/assets/CONSTITUTION.template.md").read_text()
+    out = initplan.assemble_constitution(
+        template, [],
+        [("acme/widgets", ["### widget-naming\n\n- **Directive**: x.\n",
+                           "### widget-size\n\n- **Directive**: y.\n"]),
+         ("acme/shapes", ["### no-shims\n\n- **Directive**: z.\n"])])
+    # each pack gets a `## <owner>/<pack>` header, between `## Directives` and
+    # `## Amendment process`, with its directives nested under it.
+    assert "## acme/widgets" in out and "## acme/shapes" in out
+    assert out.index("## Directives") < out.index("## acme/widgets") < out.index("## Amendment process")
+    assert out.index("## acme/widgets") < out.index("### widget-naming") < out.index("## acme/shapes")
+    assert out.index("## acme/shapes") < out.index("### no-shims") < out.index("## Amendment process")
 
 
 # --- end-to-end init-apply --------------------------------------------------

--- a/scripts/test-packverb-apply.py
+++ b/scripts/test-packverb-apply.py
@@ -39,7 +39,6 @@ def _load(name: str):
 
 packplan = _load("packplan")
 packapply = _load("packapply")
-docsurgery = _load("docsurgery")
 
 GIT_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
@@ -165,57 +164,8 @@ def _capture(fn):
     return rc, json.loads(out)
 
 
-# --- docsurgery (pure) ------------------------------------------------------
-
-CONST = (
-    "# CONSTITUTION\n\n## Directives\n\n"
-    "### required-docs\n\n- body A\n\n"
-    "### no-console-log\n\n- body B\n\n"
-    "### secrets-hygiene\n\n- body C\n\n"
-    "## Evolution Log\n\n<!-- hint -->\n\n- 2026-01-01 — old\n"
-)
-
-
-def test_strip_subsection_removes_only_target() -> None:
-    out, removed = docsurgery.strip_directive_subsection(CONST, "no-console-log")
-    assert removed
-    assert "### no-console-log" not in out
-    assert "### required-docs" in out and "### secrets-hygiene" in out
-    assert "- body A" in out and "- body C" in out and "- body B" not in out
-
-
-def test_strip_subsection_absent_is_noop() -> None:
-    out, removed = docsurgery.strip_directive_subsection(CONST, "nope")
-    assert not removed and out == CONST
-
-
-def test_strip_subsection_prefix_no_alias() -> None:
-    # `doc` must not match `doc-freshness`.
-    text = "## Directives\n\n### doc-freshness\n\nbody\n"
-    out, removed = docsurgery.strip_directive_subsection(text, "doc")
-    assert not removed and out == text
-
-
-def test_upsert_replaces_in_place() -> None:
-    out, action = docsurgery.upsert_directive_subsection(
-        CONST, "no-console-log", "### no-console-log\n\n- NEW body\n")
-    assert action == "replaced"
-    assert "- NEW body" in out and "- body B" not in out
-    assert out.count("### no-console-log") == 1
-
-
-def test_upsert_inserts_at_end_of_directives() -> None:
-    out, action = docsurgery.upsert_directive_subsection(
-        CONST, "brand-new", "### brand-new\n\n- fresh\n")
-    assert action == "inserted"
-    # lands inside Directives, before Evolution Log
-    assert out.index("### brand-new") < out.index("## Evolution Log")
-
-
-def test_append_evolution_log_after_last_entry() -> None:
-    out = docsurgery.append_evolution_log(CONST, "- 2026-06-10 — new entry")
-    assert out.rstrip().endswith("- 2026-06-10 — new entry")
-    assert "- 2026-01-01 — old" in out
+# Pure docsurgery transforms (strip/upsert/render/evolution-log) are unit-tested
+# in scripts/test-docsurgery.py; this file owns the pack-plan/apply integration.
 
 
 # --- pack-plan / pack-apply: add -------------------------------------------
@@ -394,7 +344,36 @@ def test_add_upserts_constitution_subsection() -> None:
         assert text.count("### no-console-log") == 1
         assert text.index("### no-console-log") < text.index("## Evolution Log")
         assert "### required-docs" in text  # existing entry untouched
+        # pack-group-aware: the subsection lands under a `## acme/widgets` header.
+        assert "## acme/widgets" in text
+        assert text.index("## acme/widgets") < text.index("### no-console-log")
         assert report["constitution_upserted"] == ["no-console-log"]
+
+
+def test_add_relocates_ungrouped_subsection_under_pack_header() -> None:
+    # A directive whose subsection already sits ungrouped (an earlier flat upsert,
+    # or a hand-curated doc) is moved under its `## <owner>/<pack>` header — not
+    # duplicated. This is the path that fixes a previously-ungrouped subsection on
+    # a re-pin.
+    with tempfile.TemporaryDirectory() as tmp:
+        src = _write_source_pack(Path(tmp) / "src")
+        ungrouped = (
+            "# CONSTITUTION\n\n## Directives\n\n"
+            "### no-console-log\n\n- stale flat body\n\n"
+            "### required-docs\n\n- body\n\n"
+            "## Evolution Log\n\n- 2026-01-01 — seed\n"
+        )
+        root = _make_repo(Path(tmp) / "repo", constitution=ungrouped)
+        packplan.fetch_ref = _stub_fetch(src, "acme/widgets", "a" * 40)
+        rc, report = _capture(lambda: packapply.cmd_pack_apply(
+            _ns(mode="add", root=str(root), target="gh:acme/widgets")))
+        assert rc == 0 and report["result"] == "applied", report
+        text = (root / "CONSTITUTION.md").read_text()
+        assert text.count("### no-console-log") == 1  # relocated, not duplicated
+        assert "stale flat body" not in text          # old copy gone
+        assert text.index("## acme/widgets") < text.index("### no-console-log")
+        # the unrelated ungrouped entry is left where it was
+        assert text.index("### required-docs") < text.index("## acme/widgets")
 
 
 def test_update_replaces_constitution_subsection_in_place() -> None:
@@ -415,6 +394,8 @@ def test_update_replaces_constitution_subsection_in_place() -> None:
         text = (root / "CONSTITUTION.md").read_text()
         assert text.count("### no-console-log") == 1  # replaced, not duplicated
         assert "REVISED body" in text
+        # still grouped under its pack header after the update
+        assert text.index("## acme/widgets") < text.index("### no-console-log")
         assert report["constitution_upserted"] == ["no-console-log"]
 
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -84,6 +84,10 @@ run_layer "skill bootstrap: fetch-only shim + cache contract (Python)" \
     uv run --quiet --isolated --with PyYAML python "$ROOT/scripts/test-bootstrap.py" \
     || failed_layers+=("test-bootstrap.py")
 
+run_layer "docsurgery: pure CONSTITUTION.md transforms (Python)" \
+    uv run --quiet --isolated python "$ROOT/scripts/test-docsurgery.py" \
+    || failed_layers+=("test-docsurgery.py")
+
 run_layer "pack-apply: plan/apply add/update/remove + doc surgery (Python)" \
     uv run --quiet --isolated --with PyYAML python "$ROOT/scripts/test-packverb-apply.py" \
     || failed_layers+=("test-packverb-apply.py")


### PR DESCRIPTION
Closes #238 (split out of #229's appended follow-up #2).

`packapply`'s `pack add`/`update` upserts each directive's `constitution.md` subsection (#227/#228) via `docsurgery.upsert_directive_subsection`, which landed it bare under `## Directives` rather than under the directive's `## <owner>/<pack>` header — so directives added via `pack add` (e.g. the architecture pack) appear ungrouped, above the per-pack sections.

Investigation found the grouping convention is broader than the issue implied: **neither `init` nor `packapply` generated the `## <owner>/<pack>` headers** — the live grouping was a hand-curated migration in #193. So the fix is a **shared pack-group-aware renderer** used by every lifecycle path.

## Changes

- **`docsurgery.py`**: `render_pack_groups(groups)` (shared renderer) + `upsert_directive_subsection(text, did, subsection, pack_id=None)`. With `pack_id`, the subsection is homed under `## <owner>/<pack>` (header created at the end of the Directives region if absent), inserted in **sorted** position within the group, and any stray copy elsewhere is removed first — so a re-pin **relocates** a previously-ungrouped subsection into its group. `pack_id=None` preserves the exact legacy flat behaviour.
- **`init`** (`initplan.assemble_constitution` + `initapply`): builds `[(pack_id, [subsection…])]` groups and renders via `render_pack_groups`, so a fresh install groups by pack.
- **`packapply`**: passes `pack["id"]` to the upsert (add + update).
- **`resetapply`**: passes the directive's `pack_id` too, so reset is consistent (the plan already carried it).

A pack header is discriminated from a major section by the slash in `<owner>/<pack>` — no hard-coded section list. The GDD invariant (every directive ↔ a constitution entry) holds throughout.

## Tests

- New `scripts/test-docsurgery.py` (split out of `test-packverb-apply.py` so both stay under the file-size limit): pure-transform unit tests, including header-creation, sorted nesting, **relocation**, idempotency, and `render_pack_groups`.
- `test-init.py`: new `test_assemble_constitution_groups_subsections_by_pack`.
- `test-packverb-apply.py`: add/update tests assert pack-header placement; new `test_add_relocates_ungrouped_subsection_under_pack_header`.
- `bash scripts/test.sh` green (all kit-internal layers incl. the new docsurgery layer); `bash scripts/dogfood-smoke.sh` green.

## Out of scope

Relocating *this* repo's own ungrouped architecture directives — that happens when the dogfood re-pins architecture (the sibling follow-up #1 of #229), which runs this fixed upsert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
