### PR TITLE
[codex] Sharpen README core idea and GPT-5.5 rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@
 
 ## The core idea
 
-If you use coding agents heavily, you know the real failure mode. The agent doesn't fail the task — it completes it, in a way that's locally fine and globally wrong.
+If you use coding agents heavily, you know the real failure mode: the agent completes the task, but in a way that's locally fine and globally wrong.
 
-It lands the feature but routes the logic through the wrong layer, reinvents a pattern you already have, or widens a boundary you wanted held. The objective passes; the architecture drifts. It half-follows the constraints you wrote into `AGENTS.md` or `CLAUDE.md`, missing the ones that matter or optimizing for the wrong ones. And the next agent on the branch has no memory of the correction you gave the last, so you give it again.
+It lands the feature through the wrong layer, reinvents a pattern you already have, or widens a boundary you wanted held. The objective passes; the architecture drifts. It half-follows `AGENTS.md` or `CLAUDE.md`, missing the constraint that mattered. The next agent has no memory of the correction, so you give it again.
 
-The obvious fix is to write the rule into the instruction file so it sticks. But that file only grows, and a wall of instructions crowds out the task, the code, and the docs the agent needs in context. More instructions buy less control.
+The obvious fix is to add another instruction. But instruction files only grow, crowding out the task, the code, and the docs the agent needs in context. More prompt does not reliably buy more control.
 
-Governance kit turns those repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit.
+Governance kit turns repeated corrections into **repo-native invariants**. The rules stop living in your head, your prompt, or one agent's context window. They live in git, next to the code, with executable checks that run on every commit.
 
-Invariants keep the work coherent; **receipts** keep it accountable. When an agent finishes, what it changed, what it cost, and how often you had to correct it normally disappears when the session ends — so governance kit pins that record to the issue as a receipt in git, where the next reviewer, human or agent, can actually use it.
+Invariants keep the work coherent; **receipts** keep it accountable. When an agent finishes, what it changed, what it cost, and how often you had to correct it usually disappears with the session. Governance kit pins that record to the issue as a receipt in git, where the next reviewer, human or agent, can use it.
 
 Examples of what the repo carries once agents do real work:
 
@@ -61,7 +61,7 @@ flowchart LR
     P["Pack captures it<br/>directive + rationale + evals"]
     G{"Git hook / CI"}
     A["Agent repairs the repo<br/>using the failure as instruction"]
-    R["Repo carries the durable record<br/>constitution + receipt + trailers"]
+    R["Repo carries the durable record<br/>constitution + receipts + accounting"]
 
     H --> P --> G
     G -- "fails with why" --> A
@@ -93,7 +93,7 @@ The key power is the depth of invariants you can express. Start with determinist
 |---|---|---|
 | **Repo state** | "Every repo needs a README, license, security contact, and architecture note." "Do not commit build output or merge markers." | Cheap `check.sh` over the tree, run locally and in CI. |
 | **Change set** | "A CI config change needs a reason in the commit." "A receipt for issue #42 must mention the files this PR actually changed." | Diff-aware hooks plus CI's merge-base walk. |
-| **Ledger** | "For each agent-authored commit, show the issue, receipt, token cost, and human steering count." | Git trailers and receipt accounting rows, cross-checked by directives. |
+| **Ledger** | "For each agent-authored change, show the issue, receipt, token cost, and human steering count." | Receipt accounting rows, cross-checked by directives. |
 | **Sub-agent attestation** | "Before merging a cross-layer refactor, have a fresh reader compare the diff to the architecture map." "Before accepting a receipt, have a fresh reader verify it matches the issue and diff." | Hook fails with a fresh-context sub-agent prompt; agent records a PASS/REFUTED section; hook verifies presence. |
 
 That range matters: the failures that hurt are rarely mechanical ("forgot the formatter") — they're semantic, and no single enforcement style catches both. Governance kit matches each rule to a surface — cheap deterministic checks for the mechanical, fresh-context attestation for the judgment calls.
@@ -289,7 +289,7 @@ Full catalog: [DIRECTIVES_CATALOG.md](kit/references/DIRECTIVES_CATALOG.md).
 | `audit` | `issues-tracked` | `QUALITY.md` exists at repo root with `## Open` and `## Resolved` sections. | standard |
 | `audit` | `receipt-per-issue` | Every `receipts/*.md` has a unique `issue-<N>` filename token, required narrative/audit sections, and checked items that crosswalk into the receipt's evidence. | standard |
 | `audit` | `commit-issue-receipt-match` | Every non-merge commit adds or updates a `receipts/issue-<N>.md` — the touched receipt path is the commit's issue anchor (file-first). | standard |
-| `audit` | `agent-token-accounting` | Every agent commit's token cost lands as a row in the issue's receipt; a commit-time check reconciles the receipt's recorded cumulative against the transcript (no commit trailers). | standard |
+| `audit` | `agent-token-accounting` | Every agent commit's token cost lands as a row in the issue's receipt; a commit-time check reconciles the receipt's recorded cumulative against the runtime endpoint. | standard |
 | `audit` | `agent-steering-accounting` | Detected human-steering events (interrupts, corrections) are recorded in the issue's receipt; `check.sh` validates the ledger shape. **`always_install: true`** — records human correction text verbatim; redact via the directive's classifier hook rather than skipping it. | standard |
 | `audit` | `doc-integrity` | **`always_install: true`** — system-of-record documents are tamper-proof: receipts freeze once on the trunk, frozen sections (`QUALITY.md` Resolved, the Evolution Log) keep their baseline lines verbatim. Branch-authored content stays editable until it merges. | standard |
 | `audit` | `toolchain-config-protection` | A commit changing lint / format / type-check / CI / hook config carries a `governance: allow-toolchain-config <reason>` body line. | standard |

--- a/packs/audit/directives/agent-token-accounting/defaults.conf
+++ b/packs/audit/directives/agent-token-accounting/defaults.conf
@@ -58,9 +58,10 @@ rate claude-sonnet-4-0 3.00 3.75 0.30 15.00
 rate claude-sonnet-3-7 3.00 3.75 0.30 15.00
 
 # ── OpenAI GPT-5 family ────────────────────────────────────────────────
-# `gpt-5` is the family fallback for `gpt-5.5`, `gpt-5.6`, etc. Specific
-# variants override — `gpt-5.4-mini`/`-nano` win by length.
+# `gpt-5` is the family fallback for future `gpt-5.x` releases. Specific
+# variants override — `gpt-5.4-mini`/`-nano` and `gpt-5.5` win by length.
 rate gpt-5         2.50 2.50 0.25  15.00
 rate gpt-5.4       2.50 2.50 0.25  15.00
 rate gpt-5.4-mini  0.75 0.75 0.075  4.50
 rate gpt-5.4-nano  0.20 0.20 0.02   1.25
+rate gpt-5.5       5.00 5.00 0.50  30.00

--- a/receipts/issue-307-readme-rates.md
+++ b/receipts/issue-307-readme-rates.md
@@ -1,0 +1,57 @@
+# Receipt: README core idea and GPT-5.5 rates
+
+## Checklist
+
+- [x] README core idea is crisper while preserving the product story.
+- [x] Current README no longer says the durable record or ledger path uses commit trailers.
+- [x] agent-token-accounting defaults include `rate gpt-5.5 5.00 5.00 0.50 30.00`.
+- [x] Governance checks pass.
+
+## What changed
+
+- `README.md` tightens the opening core idea prose while preserving the same story: agents can complete local tasks while violating repo-level intent, prompt bloat is not durable control, and governance kit moves repeated corrections into executable repo invariants plus issue receipts.
+- `README.md` removes the current commit-trailer wording from the durable-record diagram and the invariant ladder, replacing it with receipts/accounting language.
+- `packs/audit/directives/agent-token-accounting/defaults.conf` adds the explicit `rate gpt-5.5 5.00 5.00 0.50 30.00` row and adjusts the GPT-5 family comment so GPT-5.5 is no longer described as only a fallback case.
+- `receipts/issue-307-readme-rates.md` records this issue's checklist, scope, verification, and attestations.
+- README core idea is crisper while preserving the product story.
+- Current README no longer says the durable record or ledger path uses commit trailers.
+- agent-token-accounting defaults include `rate gpt-5.5 5.00 5.00 0.50 30.00`.
+
+## Decisions
+
+- Kept historical mentions of trailers outside the live README out of scope because they document old behavior in frozen receipts, cost ledgers, or directive rationale.
+- Added the GPT-5.5 row in the source pack under `packs/audit/` only, matching the repo rule that source pack changes do not hand-edit the consumed `.governance/` tree.
+
+## Out of scope
+
+- No change to historical `COSTS.md`, `STEERING.md`, or old receipts that mention retired trailer behavior.
+- No release/version bump or consumed-tree update.
+
+## Verification
+
+```sh
+rg -n "trailers|Git trailers|receipt \\+ trailers" README.md
+python3 packs/audit/directives/agent-token-accounting/lib/rates.py cost gpt-5.5 1000000 1000000 1000000 1000000
+bash .governance/run.sh
+```
+
+Governance checks pass.
+
+## Audit
+
+PASS - The receipt maps to the intended diff: `README.md` carries the crisper core idea and no longer uses trailer language for the live durable record or ledger row; `packs/audit/directives/agent-token-accounting/defaults.conf` adds the requested GPT-5.5 rate row; and this receipt names every changed file. The checklist mirrors issue #307's acceptance criteria and each checked item is evidenced in `## What changed` or `## Verification`.
+
+## Layer boundaries
+
+PASS - The changed files stay in their owning layers: public README copy remains at the repo root, pack-owned rate-card data changes in the audit pack source under `packs/audit/`, and the receipt lives under `receipts/`. No kit engine logic lands in a pack and no consumed `.governance/` materialization is hand-edited.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| codex-019ed445-462-1781678243-1 | codex | 019ed445-4625-7af2-bb97-4059ffe54704 | #307 | gpt-5.5 | 157214 | 0 | 1757568 | 7816 | 165030 | 0.9497 | 157214 | 0 | 1757568 | 7816 | docs(readme): sharpen core idea and rates (#307) |
+| codex-019ed445-462-1781678392-1 | codex | 019ed445-4625-7af2-bb97-4059ffe54704 | #307 | gpt-5.5 | 40821 | 0 | 636032 | 1360 | 42181 | 0.2815 | 198035 | 0 | 2393600 | 9176 | docs(readme): sharpen core idea and rates (#307) -m governance: allow-agent-toke |


### PR DESCRIPTION
## Summary

- tighten the README core idea section while preserving the governance-kit story
- remove live README references to commit trailers and describe receipts/accounting instead
- add explicit GPT-5.5 pricing: `rate gpt-5.5 5.00 5.00 0.50 30.00`
- add receipt `receipts/issue-307-readme-rates.md`

Closes #307.

## Validation

- `rg -n "trailers|Git trailers|receipt \+ trailers" README.md || true`
- `python3 packs/audit/directives/agent-token-accounting/lib/rates.py cost gpt-5.5 1000000 1000000 1000000 1000000` → `40.5000`
- `bash .governance/run.sh`
- `bash packs/audit/directives/agent-token-accounting/evals/test.sh`
- commit hook ran full `scripts/test.sh` / pack eval gate successfully

## Notes

The commit includes a scoped `governance: allow-agent-token-accounting` body line because the long pre-commit test gate advanced the live Codex transcript after the hook had already staged the receipt accounting row.