### PR TITLE
fix(foundation): managed-tree-integrity must not marker-validate seed-once sweep assets

### DIFF
--- a/packs/foundation/directives/managed-tree-integrity/evals/test.sh
+++ b/packs/foundation/directives/managed-tree-integrity/evals/test.sh
@@ -125,5 +125,22 @@ EVAL_LABEL="$EVAL_ID sweep engine modified" expect_fail "$CHECK"
 mkdir -p .governance/conf/governance-kit/foundation
 printf '.governance/sweep.py\n' > .governance/conf/governance-kit/foundation/$EVAL_ID.conf
 EVAL_LABEL="$EVAL_ID sweep engine waiver" expect_pass "$CHECK"
+rm -f .governance/conf/governance-kit/foundation/$EVAL_ID.conf
+
+# 8c. issue #263 — a sweep asset carries its *seed-time* marker and is never
+#     re-stamped on a kit update, so its `kit-version=` legitimately differs from
+#     the manifest pin. That divergence must NOT be a violation (unlike a true
+#     runtime file, cf. case 1b): the digest still guards the content. Stamp the
+#     engine with an older marker than the pin, record its matching digest →
+#     passes on digest alone, no marker-vs-manifest false positive.
+printf '#!/usr/bin/env python3\n# governance-kit:managed kit-version=0.0.1\nprint("sweep")\n' > .governance/sweep.py
+write_manifest "managed_digests:
+  .governance/sweep.py: $(file_digest ".governance/sweep.py")"
+EVAL_LABEL="$EVAL_ID sweep engine seed-time marker" expect_pass "$CHECK"
+
+# 8d. fail — the digest still guards the sweep engine even when its marker
+#     diverges from the pin: a content hand-edit is caught.
+printf '\n# tampered\n' >> .governance/sweep.py
+EVAL_LABEL="$EVAL_ID sweep engine divergent marker + tamper" expect_fail "$CHECK"
 
 eval_done

--- a/packs/foundation/directives/managed-tree-integrity/lib/integrity.py
+++ b/packs/foundation/directives/managed-tree-integrity/lib/integrity.py
@@ -33,6 +33,19 @@ from pathlib import Path
 
 EXCLUDED_DIRS = ("evals", "install-assets", "__pycache__")
 
+# Seed-once sweep-lane assets (issue #259): the apply engines digest-record them
+# (via digestlib.managed_runtime_files), but they are *seeded* with the kit
+# version current at seed time and never re-stamped on a kit update — unlike the
+# four manifest-scalar runtime files, nothing re-renders them forward. Their
+# `kit-version=` marker therefore legitimately diverges from the manifest pin, so
+# they are exempt from the marker-version equality check below (issue #263). The
+# digest check still guards their content fully — the marker line is inside the
+# digested bytes — so a hand-edit is still caught. Mirrors applylib.SWEEP_ASSETS.
+SWEEP_ASSET_RELPATHS = (
+    ".github/workflows/governance-sweep.yml",
+    ".governance/sweep.py",
+)
+
 
 # ── digest (must stay byte-identical to digestlib.py) ───────────────────────
 def file_digest(path) -> str:
@@ -206,7 +219,12 @@ def main(argv: list[str]) -> int:
             # Marker / manifest consistency (subsumes the former kit-version-sync):
             # a hand-edited manifest kit_version leaves the files matching their
             # recorded digests, so the digest alone can't catch it — compare the
-            # file's stamped marker to the manifest's kit_version.
+            # file's stamped marker to the manifest's kit_version. Seed-once sweep
+            # assets are exempt: they carry their seed-time marker and are never
+            # re-stamped on a kit update, so marker != pin is expected, not drift
+            # (issue #263). The digest check above still guards their content.
+            if rel in SWEEP_ASSET_RELPATHS:
+                continue
             mv = marker_version(f)
             if kit_version and mv and mv != kit_version:
                 report(rel, f"{rel}: stamped kit-version={mv} but install.yaml pins kit_version={kit_version} "

--- a/receipts/issue-263.md
+++ b/receipts/issue-263.md
@@ -1,0 +1,9 @@
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-a8a926bf-cad-1781380146-1 | claude-code | a8a926bf-cadc-4815-98ae-0cdb24b4482e | #263 | claude-opus-4-8 | 37970 | 422061 | 15467961 | 173532 | 633563 | 14.9000 | 37970 | 422061 | 15467961 | 173532 |  |


### PR DESCRIPTION
Closes #263.

## Problem

Cutting kit v0.9.0 + foundation v0.4.0 (#261) and updating this repo's dogfood (#262) surfaced a regression: `governance update` to kit 0.9.0 fails `managed-tree-integrity` in any repo with a **sweep lane** installed:

```
.governance/sweep.py: stamped kit-version=0.8.0 but install.yaml pins kit_version=0.9.0 — half-applied update or an out-of-band version edit; re-run 'governance update'
.github/workflows/governance-sweep.yml: stamped kit-version=0.8.0 but install.yaml pins kit_version=0.9.0 — ...
```

kit 0.9.0's `digestlib.managed_runtime_files` (#259/#260) correctly enumerates the seed-once sweep assets so the apply engines **digest**-record them. But `integrity.py` applied its *marker-version equality* check (the folded-in former `kit-version-sync`) to **every** `managed_digests` entry. Sweep assets are seeded once with the kit version current **at seed time** and never re-stamped on a kit update (`_inventory` only re-stamps the four manifest-scalar runtime files; `seed_sweep_assets` only stamps *missing* assets), so their marker legitimately diverges from the pin → false positive, with no verb able to remediate.

## Fix

The `managed-tree-integrity` constitution only ever promised **sha256 (digest)** for the sweep assets — never marker-version equality — and the digest check alone fully guards their content (the marker line is inside the digested bytes). So exempt the sweep relpaths from the marker check while keeping the digest guard. **kit v0.9.0 is correct as-is — no kit change needed.**

- `integrity.py`: `SWEEP_ASSET_RELPATHS` constant (mirrors `applylib.SWEEP_ASSETS`); skip the marker check for those two relpaths.
- evals: case **8c** (sweep marker ≠ pin but digest matches → pass — the regression) and **8d** (divergent marker + content tamper → fail; digest still guards).

foundation `0.4.0 → 0.4.1` (PATCH: check bug fix, strictly fewer false failures) — version bump is cut separately by `release.sh`, not in this PR.

## Verification

- `bash packs/foundation/directives/managed-tree-integrity/evals/test.sh` — 15 cases pass incl. the two new ones.
- `python3 scripts/test-digestlib.py` — digest pin holds (no change to `file_digest`/`directory_digest`).
- `bash .governance/run.sh` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)