### PR TITLE
docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </div>
 
-<p align="center"><strong>stop re-teaching agents · prevent unwanted rewrites · expose token spend · keep durable rules in git · MIT</strong></p>
+<p align="center"><strong>keep every agent coherent with your repo · stop re-teaching them · expose token spend · rules live in git · MIT</strong></p>
 
 <p align="center">
   <a href="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml"><img src="https://github.com/Duaility/governance-kit/actions/workflows/governance.yml/badge.svg" alt="governance"></a>
@@ -36,22 +36,24 @@
 
 ## The core idea
 
-If you use coding agents heavily, you know the pattern.
+If you use coding agents heavily, you know the real failure mode. The agent doesn't fail the task — it completes it, in a way that's locally fine and globally wrong.
 
-You ask Claude Code to make one small change. It touches six files, invents a new pattern, and the feature starts drifting. Tomorrow you ask Codex to continue the same branch, and it has no memory of the correction you gave Claude. Another agent rewrites a working module instead of making the surgical edit. A third spends real money exploring the wrong direction, but the only record is buried in a transcript you will never read again.
+It lands the feature but routes the logic through the wrong layer, reinvents a pattern you already have, or widens a boundary you wanted held. The objective passes; the architecture drifts. It half-follows the constraints you wrote into `AGENTS.md` or `CLAUDE.md`, missing the ones that matter or optimizing for the wrong ones. And the next agent on the branch has no memory of the correction you gave the last, so you give it again.
+
+The obvious fix is to write the rule into the instruction file so it sticks. But that file only grows, and a wall of instructions crowds out the task, the code, and the docs the agent needs in context. More instructions buy less control.
 
 Governance kit turns those repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit.
 
-Examples of rules developers need once agents do real work:
+Invariants keep the work coherent; **receipts** keep it accountable. When an agent finishes, what it changed, what it cost, and how often you had to correct it normally disappears when the session ends — so governance kit pins that record to the issue as a receipt in git, where the next reviewer, human or agent, can actually use it.
 
-- define the slice before coding: goal, non-goals, allowed files, and checks
-- keep the diff inside that slice unless the human approves the expanded surface
-- block "small fixes" that become rewrites or duplicate abstractions
+Examples of what the repo carries once agents do real work:
+
+- catch boundary drift before anyone debates code quality
+- stop a "small fix" from turning into a rewrite or a duplicate abstraction
 - make receipts say what changed, what was tested, and what risk remains
-- audit boundary drift before debating code quality
 - record token cost and human steering in git, not in a chat transcript
 
-Prompts steer one session. Governance kit makes the repo carry the rule, the rationale, the executable check, and the audit trail. When the next agent resumes the work, it does not need the old transcript to know what matters; the repo gives it a failing check with the reason attached.
+Prompts steer one session, and only by filling its context window. Governance kit makes the repo — not the prompt — carry the rule, the rationale, the executable check, and the audit trail, so the agent spends its context on the task. The next agent doesn't need the old transcript or a swollen rulebook; the one constraint it's about to break arrives as a failing check, reason attached, exactly when it's relevant.
 
 ```mermaid
 flowchart LR
@@ -94,12 +96,10 @@ The key power is the depth of invariants you can express. Start with determinist
 | **Ledger** | "For each agent-authored commit, show the issue, receipt, token cost, and human steering count." | Git trailers and receipt accounting rows, cross-checked by directives. |
 | **Sub-agent attestation** | "Before merging a cross-layer refactor, have a fresh reader compare the diff to the architecture map." "Before accepting a receipt, have a fresh reader verify it matches the issue and diff." | Hook fails with a fresh-context sub-agent prompt; agent records a PASS/REFUTED section; hook verifies presence. |
 
-That range matters. Most painful agent failures are not "forgot to run formatter." They are semantic: the agent split a path you wanted unified, moved shared logic into the wrong layer, claimed verification that does not match the diff, preserved a legacy branch after being asked to remove it, or burned tokens without leaving a usable trail. Governance kit gives each kind of rule an enforcement surface that matches its nature.
+That range matters: the failures that hurt are rarely mechanical ("forgot the formatter") — they're semantic, and no single enforcement style catches both. Governance kit matches each rule to a surface — cheap deterministic checks for the mechanical, fresh-context attestation for the judgment calls.
 
 ## What developers get
 
-- **Less repeated steering** - encode "do not rewrite this," "keep this path unified," or "update the receipt with evidence" once, then let hooks and CI repeat it for every agent.
-- **Shared behavior across agents** - Claude Code, Codex, Cursor, OpenCode, and humans all hit the same repo-pinned checks instead of inheriting different chat histories.
 - **Cost transparency** - token spend and human steering can be recorded in the issue receipt, so expensive turns and repeated corrections become visible review data.
 - **Executable constitution** - `CONSTITUTION.md` is readable policy, but every directive has executable enforcement beside it.
 - **Agent-readable failures** - violations name the rule, the specific gap, and the rationale, so the next agent turn has useful context.
@@ -333,47 +333,26 @@ Directives that need more carry optional siblings — `lib/` (shared bash/Python
 
 ## The audit chain
 
-If you are trusting agents to ship code, you need to see what they were asked to do, what they actually changed, what it cost, and how much human correction it took. Four git-native artifacts compose into a chain, and breaking any link fails the next push:
+A receipt is only worth reading if it can't quietly drift from what happened — so it sits in a chain. The issue defines the work, the receipt records it, and every non-merge commit must touch that receipt; break a link and the next push fails. The cost and steering rows aren't hand-typed either: a commit-time check reconciles them against the runtime transcript.
 
 ```mermaid
 flowchart LR
-    subgraph Work["Work order"]
-        I["Issue #N<br/>context + acceptance criteria"]
-        R["receipts/issue-N.md<br/>claims + verification + audit"]
-    end
+    I["Issue #N<br/>the work order"] --> R["receipt<br/>issue-N.md"] --> C["commit<br/>touches the receipt"] --> P(["push / CI gate"])
+    T["runtime transcript"] -. "cost + steering,<br/>reconciled at commit" .-> R
 
-    subgraph History["Git history"]
-        C["commit<br/>touches the issue's receipt"]
-    end
-
-    subgraph Accounting["## Accounting (in the receipt)"]
-        CO["cost row<br/>tokens + USD + cumulative"]
-        ST["steering row<br/>human corrections"]
-    end
-
-    T["runtime transcript<br/>session cumulative + events"]
-
-    I -- "defines" --> R
-    R -- "must be touched by" --> C
-    T -- "written into" --> CO
-    T -- "written into" --> ST
-    CO -- "commit-time check reconciles vs" --> T
-    CO -- "lives in" --> R
-    ST -- "lives in" --> R
-
-    classDef work fill:#3f3586,stroke:#8b7ff0,color:#eeeaff
-    classDef history fill:#075b4a,stroke:#36d6af,color:#dcfff4
-    classDef accounting fill:#0e4e85,stroke:#5aa8e9,color:#e9f5ff
-    classDef source fill:#5a3a1e,stroke:#d99a4e,color:#fff3e0
-    class I,R work
-    class C history
-    class CO,ST accounting
-    class T source
+    classDef chain fill:#0e4e85,stroke:#5aa8e9,color:#e9f5ff
+    classDef hub fill:#075b4a,stroke:#36d6af,color:#dcfff4
+    classDef src fill:#3f403a,stroke:#a5a49b,color:#efeee8
+    class I,C,P chain
+    class R hub
+    class T src
 ```
+
+Four records, all in git, each enforced by a directive:
 
 - **Directive provenance** — every `CONSTITUTION.md` line is git-blameable to the commit and check that introduced it; the Evolution Log summarizes every amendment
 - **Receipts** — one per issue; every checked box must crosswalk into `## What changed` or `## Verification`, so boxes can't flip silently. The reviewer reads the receipt, not the diff
-- **Token cost** — every agent commit's token cost lands as a row in the issue's receipt, reconciled at commit time against the runtime transcript; every change has a price tag
+- **Token cost** — every agent commit's token cost lands as a row in the issue's receipt, so every change carries a price tag
 - **Steering** — every commit tallies the human interrupts and redirects it needed; see at a glance which commits ran on autopilot
 
 Ships in the `governance-kit/audit` pack, `standard` preset.
@@ -389,61 +368,14 @@ governance reset {--directive <id>|--pack <id>|--all}  # restore drifted directi
 governance uninstall [--dry-run|--soft|--hard]         # tear-down
 ```
 
-The mental model — an installer, a product, its content. Like a language toolchain manager:
+<div align="center">
 
-```mermaid
-flowchart TB
-    T["the model — an installer, a product, its content. like a language toolchain manager."]
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/lifecycle-dark.svg">
+  <img src="docs/assets/lifecycle-light.svg" alt="Governance lifecycle as a language-toolchain model: the governance skill is the installer (like rustup), the kit is the product (like the toolchain), packs are the content (like the lockfile), and the repo pins every version via install.yaml and packs.lock" width="840">
+</picture>
 
-    subgraph R1[" "]
-        direction LR
-        S["governance skill — the installer<br/>install · update · uninstall"]
-        RU["≈ rustup<br/>the version manager"]
-    end
-
-    subgraph R2[" "]
-        direction LR
-        K["the kit — kit/vX.Y.Z — the product<br/>engine · flows · assets · all verbs"]
-        TC["≈ the toolchain<br/>compiler · libs · tools"]
-    end
-
-    subgraph R3[" "]
-        direction LR
-        P["packs — pack/vX.Y.Z — the content<br/>directive content, lock-pinned"]
-        LF["≈ the lockfile<br/>pinned dependencies"]
-    end
-
-    PIN["the repo decides its versions<br/>install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin"]
-    LEGEND["purple = installer · teal = product · coral = content · gray = familiar analogy"]
-
-    T ~~~ S
-    S -.- RU
-    S -->|"installs · updates"| K
-    K -.- TC
-    K -->|"consumes"| P
-    P -.- LF
-    P ~~~ PIN
-    LF ~~~ PIN
-    PIN ~~~ LEGEND
-
-    style R1 fill:transparent,stroke:transparent
-    style R2 fill:transparent,stroke:transparent
-    style R3 fill:transparent,stroke:transparent
-    classDef title fill:transparent,stroke:transparent,color:#d8d5cb,font-weight:bold
-    classDef installer fill:#3f3586,stroke:#8b7ff0,color:#eeeaff
-    classDef product fill:#075b4a,stroke:#36d6af,color:#dcfff4
-    classDef content fill:#7b2b17,stroke:#ef9673,color:#fff0e8
-    classDef analogy fill:#3f403a,stroke:#a5a49b,color:#efeee8
-    classDef pin fill:#0e4e85,stroke:#5aa8e9,color:#e9f5ff
-    classDef legend fill:transparent,stroke:transparent,color:#d8d5cb
-    class T title
-    class S installer
-    class K product
-    class P content
-    class RU,TC,LF analogy
-    class PIN pin
-    class LEGEND legend
-```
+</div>
 
 The two version axes are independent (the Helm `Chart.version` vs `appVersion` model — [VERSIONING.md](kit/references/VERSIONING.md)): the **kit** is the framework (runtime, hook generators, engines, schemas; tagged `kit/vX.Y.Z`), **packs** are the directive content (each on its own `pack.yaml` version). `.governance/packs.lock` pins what runs; the check code is vendored into `.governance/packs/` and committed, so a pack bump shows the real `check.sh` diff, not just a SHA.
 

--- a/docs/assets/lifecycle-dark.svg
+++ b/docs/assets/lifecycle-dark.svg
@@ -1,0 +1,60 @@
+<svg viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" role="img" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif">
+  <title>Governance lifecycle as a language-toolchain model</title>
+  <desc>Three stacked tiers — installer (skill), product (kit), content (packs) — each paired with a toolchain analogy (rustup, toolchain, lockfile), with a repo-pins-versions bar at the bottom.</desc>
+
+  <defs>
+    <marker id="arw" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L9,5 L0,10 z" fill="#97948c"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text x="480" y="32" text-anchor="middle" font-size="14.5" fill="#a8a59d">the model — an installer, a product, its content. like a language toolchain manager.</text>
+
+  <!-- Row 1: installer / rustup -->
+  <rect x="60" y="64" width="380" height="88" rx="8" fill="#3f3586" stroke="#8b7ff0" stroke-width="1.5"/>
+  <text x="80" y="100" font-size="15.5" font-weight="700" fill="#eeeaff">governance skill — the installer</text>
+  <text x="80" y="124" font-size="12.5" fill="#eeeaff" opacity="0.75">install · update · uninstall</text>
+
+  <rect x="520" y="64" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="100" font-size="15.5" font-weight="700" fill="#efeee8">≈ rustup</text>
+  <text x="540" y="124" font-size="12.5" fill="#efeee8" opacity="0.75">the version manager</text>
+
+  <line x1="440" y1="108" x2="520" y2="108" stroke="#6e6e69" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <line x1="250" y1="152" x2="250" y2="186" stroke="#97948c" stroke-width="1.6" marker-end="url(#arw)"/>
+  <text x="262" y="174" font-size="12.5" fill="#a8a59d">installs · updates</text>
+
+  <!-- Row 2: product / toolchain -->
+  <rect x="60" y="190" width="380" height="88" rx="8" fill="#075b4a" stroke="#36d6af" stroke-width="1.5"/>
+  <text x="80" y="226" font-size="15.5" font-weight="700" fill="#dcfff4">the kit — kit/vX.Y.Z — the product</text>
+  <text x="80" y="250" font-size="12.5" fill="#dcfff4" opacity="0.78">engine · flows · assets · all verbs</text>
+
+  <rect x="520" y="190" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="226" font-size="15.5" font-weight="700" fill="#efeee8">≈ the toolchain</text>
+  <text x="540" y="250" font-size="12.5" fill="#efeee8" opacity="0.75">compiler · libs · tools</text>
+
+  <line x1="440" y1="234" x2="520" y2="234" stroke="#6e6e69" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <line x1="250" y1="278" x2="250" y2="312" stroke="#97948c" stroke-width="1.6" marker-end="url(#arw)"/>
+  <text x="262" y="300" font-size="12.5" fill="#a8a59d">consumes</text>
+
+  <!-- Row 3: content / lockfile -->
+  <rect x="60" y="316" width="380" height="88" rx="8" fill="#7b2b17" stroke="#ef9673" stroke-width="1.5"/>
+  <text x="80" y="352" font-size="15.5" font-weight="700" fill="#fff0e8">packs — pack/vX.Y.Z — the content</text>
+  <text x="80" y="376" font-size="12.5" fill="#fff0e8" opacity="0.78">directive content, lock-pinned</text>
+
+  <rect x="520" y="316" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="352" font-size="15.5" font-weight="700" fill="#efeee8">≈ the lockfile</text>
+  <text x="540" y="376" font-size="12.5" fill="#efeee8" opacity="0.75">pinned dependencies</text>
+
+  <line x1="440" y1="360" x2="520" y2="360" stroke="#6e6e69" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <!-- bottom: repo pins -->
+  <rect x="60" y="446" width="840" height="80" rx="8" fill="#0e4e85" stroke="#5aa8e9" stroke-width="1.5"/>
+  <text x="80" y="480" font-size="15.5" font-weight="700" fill="#e9f5ff">the repo decides its versions</text>
+  <text x="80" y="504" font-size="12.5" fill="#e9f5ff" opacity="0.8">install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin</text>
+
+  <!-- legend -->
+  <text x="480" y="562" text-anchor="middle" font-size="12.5" fill="#a8a59d">purple = installer · teal = product · coral = content · gray = familiar analogy</text>
+</svg>

--- a/docs/assets/lifecycle-light.svg
+++ b/docs/assets/lifecycle-light.svg
@@ -1,0 +1,60 @@
+<svg viewBox="0 0 960 600" xmlns="http://www.w3.org/2000/svg" role="img" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif">
+  <title>Governance lifecycle as a language-toolchain model</title>
+  <desc>Three stacked tiers — installer (skill), product (kit), content (packs) — each paired with a toolchain analogy (rustup, toolchain, lockfile), with a repo-pins-versions bar at the bottom.</desc>
+
+  <defs>
+    <marker id="arw" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L9,5 L0,10 z" fill="#8f8c84"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text x="480" y="32" text-anchor="middle" font-size="14.5" fill="#6b6862">the model — an installer, a product, its content. like a language toolchain manager.</text>
+
+  <!-- Row 1: installer / rustup -->
+  <rect x="60" y="64" width="380" height="88" rx="8" fill="#3f3586" stroke="#8b7ff0" stroke-width="1.5"/>
+  <text x="80" y="100" font-size="15.5" font-weight="700" fill="#eeeaff">governance skill — the installer</text>
+  <text x="80" y="124" font-size="12.5" fill="#eeeaff" opacity="0.75">install · update · uninstall</text>
+
+  <rect x="520" y="64" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="100" font-size="15.5" font-weight="700" fill="#efeee8">≈ rustup</text>
+  <text x="540" y="124" font-size="12.5" fill="#efeee8" opacity="0.75">the version manager</text>
+
+  <line x1="440" y1="108" x2="520" y2="108" stroke="#bdbbb5" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <line x1="250" y1="152" x2="250" y2="186" stroke="#8f8c84" stroke-width="1.6" marker-end="url(#arw)"/>
+  <text x="262" y="174" font-size="12.5" fill="#6b6862">installs · updates</text>
+
+  <!-- Row 2: product / toolchain -->
+  <rect x="60" y="190" width="380" height="88" rx="8" fill="#075b4a" stroke="#36d6af" stroke-width="1.5"/>
+  <text x="80" y="226" font-size="15.5" font-weight="700" fill="#dcfff4">the kit — kit/vX.Y.Z — the product</text>
+  <text x="80" y="250" font-size="12.5" fill="#dcfff4" opacity="0.78">engine · flows · assets · all verbs</text>
+
+  <rect x="520" y="190" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="226" font-size="15.5" font-weight="700" fill="#efeee8">≈ the toolchain</text>
+  <text x="540" y="250" font-size="12.5" fill="#efeee8" opacity="0.75">compiler · libs · tools</text>
+
+  <line x1="440" y1="234" x2="520" y2="234" stroke="#bdbbb5" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <line x1="250" y1="278" x2="250" y2="312" stroke="#8f8c84" stroke-width="1.6" marker-end="url(#arw)"/>
+  <text x="262" y="300" font-size="12.5" fill="#6b6862">consumes</text>
+
+  <!-- Row 3: content / lockfile -->
+  <rect x="60" y="316" width="380" height="88" rx="8" fill="#7b2b17" stroke="#ef9673" stroke-width="1.5"/>
+  <text x="80" y="352" font-size="15.5" font-weight="700" fill="#fff0e8">packs — pack/vX.Y.Z — the content</text>
+  <text x="80" y="376" font-size="12.5" fill="#fff0e8" opacity="0.78">directive content, lock-pinned</text>
+
+  <rect x="520" y="316" width="380" height="88" rx="8" fill="#3f403a" stroke="#a5a49b" stroke-width="1.5"/>
+  <text x="540" y="352" font-size="15.5" font-weight="700" fill="#efeee8">≈ the lockfile</text>
+  <text x="540" y="376" font-size="12.5" fill="#efeee8" opacity="0.75">pinned dependencies</text>
+
+  <line x1="440" y1="360" x2="520" y2="360" stroke="#bdbbb5" stroke-width="1.4" stroke-dasharray="4 4"/>
+
+  <!-- bottom: repo pins -->
+  <rect x="60" y="446" width="840" height="80" rx="8" fill="#0e4e85" stroke="#5aa8e9" stroke-width="1.5"/>
+  <text x="80" y="480" font-size="15.5" font-weight="700" fill="#e9f5ff">the repo decides its versions</text>
+  <text x="80" y="504" font-size="12.5" fill="#e9f5ff" opacity="0.8">install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin</text>
+
+  <!-- legend -->
+  <text x="480" y="562" text-anchor="middle" font-size="12.5" fill="#6b6862">purple = installer · teal = product · coral = content · gray = familiar analogy</text>
+</svg>

--- a/receipts/issue-303-tighten-readme-messaging-and-lifecycle-svg.md
+++ b/receipts/issue-303-tighten-readme-messaging-and-lifecycle-svg.md
@@ -1,0 +1,71 @@
+# Issue 303: Tighten README messaging and replace lifecycle diagram with SVG
+
+Closes [#303](https://github.com/Duaility/governance-kit/issues/303).
+
+## Checklist
+
+- [x] Reframe the opening around the real failure mode.
+- [x] Introduce receipts as the accountability pillar in the core idea.
+- [x] Lead the tagline on coherence and trim the slice and redundant value-prop bullets.
+- [x] Reword the audit-chain section and simplify its diagram.
+- [x] Replace the Lifecycle mermaid with theme-aware committed SVG variants.
+- [x] Verify the governance suite passes.
+
+## What changed
+
+**Reframe the opening around the real failure mode.** `README.md`'s core idea no longer opens with a four-anecdote story. It now states the failure crisply — the agent completes the task "in a way that's locally fine and globally wrong" — then names three distinct failure modes (architecture drift; half-following the constraints written into `AGENTS.md`/`CLAUDE.md`, missing the ones that matter or optimizing for the wrong ones; the next agent losing the correction across sessions) and the backfiring reflex of piling more rules into a bloated instruction file ("More instructions buy less control").
+
+**Introduce receipts as the accountability pillar in the core idea.** `README.md` now pairs invariants ("keep the work coherent") with receipts ("keep it accountable") in the core idea, explaining that what an agent changed, cost, and was corrected on would otherwise disappear when the session ends — so the kit pins it to the issue as a receipt in git. This earns the downstream audit-chain section.
+
+**Lead the tagline on coherence and trim the slice and redundant value-prop bullets.** The header tagline in `README.md` now leads with "keep every agent coherent with your repo." The two "define the slice"/"keep the diff inside that slice" bullets (capabilities the kit does not enforce) were removed, the example list was reordered coherence-first, and the two "What developers get" bullets that merely restated the core idea ("Less repeated steering", "Shared behavior across agents") were cut.
+
+**Reword the audit-chain section and simplify its diagram.** The `## The audit chain` intro in `README.md` was rewritten to build on the new receipts framing (the receipt is trustworthy because it sits in an enforced chain and its cost/steering rows reconcile against the transcript) instead of re-explaining what a receipt is. Its mermaid diagram was reduced from three subgraphs and seven labeled cross-edges to a linear `Issue → receipt → commit → push` spine with a single dashed transcript feeder; the duplicate reconciliation clause was dropped from the Token-cost bullet.
+
+**Replace the Lifecycle mermaid with theme-aware committed SVG variants.** The Lifecycle mermaid block (and its now-redundant lead-in sentence) in `README.md` was replaced with a centered `<picture>` referencing two new assets, `docs/assets/lifecycle-light.svg` and `docs/assets/lifecycle-dark.svg`, that switch on `prefers-color-scheme` exactly like the banner. The variants share an identical layout and tier colors and differ only in their neutral grays.
+
+**Verify the governance suite passes.** `bash .governance/run.sh` was run after the edits.
+
+## Out of scope
+
+- Any change to the kit engine, packs, or directive behavior.
+- The consumed `.governance/` tree, release metadata, or version markers.
+- New README sections beyond the messaging and diagram changes above.
+
+## Decisions
+
+- The lifecycle diagram was rendered as a committed SVG (with light/dark variants via `<picture>`) rather than refined mermaid, because mermaid's auto-layout cannot guarantee the clean two-column block alignment across renderers; the trade is that label changes now require regenerating the SVG. The other (flow) mermaid diagrams were left in place where exact layout does not matter.
+
+## Verification
+
+```sh
+bash .governance/run.sh
+```
+
+Result: all directives passed.
+
+## Audit
+
+PASS - The only product-facing file changed is `README.md`; the change also adds two SVG assets under `docs/assets/` and this receipt under `receipts/`. The receipt's checklist mirrors the issue, every checked item crosswalks into a bold heading under `## What changed`, and every changed path (`README.md`, `docs/assets/lifecycle-light.svg`, `docs/assets/lifecycle-dark.svg`) is named. The claims describe copy edits and a mermaid-to-SVG swap that match the diff.
+
+## Layer boundaries
+
+PASS - The diff touches only the documentation/audit layer: `README.md` copy, two presentational SVG assets under `docs/assets/`, and this receipt under `receipts/`. No kit engine logic, pack directive code, runtime files, or consumed `.governance/` tree were added, moved, or modified. No shared logic was introduced or duplicated and no cross-layer dependency was created.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-e50a46d6-f96-1781674354-1 | claude-code | e50a46d6-f96c-4520-a835-f8b11c02a3c2 | #303 | claude-opus-4-8 | 71846 | 1714654 | 23179821 | 440535 | 2227035 | 33.6791 | 71846 | 1714654 | 23179821 | 440535 | docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303) -m |
+
+### Steering
+
+| steer-key | session | issue | type | tier | user-reason | commit | ordinal | timestamp |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| steer-e50a46d6f96-1781674353-1 | e50a46d6-f96c-4520-a835-f8b11c02a3c2 | #303 | correction | classifier | Wanted opening point sharper and reframed more generically across whole README | docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303) -… | 1 | 2026-06-16T18:17:04.238Z |
+| steer-e50a46d6f96-1781674353-2 | e50a46d6-f96c-4520-a835-f8b11c02a3c2 | #303 | correction | classifier | Asked to undo the harness-engineering blockquote change | docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303) -… | 2 | 2026-06-17T04:52:02.302Z |
+| steer-e50a46d6f96-1781674353-3 | e50a46d6-f96c-4520-a835-f8b11c02a3c2 | #303 | correction | classifier | Rejected lifecycle diagram; wanted a simple block diagram instead | docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303) -… | 3 | 2026-06-17T05:11:24.438Z |
+| steer-e50a46d6f96-1781674353-4 | e50a46d6-f96c-4520-a835-f8b11c02a3c2 | #303 | correction | classifier | Said the audit-chain diagram was too complex; wanted it simplified | docs(readme): tighten messaging and replace lifecycle diagram with SVG (#303) -… | 4 | 2026-06-17T05:21:31.888Z |


### PR DESCRIPTION
Closes #303.

## What changed

A messaging + presentation pass over `README.md`, plus two new committed SVG assets.

- **Opening reframed around the real failure mode.** The four-anecdote story is gone. The core idea now states it plainly — the agent completes the task "in a way that's locally fine and globally wrong" — and names three distinct failures: architecture drift, half-following the constraints written into `AGENTS.md`/`CLAUDE.md` (missing the ones that matter or optimizing for the wrong ones), and losing corrections across sessions. The backfiring reflex — piling more rules into a bloated instruction file — closes with "More instructions buy less control."
- **Receipts introduced as the accountability pillar** in the core idea ("invariants keep the work coherent; receipts keep it accountable"), so the dedicated audit-chain section is earned rather than appearing cold.
- **Tagline leads on coherence**; removed the two "define the slice"/"keep the diff inside that slice" bullets (capabilities the kit does not enforce); cut the two "What developers get" bullets that just restated the core idea.
- **Audit-chain section reworded** to build on the receipts framing, and its diagram simplified from three subgraphs + seven labeled cross-edges to a linear `Issue → receipt → commit → push` spine.
- **Lifecycle mermaid replaced** with `docs/assets/lifecycle-{light,dark}.svg` via `<picture>` (the banner mechanism). The old mermaid rendered messy (nested LR subgraphs in a TB graph + title/legend nodes wired with invisible links); the committed SVG renders cleanly on every renderer.

## Why

The README described some behaviors the product doesn't have (slice-definition / scope-approval), argued the same value prop in four places, never introduced receipts in the idea section, and shipped a lifecycle diagram that mermaid couldn't lay out cleanly.

## Reviewer notes

- Docs-only: `README.md` copy + two presentational SVGs + the issue receipt. No kit engine, pack, runtime, or `.governance/` changes.
- A fresh-context sub-agent independently verified the receipt's `## Audit` and `## Layer boundaries` attestations against the staged diff (both PASS).
- `bash .governance/run.sh` → all 17 directives pass.
- **Trade-off:** the lifecycle labels are now pixels — a future version-model change means regenerating the two SVGs rather than editing mermaid text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)