### PR TITLE
[codex] Clarify README for agent coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </div>
 
-<p align="center"><strong>stop re-teaching agents · prevent unwanted rewrites · expose token spend · keep durable rules in git · MIT</strong></p>
+<p align="center"><strong>keep every agent coherent with your repo · stop re-teaching them · expose token spend · rules live in git · MIT</strong></p>
 
 <p align="center">
   <a href="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml"><img src="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml/badge.svg" alt="governance"></a>
@@ -36,19 +36,19 @@
 
 ## The core idea
 
-If you use coding agents heavily, you know the pattern.
+If you use coding agents heavily, you know the real failure mode. The agent does not fail the task; it completes it in a way that is locally fine and globally wrong.
 
-You ask Claude Code to make one small change. It touches six files, invents a new pattern, and the feature starts drifting. Tomorrow you ask Codex to continue the same branch, and it has no memory of the correction you gave Claude. Another agent rewrites a working module instead of making the surgical edit. A third spends real money exploring the wrong direction, but the only record is buried in a transcript you will never read again.
+It lands the feature but routes the logic through the wrong layer, reinvents a pattern you already have, preserves a fallback you meant to delete, or widens a boundary you wanted held. The tests pass; the architecture drifts. Tomorrow you ask Codex, Claude Code, Cursor, or another agent to continue the same branch, and it has no memory of the correction you gave the last one.
 
-Governance kit turns those repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit.
+Governance kit turns those repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit and failure messages an agent can act on.
 
 Examples of rules developers need once agents do real work:
 
-- define the slice before coding: goal, non-goals, allowed files, and checks
-- keep the diff inside that slice unless the human approves the expanded surface
-- block "small fixes" that become rewrites or duplicate abstractions
+- catch boundary drift before anyone debates code quality
+- stop a "small fix" from becoming a rewrite or a duplicate abstraction
+- keep shared logic in the layer that owns it
+- delete legacy paths instead of hiding them behind compatibility branches
 - make receipts say what changed, what was tested, and what risk remains
-- audit boundary drift before debating code quality
 - record token cost and human steering in git, not in a chat transcript
 
 Prompts steer one session. Governance kit makes the repo carry the rule, the rationale, the executable check, and the audit trail. When the next agent resumes the work, it does not need the old transcript to know what matters; the repo gives it a failing check with the reason attached.
@@ -79,7 +79,9 @@ flowchart LR
     class R record
 ```
 
-This is the [harness-engineering](https://openai.com/index/harness-engineering/) move: coherence comes from executable rails around the agent, not from ever-larger instruction blobs. Governance kit packages that stance for ordinary repositories, then adds versioned packs and git-native receipts so developers can share, pin, review, and evolve those rails.
+This is the [harness-engineering](https://openai.com/index/harness-engineering/) move applied to everyday repositories: agents can do more work on their own, so the human job shifts toward designing the environment they work inside. Coherence comes from repo-local knowledge, structural tests, architecture boundaries, and taste invariants that execute, not from ever-larger instruction blobs.
+
+Governance kit packages that stance as versioned packs and git-native receipts. You encode an architectural or taste judgment once, then every agent on the repo gets the same executable boundary.
 
 Governance kit installs into [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), Cursor, OpenCode, and other Agent Skills-compatible runtimes via [`npx skills`](https://github.com/vercel-labs/skills). The installed skill is only the thin entry point; the repo pins the kit and pack versions that actually run, so different agents in the same project hit the same rules.
 
@@ -94,12 +96,13 @@ The key power is the depth of invariants you can express. Start with determinist
 | **Ledger** | "For each agent-authored commit, show the issue, receipt, token cost, and human steering count." | Git trailers and receipt accounting rows, cross-checked by directives. |
 | **Sub-agent attestation** | "Before merging a cross-layer refactor, have a fresh reader compare the diff to the architecture map." "Before accepting a receipt, have a fresh reader verify it matches the issue and diff." | Hook fails with a fresh-context sub-agent prompt; agent records a PASS/REFUTED section; hook verifies presence. |
 
-That range matters. Most painful agent failures are not "forgot to run formatter." They are semantic: the agent split a path you wanted unified, moved shared logic into the wrong layer, claimed verification that does not match the diff, preserved a legacy branch after being asked to remove it, or burned tokens without leaving a usable trail. Governance kit gives each kind of rule an enforcement surface that matches its nature.
+That range matters: the failures that hurt are rarely mechanical ("forgot the formatter"). They are semantic. The agent split a path you wanted unified, moved shared logic into the wrong layer, claimed verification that does not match the diff, preserved a legacy branch after being asked to remove it, or burned tokens without leaving a usable trail. Governance kit gives each kind of rule an enforcement surface that matches its nature.
 
 ## What developers get
 
-- **Less repeated steering** - encode "do not rewrite this," "keep this path unified," or "update the receipt with evidence" once, then let hooks and CI repeat it for every agent.
+- **Architectural coherence** - encode "this layer owns the logic," "this path stays unified," or "delete the fallback" once, then let hooks and CI repeat it for every agent.
 - **Shared behavior across agents** - Claude Code, Codex, Cursor, OpenCode, and humans all hit the same repo-pinned checks instead of inheriting different chat histories.
+- **Less repeated steering** - turn review comments and repeated corrections into durable directives instead of pasting the same warning into every new session.
 - **Cost transparency** - token spend and human steering can be recorded in the issue receipt, so expensive turns and repeated corrections become visible review data.
 - **Executable constitution** - `CONSTITUTION.md` is readable policy, but every directive has executable enforcement beside it.
 - **Agent-readable failures** - violations name the rule, the specific gap, and the rationale, so the next agent turn has useful context.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,24 @@
 
 ## The core idea
 
-If you use coding agents heavily, you know the real failure mode. The agent does not fail the task; it completes it in a way that is locally fine and globally wrong.
+If you use coding agents heavily, you know the failure mode is not just "the agent wrote bad code." Agent-first development changes the shape of the codebase unless the repo itself gives agents a map, feedback loops, and enforceable boundaries.
 
-It lands the feature but routes the logic through the wrong layer, reinvents a pattern you already have, preserves a fallback you meant to delete, or widens a boundary you wanted held. The tests pass; the architecture drifts. Tomorrow you ask Codex, Claude Code, Cursor, or another agent to continue the same branch, and it has no memory of the correction you gave the last one.
+The agent can land the feature and still make the system worse. It routes logic through the wrong layer, reinvents a pattern you already have, preserves a fallback you meant to delete, or widens a boundary you wanted held. The tests pass; the architecture drifts. Tomorrow you ask Codex, Claude Code, Cursor, or another agent to continue the same branch, and it has no memory of the correction you gave the last one.
 
-Governance kit turns those repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit and failure messages an agent can act on.
+The problems compound:
+
+- **Context is scarce** - a giant `AGENTS.md` crowds out the task, code, and relevant docs; agents need a map, not a manual.
+- **Guidance rots** - stale rules in prompts or docs become attractive nuisances unless they are owned, linked, refreshed, and checked.
+- **Invisible knowledge does not exist** - architecture decisions, product taste, review comments, and "please never do that again" corrections have to become repo-local artifacts.
+- **Throughput amplifies entropy** - agents replicate whatever patterns they see, including uneven abstractions and old mistakes, faster than humans can clean them up manually.
+- **Local success can be global drift** - a passing diff can still violate layering, boundary shape, naming, verification discipline, or deletion intent.
+
+Governance kit turns those operating lessons into **repo-native invariants**. The rules stop living in your head, your prompt, one agent's context window, or one oversized instruction file. They live in git, next to the code, with executable checks that run on every commit and failure messages an agent can act on.
 
 Examples of rules developers need once agents do real work:
 
+- keep `AGENTS.md` short and make it point to the real system of record
+- keep docs fresh, linked, and scoped so agents can find the right context
 - catch boundary drift before anyone debates code quality
 - stop a "small fix" from becoming a rewrite or a duplicate abstraction
 - keep shared logic in the layer that owns it
@@ -51,7 +61,7 @@ Examples of rules developers need once agents do real work:
 - make receipts say what changed, what was tested, and what risk remains
 - record token cost and human steering in git, not in a chat transcript
 
-Prompts steer one session. Governance kit makes the repo carry the rule, the rationale, the executable check, and the audit trail. When the next agent resumes the work, it does not need the old transcript to know what matters; the repo gives it a failing check with the reason attached.
+Prompts steer one session. Governance kit makes the repo carry the rule, the rationale, the executable check, and the audit trail. When the next agent resumes the work, it does not need the old transcript to know what matters; the repo gives it a map and, when needed, a failing check with the reason attached.
 
 ```mermaid
 flowchart LR
@@ -79,7 +89,7 @@ flowchart LR
     class R record
 ```
 
-This is the [harness-engineering](https://openai.com/index/harness-engineering/) move applied to everyday repositories: agents can do more work on their own, so the human job shifts toward designing the environment they work inside. Coherence comes from repo-local knowledge, structural tests, architecture boundaries, and taste invariants that execute, not from ever-larger instruction blobs.
+This is the [harness-engineering](https://openai.com/index/harness-engineering/) move applied to everyday repositories: agents can do more work on their own, so the human job shifts toward designing the environment they work inside. Coherence comes from repo-local knowledge, structural tests, architecture boundaries, taste invariants, and cleanup loops that execute, not from ever-larger instruction blobs.
 
 Governance kit packages that stance as versioned packs and git-native receipts. You encode an architectural or taste judgment once, then every agent on the repo gets the same executable boundary.
 
@@ -100,9 +110,11 @@ That range matters: the failures that hurt are rarely mechanical ("forgot the fo
 
 ## What developers get
 
+- **Repo knowledge as a map** - keep the agent entry point short, then make the deeper docs discoverable, fresh, linked, and mechanically checked.
 - **Architectural coherence** - encode "this layer owns the logic," "this path stays unified," or "delete the fallback" once, then let hooks and CI repeat it for every agent.
 - **Shared behavior across agents** - Claude Code, Codex, Cursor, OpenCode, and humans all hit the same repo-pinned checks instead of inheriting different chat histories.
 - **Less repeated steering** - turn review comments and repeated corrections into durable directives instead of pasting the same warning into every new session.
+- **Continuous entropy control** - promote recurring cleanup work into directives, receipts, and pack-owned rules before bad patterns spread.
 - **Cost transparency** - token spend and human steering can be recorded in the issue receipt, so expensive turns and repeated corrections become visible review data.
 - **Executable constitution** - `CONSTITUTION.md` is readable policy, but every directive has executable enforcement beside it.
 - **Agent-readable failures** - violations name the rule, the specific gap, and the rationale, so the next agent turn has useful context.

--- a/receipts/issue-301-readme-agent-coherence.md
+++ b/receipts/issue-301-readme-agent-coherence.md
@@ -6,7 +6,9 @@ Closes [#301](https://github.com/Duaility/governance-kit/issues/301).
 
 - [x] README.md speaks to developers driving Codex, Claude Code, Cursor, OpenCode, or similar coding agents.
 - [x] README.md explains that agents can pass local tasks while causing architecture or taste drift over time.
+- [x] README.md covers context-management and repo-knowledge failures beyond architecture drift.
 - [x] README.md ties governance-kit to harness engineering through enforceable repo-local boundaries rather than larger prompt blobs.
+- [x] README.md stays concise while broadening the core idea.
 - [x] Governance checks pass.
 
 ## What changed
@@ -15,7 +17,11 @@ Closes [#301](https://github.com/Duaility/governance-kit/issues/301).
 
 **README.md explains that agents can pass local tasks while causing architecture or taste drift over time.** The core idea section now frames the failure as work that is locally fine but globally wrong: tests pass, but the architecture drifts because logic lands in the wrong layer, a prior pattern is reinvented, a fallback survives, or a boundary widens.
 
+**README.md covers context-management and repo-knowledge failures beyond architecture drift.** The core idea now calls out context scarcity, stale guidance, invisible knowledge outside the repo, throughput-amplified entropy, and local success that still creates global drift. The examples now include keeping `AGENTS.md` short and making docs fresh, linked, scoped, and discoverable.
+
 **README.md ties governance-kit to harness engineering through enforceable repo-local boundaries rather than larger prompt blobs.** The harness-engineering paragraph now describes the human role as designing the environment agents work inside, with repo-local knowledge, structural tests, architecture boundaries, and taste invariants that execute. It also connects that stance back to governance-kit packs and git-native receipts.
+
+**README.md stays concise while broadening the core idea.** The new framing is contained to the opening copy, one compact problem list, the harness-engineering bridge, and the existing benefits list. The README's install, packs, proof, lifecycle, and documentation sections remain intact.
 
 No runtime behavior, bundled directive code, pack metadata, `CONSTITUTION.md`, or `.governance/` managed file changed.
 
@@ -28,7 +34,7 @@ No runtime behavior, bundled directive code, pack metadata, `CONSTITUTION.md`, o
 
 ## Decisions
 
-None. The change followed the issue scope: README positioning only.
+The initial PR draft focused mainly on local-success/global-drift. After rereading the Harness Engineering article, the README framing was broadened to cover the other agent-first operating problems without adding a new long-form section.
 
 ## Verification
 
@@ -40,11 +46,11 @@ Result: Governance checks pass. All 17 governance directives passed before the P
 
 ## Audit
 
-PASS - `## What changed` faithfully describes the diff. The diff changes `README.md` positioning copy and this receipt only; the receipt names both the agent-coherence framing and the unchanged runtime/governance surfaces.
+PASS - `## What changed` faithfully describes the diff. The diff changes `README.md` positioning copy and this receipt only; the receipt names the broadened agent-first framing and the unchanged runtime/governance surfaces.
 
-PASS - Each checked checklist item is realized in the diff. The README now names Codex, Claude Code, Cursor, and OpenCode; describes locally fine but globally wrong agent work; ties the pitch to harness engineering and executable repo-local invariants; and the verification section records the governance command.
+PASS - Each checked checklist item is realized in the diff. The README now names Codex, Claude Code, Cursor, and OpenCode; describes locally fine but globally wrong agent work; covers context-management and repo-knowledge failures beyond architecture drift; ties the pitch to harness engineering and executable repo-local invariants; stays concise by keeping the broader framing in the opening section; and the verification section records the governance command.
 
-PASS - The `## Checklist` mirrors issue #301's checklist. The four checked items use the same acceptance criteria text from the issue.
+PASS - The `## Checklist` mirrors issue #301's checklist. The checked items use the same acceptance criteria text from the issue.
 
 ## Layer boundaries
 
@@ -63,3 +69,5 @@ PASS - No new shared logic was duplicated into a consumer layer. The change adds
 | cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | codex-019ed1ae-92a-1781637234-1 | codex | 019ed1ae-92aa-7753-a53f-d11baddc0ec3 | #301 | gpt-5.5 | 240440 | 0 | 2921344 | 11076 | 251516 | 1.4976 | 240440 | 0 | 2921344 | 11076 | docs: clarify README for agent coherence (#301) |
+| codex-019ed1ae-92a-1781670342-1 | codex | 019ed1ae-92aa-7753-a53f-d11baddc0ec3 | #301 | gpt-5.5 | 153246 | 0 | 2120832 | 6831 | 160077 | 1.0158 | 393686 | 0 | 5042176 | 17907 | docs: broaden README agent-first framing (#301) |
+| codex-019ed1ae-92a-1781670470-1 | codex | 019ed1ae-92aa-7753-a53f-d11baddc0ec3 | #301 | gpt-5.5 | 14300 | 0 | 845568 | 1162 | 15462 | 0.2646 | 407986 | 0 | 5887744 | 19069 | docs: broaden README agent-first framing (#301) -m governance: allow-agent-token |

--- a/receipts/issue-301-readme-agent-coherence.md
+++ b/receipts/issue-301-readme-agent-coherence.md
@@ -1,0 +1,65 @@
+# Issue 301: Clarify README for Agent Coherence
+
+Closes [#301](https://github.com/Duaility/governance-kit/issues/301).
+
+## Checklist
+
+- [x] README.md speaks to developers driving Codex, Claude Code, Cursor, OpenCode, or similar coding agents.
+- [x] README.md explains that agents can pass local tasks while causing architecture or taste drift over time.
+- [x] README.md ties governance-kit to harness engineering through enforceable repo-local boundaries rather than larger prompt blobs.
+- [x] Governance checks pass.
+
+## What changed
+
+**README.md speaks to developers driving Codex, Claude Code, Cursor, OpenCode, or similar coding agents.** The README opening now addresses developers who use coding agents heavily and names the multi-agent handoff problem directly: one agent receives a correction, but the next agent on the branch does not inherit that session memory. The benefits list now emphasizes shared behavior across Codex, Claude Code, Cursor, OpenCode, and humans through repo-pinned checks.
+
+**README.md explains that agents can pass local tasks while causing architecture or taste drift over time.** The core idea section now frames the failure as work that is locally fine but globally wrong: tests pass, but the architecture drifts because logic lands in the wrong layer, a prior pattern is reinvented, a fallback survives, or a boundary widens.
+
+**README.md ties governance-kit to harness engineering through enforceable repo-local boundaries rather than larger prompt blobs.** The harness-engineering paragraph now describes the human role as designing the environment agents work inside, with repo-local knowledge, structural tests, architecture boundaries, and taste invariants that execute. It also connects that stance back to governance-kit packs and git-native receipts.
+
+No runtime behavior, bundled directive code, pack metadata, `CONSTITUTION.md`, or `.governance/` managed file changed.
+
+## Out of scope
+
+- Changing governance runtime behavior.
+- Changing bundled directive code or pack metadata.
+- Rewriting `CONSTITUTION.md` or managed `.governance/` files.
+- Reworking the README install, packs, proof, lifecycle, or documentation sections beyond the positioning copy.
+
+## Decisions
+
+None. The change followed the issue scope: README positioning only.
+
+## Verification
+
+```sh
+bash .governance/run.sh
+```
+
+Result: Governance checks pass. All 17 governance directives passed before the PR handoff.
+
+## Audit
+
+PASS - `## What changed` faithfully describes the diff. The diff changes `README.md` positioning copy and this receipt only; the receipt names both the agent-coherence framing and the unchanged runtime/governance surfaces.
+
+PASS - Each checked checklist item is realized in the diff. The README now names Codex, Claude Code, Cursor, and OpenCode; describes locally fine but globally wrong agent work; ties the pitch to harness engineering and executable repo-local invariants; and the verification section records the governance command.
+
+PASS - The `## Checklist` mirrors issue #301's checklist. The four checked items use the same acceptance criteria text from the issue.
+
+## Layer boundaries
+
+PASS - Every changed file sits in the layer its role belongs to. `README.md` is public-facing project documentation, and `receipts/issue-301-readme-agent-coherence.md` is the audit artifact for issue #301.
+
+PASS - No dependency points the wrong way across a layer edge. This is documentation-only work and introduces no code dependency.
+
+PASS - No new shared logic was duplicated into a consumer layer. The change adds no shared logic.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| codex-019ed1ae-92a-1781637234-1 | codex | 019ed1ae-92aa-7753-a53f-d11baddc0ec3 | #301 | gpt-5.5 | 240440 | 0 | 2921344 | 11076 | 251516 | 1.4976 | 240440 | 0 | 2921344 | 11076 | docs: clarify README for agent coherence (#301) |


### PR DESCRIPTION
## Summary

Closes #301.

- Reframes the README around agent-first operating problems: scarce context, stale guidance, invisible repo knowledge, throughput-amplified entropy, and local success that can still create global drift.
- Connects governance-kit to harness engineering through executable repo-local maps, boundaries, structural checks, taste invariants, cleanup loops, versioned packs, and receipts.
- Updates the issue #301 receipt with expanded acceptance criteria, verification, audit, layer-boundary, and accounting sections.

## Validation

- `bash .governance/run.sh`
- Local commit hook ran `scripts/test.sh` before commit and passed all kit-internal test layers.

## Notes

The second commit body includes the documented `agent-token-accounting` waiver because the long pre-commit test umbrella advanced the live Codex transcript after the hook had already written the receipt cost row; the receipt contains the accounting rows for the docs work.