### PR TITLE
perf(attestation): request a low-cost model for sub-agent attestation audits (#321)

### DIFF
--- a/kit/assets/dot-governance/lib.sh
+++ b/kit/assets/dot-governance/lib.sh
@@ -164,6 +164,9 @@ extract_md_section() {
 #   attestation-backed directive emits the same recognizable instruction; the
 #   directive supplies only what varies — the section name, the <inputs> the
 #   sub-agent must be handed, and the numbered checks it must adjudicate.
+#   The envelope asks for a small, low-cost model (low capability tier): this is
+#   a bounded read-and-record audit whose verdict the merge-time sweep lane
+#   re-derives, so the expensive model belongs there, not here (cost, issue #321).
 attestation_prompt() {
     local section="$1" inputs="$2"
     shift 2
@@ -174,7 +177,7 @@ attestation_prompt() {
         i=$((i + 1))
     done
     numbered="${numbered%; }"
-    printf 'Spawn a fresh-context sub-agent with exactly these inputs — %s — and have it report PASS/REFUTED + evidence for each: %s. Default to REFUTED if uncertain. Write the findings into a '\''## %s'\'' section, then re-stage and re-commit. The hook never spawns the sub-agent itself.' \
+    printf 'Spawn a fresh-context sub-agent — on a small, low-cost model (the low capability tier, e.g. Claude Haiku or a comparable GPT-mini-class model; this is a bounded read-and-record audit, and its verdict is independently re-derived by the merge-time sweep lane) — with exactly these inputs — %s — and have it report a verdict + evidence for each, rendering each verdict as exactly the token PASS or REFUTED: %s. Default to REFUTED if uncertain. Write the findings into a '\''## %s'\'' section, then re-stage and re-commit. The hook never spawns the sub-agent itself.' \
         "$inputs" "$numbered" "$section"
 }
 

--- a/kit/references/SUBAGENT_ATTESTATION.md
+++ b/kit/references/SUBAGENT_ATTESTATION.md
@@ -67,7 +67,8 @@ Any directive's `check.sh` can source `lib.sh` and call:
   generic markdown-section reader.
 - **`attestation_prompt <section> <inputs> <check-1> [<check-2> ...]`** — print
   the canonical sub-agent authoring instruction: spawn a fresh-context
-  sub-agent with `<inputs>`, report PASS/REFUTED + evidence for each numbered
+  sub-agent **on a small, low-cost model** (see [Model tier](#model-tier-use-a-small-model) below),
+  with `<inputs>`, report PASS/REFUTED + evidence for each numbered
   check, default to REFUTED if uncertain, write into `## <section>`, and the
   hook never spawns anything. One envelope so every attestation-backed
   directive emits the same recognizable instruction.
@@ -80,6 +81,31 @@ Any directive's `check.sh` can source `lib.sh` and call:
 
 The verdict token the gate looks for is `PASS` or `REFUTED` (case-insensitive),
 so the sub-agent prompt should instruct the auditor to render exactly those.
+
+## Model tier: use a small model
+
+The author-time attestation is a **bounded read-and-record audit**, not the
+final word on truth. The commit-path gate only checks the section is *present
+and verdict-bearing*; the verdict's correctness is independently re-derived by
+the merge-time **sweep lane** (`surface: sweep`), which picks its own
+`model_tier`. So the expensive reasoning belongs there — the author-time pass
+should run on a **small, low-cost model** (the *low* capability tier — e.g.
+Claude Haiku or a comparable GPT-mini-class model). This is a deliberate cost
+optimization (issue #321): the audit fires on every newly added attested
+artifact, and over-provisioning it with a large model buys little when a cheap
+model can read the diff, compare it to the artifact, and record a verdict.
+
+`attestation_prompt` bakes this request into the instruction it emits, so every
+attestation-backed directive inherits the small-model guidance from one surface
+— there is no per-directive knob. Two practical notes:
+
+- The guidance names a **capability tier**, not a pinned model id (mirroring the
+  sweep lane's `model_tier`), so a model upgrade within the tier doesn't silently
+  change behavior.
+- Small models occasionally fumble strict output formatting. The prompt asks the
+  auditor to render the verdict as literally `PASS` or `REFUTED`, and the gate
+  matches that token case-insensitively anywhere in the section — so a verbose or
+  slightly-off-format audit still passes as long as it records the token.
 
 ## Wiring a directive onto it
 

--- a/packs/audit/directives/receipt-per-issue/check.sh
+++ b/packs/audit/directives/receipt-per-issue/check.sh
@@ -54,8 +54,10 @@
 #      (the audit step did not run), and demanding presence is all the hook can
 #      do without an LLM judge on the commit path.
 #
-#      The sub-agent prompt (what the harness agent runs, with the diff, this
-#      receipt, and `gh issue view <N>` as the only inputs):
+#      The sub-agent prompt (what the harness agent runs on a small, low-cost
+#      model — the shared attestation_prompt envelope requests the low capability
+#      tier; see kit/references/SUBAGENT_ATTESTATION.md "Model tier" — with the
+#      diff, this receipt, and `gh issue view <N>` as the only inputs):
 #        You are auditing a receipt against ground truth. For each check report
 #        PASS or REFUTED plus evidence: (1) `## What changed` faithfully
 #        describes the diff — no misrepresentation, no omission; (2) each

--- a/receipts/issue-321-attestation-small-model.md
+++ b/receipts/issue-321-attestation-small-model.md
@@ -1,0 +1,70 @@
+# Receipt — issue #321
+
+Have the sub-agent attestation envelope explicitly request a small, low-cost model. The author-time attestation is a bounded read-and-record audit whose verdict the merge-time sweep lane re-derives, so the expensive model belongs in the sweep lane, not on the commit-path audit. The request rides the shared `attestation_prompt` helper, so every attestation directive (`receipt-per-issue`, `layer-boundaries`, any future adopter) inherits it from one surface — no per-directive knob.
+
+## Checklist
+
+- [x] `attestation_prompt` (`lib.sh`) requests a small, low-cost model (the low capability tier — e.g. Claude Haiku or a GPT-mini-class model) when instructing the harness to spawn the sub-agent.
+- [x] Document the rationale in `SUBAGENT_ATTESTATION.md` and align `receipt-per-issue`'s in-source prompt comment.
+
+## What changed
+
+- **`attestation_prompt` (`lib.sh`) requests a small, low-cost model (the low capability tier — e.g. Claude Haiku or a GPT-mini-class model) when instructing the harness to spawn the sub-agent.** — `kit/assets/dot-governance/lib.sh`'s `attestation_prompt` printf now opens `Spawn a fresh-context sub-agent — on a small, low-cost model (the low capability tier, e.g. Claude Haiku or a comparable GPT-mini-class model; … verdict is independently re-derived by the merge-time sweep lane) — …`, and also asks the auditor to render each verdict as exactly the token `PASS` or `REFUTED`. The asserted substring `Spawn a fresh-context sub-agent` (`scripts/test-runtime.sh`) is preserved. The function's doc comment gains a note that the small-model request is a deliberate cost optimization (issue #321) because the verdict is re-derived by the sweep lane. Because both `receipt-per-issue` and the repo-local `layer-boundaries` emit their instruction through this one helper, they inherit the guidance with no per-directive change.
+- **Document the rationale in `SUBAGENT_ATTESTATION.md` and align `receipt-per-issue`'s in-source prompt comment.** — `kit/references/SUBAGENT_ATTESTATION.md` gains a "Model tier: use a small model" section (the author-time pass is bounded read-and-record; the sweep lane re-derives the truth on its own `model_tier`; capability tier not a pinned model id; small models can fumble strict formatting but the gate matches the verdict token case-insensitively anywhere), and its `attestation_prompt` helper bullet now links that section. `packs/audit/directives/receipt-per-issue/check.sh`'s in-source prompt comment notes the harness runs the audit on a small, low-cost model and points at the new section, so the comment no longer understates what the shared envelope emits.
+
+## Out of scope
+
+- The repo-local `layer-boundaries` directive (`.governance/packs/duaility/governance-kit/`) — it consumes `require_attestation` from the consumed `.governance/lib.sh`, so it inherits the small-model request automatically once the dogfood catches up to this `kit/assets/` source edit at the next release + `governance update`. No edit to the consumed tree (hand-edit-forbidden).
+- A `defaults.conf` knob to configure the model/tier — deliberately not added; the model choice rides the prompt text (the single existing surface), keeping one opt-in surface rather than a new per-directive gate.
+- The sweep lane's `model_tier` — already a capability tier; unchanged. This issue only governs the author-time attestation pass.
+- `CONSTITUTION.md` / `.governance/` consumed tree — not hand-edited; catches up at the next release.
+
+## Verification
+
+The runtime test (which asserts the `attestation_prompt` output), the pack evals (which install the directive against this source `lib.sh` and exercise `receipt-per-issue`'s `## Audit` gate), and the dogfood suite all pass:
+
+```sh
+bash -n kit/assets/dot-governance/lib.sh           # printf edit is valid bash
+bash scripts/test-runtime.sh                        # 78 assertions, incl. the attestation-prompt substring
+bash scripts/test-packs.sh                          # 3 packs, 15 directives, 15 evals
+bash .governance/run.sh                             # 16 directives pass
+```
+
+This receipt's own `## Audit` and `## Layer boundaries` sections were authored by fresh-context sub-agents spawned **on Haiku** — dogfooding the very optimization this issue introduces.
+
+## Decisions
+
+- **One surface (`attestation_prompt`), no config knob.** The model request lives in the shared prompt envelope, so every attestation directive inherits it and there is nothing per-directive to wire. A `defaults.conf` tier knob was considered and rejected — it would add an internal gate to an already-single opt-in surface.
+- **Capability tier, not a model id.** The prompt says "low capability tier — e.g. Claude Haiku or a GPT-mini-class model" rather than pinning one model, mirroring the sweep lane's `model_tier`, and naming both a Claude and an OpenAI example because the envelope is emitted under both the Claude Code and Codex harnesses.
+- **Also asked for a literal `PASS`/`REFUTED` token.** A trial run of the attestations on Haiku for this very PR showed a small model can leave template/placeholder text in its output. The gate already matches the token case-insensitively anywhere in the section, so this never blocks a commit, but instructing the auditor to render the bare token keeps the recorded section clean — a cheap robustness add that directly serves the cost goal (cheap models need crisper format instructions).
+- **`layer-boundaries` not touched directly.** It inherits the change through `require_attestation` once the consumed tree catches up; editing the consumed tree by hand is forbidden.
+
+## Audit
+
+PASS
+
+- PASS — The `## What changed` section accurately describes all four changed files (`lib.sh`, `SUBAGENT_ATTESTATION.md`, `receipt-per-issue/check.sh`, and this receipt). The `attestation_prompt` printf now opens with the preserved substring "Spawn a fresh-context sub-agent" followed by the small-model guidance, asks for the literal `PASS`/`REFUTED` token, and the doc comment gains the cost-optimization note. `SUBAGENT_ATTESTATION.md` adds the "Model tier: use a small model" section with a link from the helper bullet, and `receipt-per-issue/check.sh`'s comment is updated to reference it. All paths and edits match the staged diff.
+- PASS — Both checklist items are realized in the diff: item 1 (attestation_prompt requests a small model) in `lib.sh`'s doc comment and printf; item 2 (document in SUBAGENT_ATTESTATION.md + align the receipt-per-issue comment) in the new doc section and the updated check.sh comment. The substring asserted by `scripts/test-runtime.sh` is preserved and the language is capability-tier, not a pinned model id.
+- PASS — The `## Checklist` mirrors issue #321's proposed change exactly: request a small/low-cost model in `attestation_prompt`, document the rationale in `SUBAGENT_ATTESTATION.md`, align `receipt-per-issue`'s comment, preserve the substring, and use capability-tier language.
+
+This `## Audit` verdict was derived by a fresh-context sub-agent (run on Haiku) handed only the staged diff, this receipt, and `gh issue view 321`; it returned PASS on all three dimensions.
+
+## Layer boundaries
+
+PASS
+
+- PASS — All changed files sit in their declared layers: `kit/assets/dot-governance/lib.sh` and `kit/references/SUBAGENT_ATTESTATION.md` are kit-layer (shared engine + docs); `packs/audit/directives/receipt-per-issue/check.sh` is a pack-layer directive (comment-only edit); the receipt is repo-root tooling outside the stack. ARCHITECTURE.md's `skill → kit → packs` (downward-only) map is honored.
+- PASS — Dependency edges point downward only. The pack's `check.sh` sources the kit-owned `lib.sh` and calls `require_attestation`/`attestation_prompt` (kit-layer functions); no kit code references pack code. The kit→pack edge is the permitted direction; the change adds no upward edge.
+- PASS — The small-model request is wired into the one kit-owned shared helper (`attestation_prompt` in `lib.sh`), not duplicated into the pack. Every attestation-backed directive inherits it via `require_attestation` → `attestation_prompt`; the pack's comment merely references the kit documentation.
+
+This `## Layer boundaries` verdict was derived by a fresh-context sub-agent (run on Haiku) handed only the staged diff and the `## Layer map` section of `ARCHITECTURE.md`; it returned PASS on all three dimensions.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-c594b53d-954-1781706595-1 | claude-code | c594b53d-954e-457f-b804-476378ea9dd1 | #321 | claude-opus-4-8 | 86010 | 341768 | 41440108 | 265858 | 693636 | 29.9326 | 116925 | 754822 | 58191654 | 430125 |  |


### PR DESCRIPTION
Closes #321.

## Why

The sub-agent attestation pattern (#272) spawns a fresh-context sub-agent to audit correspondence-to-reality (`receipt-per-issue`'s `## Audit`, `layer-boundaries`'s `## Layer boundaries`). The author-time pass is a **bounded read-and-record audit** — a forcing function. The commit-path gate only checks the section is *present and verdict-bearing*; the verdict's *truth* is independently re-derived by the merge-time **sweep lane** (which picks its own `model_tier`). So the expensive model belongs in the sweep lane, and the author-time audit should run on a small, low-cost model.

## What changed

- **`kit/assets/dot-governance/lib.sh`** — `attestation_prompt` (the single envelope every attestation directive emits) now asks the harness to spawn the sub-agent **on a small, low-cost model** (the low capability tier — e.g. Claude Haiku or a GPT-mini-class model) and to render the verdict as the literal `PASS`/`REFUTED` token. Because both `receipt-per-issue` and `layer-boundaries` go through this one helper, they inherit the guidance from a single surface — no per-directive knob.
- **`kit/references/SUBAGENT_ATTESTATION.md`** — new "Model tier: use a small model" section explaining the rationale (capability tier not a pinned id; the sweep lane re-derives the truth); the helper bullet links it.
- **`packs/audit/directives/receipt-per-issue/check.sh`** — the in-source prompt comment now reflects that the audit runs on a small model.

The `"Spawn a fresh-context sub-agent"` substring asserted by `scripts/test-runtime.sh` is preserved.

## Verification

```sh
bash scripts/test-runtime.sh    # 78 assertions, incl. the attestation-prompt substring
bash scripts/test-packs.sh      # 3 packs, 15 directives, 15 evals
bash .governance/run.sh         # 16 directives pass
```

This PR's own receipt attestations (`## Audit`, `## Layer boundaries`) were generated **on Haiku** — dogfooding the optimization. Both returned PASS; the small model did leave some preamble around the verdict block (noted in the receipt's Decisions), which is why the prompt also asks for a literal `PASS`/`REFUTED` token — the gate matches it case-insensitively anywhere, so a verbose audit still passes.

> [!NOTE]
> Touches the same attestation subsystem as #320 (still open). The only shared file is `SUBAGENT_ATTESTATION.md`, and the edits are in non-overlapping regions (this PR adds a "Model tier" section + helper-bullet link; #320 corrects the "Versioning note"), so they merge independently in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)