### PR TITLE
docs: refresh the published docs site to match recent releases and the README (#323)

### DIFF
--- a/docs/concepts/audit-chain.mdx
+++ b/docs/concepts/audit-chain.mdx
@@ -12,9 +12,9 @@ If you trust agents to ship code, you need to see what they were told, what they
 ```mermaid
 flowchart LR
     I["<b>Issue #N</b><br/>the work order"]
-    R["<b>Receipt</b><br/>claims crosswalked<br/>to evidence"]
-    C["<b>Commit</b><br/>cost + steering<br/>trailers"]
-    CO["<b>Cost row</b><br/>joined by Cost-Key —<br/>survives the squash"]
+    R["<b>Receipt</b><br/>receipts/issue-N.md<br/>claims + accounting rows"]
+    C["<b>Commit</b><br/>touches the receipt —<br/>the path is the anchor"]
+    CO["<b>Accounting rows</b><br/>cost + steering,<br/>frozen on the trunk"]
 
     I --> R --> C --> CO
 
@@ -28,10 +28,12 @@ Every link is enforced by a directive in the `governance-kit/audit` pack (the `s
 |---|---|---|
 | Issues exist & are structured | `issue-templates`, `issues-tracked` | Issue forms with handoff fields; a `QUALITY.md` board with `## Open` / `## Resolved` |
 | Work attests itself | `receipt-per-issue` | One receipt file per issue with the required sections and a crosswalked checklist |
-| Commits anchor to work | `commit-issue-receipt-match` | Every commit's `(#N)` anchor matches a receipt it touches |
-| Work carries its price | `agent-token-accounting` | Token + cost trailers on every commit, matching a cost row in the issue's receipt |
-| Steering is visible | `agent-steering-accounting` | `Steer-*` trailers tallying steering rows in the issue's receipt |
+| Commits anchor to work | `commit-issue-receipt-match` | Every non-merge commit touches its issue's `receipts/issue-<N>.md` — the receipt path **is** the anchor |
+| Work carries its price | `agent-token-accounting` | Each agent commit's token cost is one row in the issue's receipt, reconciled at commit time against the writer's frozen token endpoint |
+| Steering is visible | `agent-steering-accounting` | Each human-steering event is a row in the issue's receipt; the ledger shape is validated |
 | The record can't be rewritten | `doc-integrity` | Receipts freeze once on the trunk; frozen sections keep their baseline lines verbatim |
+
+Everything homes in the receipt. There are **no accounting commit trailers** — that was the design before issue #293; the rows now live only in `receipts/issue-<N>.md`, which `doc-integrity` already freezes on the trunk. A commit-message copy of facts already in the receipt added a denormalised projection and a squash-merge re-validation dance, and bought nothing the frozen receipt didn't already give you.
 
 ## Receipts: attestation over promise
 
@@ -47,60 +49,40 @@ A plan says what the model *intends*; a receipt says what it *did*, in a form a 
 
 The trust boundary: **every `- [x]` checklist item must crosswalk** — its text must appear in `## What changed` or `## Verification`. An agent cannot flip a box without writing down what it did and how that was verified. The receipt is what a reviewer reads instead of the raw diff.
 
-`commit-issue-receipt-match` then ties commits to receipts: each non-merge commit needs an issue anchor (`(#N)` in the subject or `Issue: #N` trailer) matching an `issue-<N>` token on a receipt the commit touches.
+`commit-issue-receipt-match` ties commits to receipts the other direction, and it does it **file-first**: every non-merge, non-revert commit must add or modify at least one `receipts/issue-<N>.md`, and the touched receipt's filename *is* the issue anchor. That path sits in the diff identically before and after a squash-merge — where the subject flips to the PR number — so the link survives the squash with no body trailer to recover it. (The subject's own `(#N)` is still required, separately, by `commit-message-format`.)
 
 ## Cost accounting: every change has a price tag
 
-`agent-token-accounting` requires the token/cost trailers on every non-merge commit:
+`agent-token-accounting` records each agent-authored commit's token cost as exactly one row under `## Accounting` → `### Costs` in the issue's receipt:
 
 ```
-Agent: claude-code
-Issue: #123
-Session: 01HXYZ…
-Token-Input: 1200
-Token-Output: 450
-Token-Total: 1650
-Cost-Key: claude-01HXYZab-1713800000
-Cost-USD: 2.7932
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
 ```
 
-…and a matching row under `### Costs` in the issue's receipt:
+The interesting part is what keeps the row honest across a session that spans branches and a squash that rewrites SHAs:
 
-```
-| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | note |
-```
+- **The `cum-*` columns are absolute coordinates.** They are the session's cumulative input / cache-create / cache-read / output counters at this commit, written blind from the transcript. They are the source of truth; the delta columns (`input` / `output` / `new-work` / `cost-usd`) are derived claims for display, so the row reads in isolation.
+- **The endpoint, not a trailer, proves completeness.** At commit time the directive's `pre-commit` writer samples the transcript, writes the cost row, and freezes the sampled endpoint keyed by the staged tree under `.git/governance-token-endpoints/<tree>.json`. The `commit-msg` check then recomputes `git write-tree` and verifies the staged row matches that frozen endpoint — a missing endpoint means the runtime-aware hook never ran; a mismatch means the row doesn't record what the writer sampled.
+- **`cost-key` is the stable join token** — opaque, globally unique across `receipts/*.md`, and the thing cross-issue reports group by. It is a join key, not a parseable structure.
 
-The layering is the interesting part. Naive anchors all break: PR-level accounting is too late, commit SHAs disappear under squash-merge, transcripts are ephemeral. So:
+Because rows store positions on a monotonic counter rather than quantities, double-counting is structurally impossible to write and provable to detect, and a commit made via `--no-verify` simply rolls its tokens into the next accounted row instead of corrupting the ledger.
 
-- **Trailers** carry branch-time provenance on the commit itself.
-- **The receipt row** is the durable record.
-- **`Cost-Key`** is the stable join key present in both — it survives the squash because it lives in the message body and the receipt, not in a SHA.
-- The directive cross-checks trailer ↔ receipt on every commit.
-
-Token columns distinguish *new work* from cache traffic (`new-work = input + cache-create + output`; cache reads are excluded), and `Cost-USD` is computed from the runtime-reported model via a rates table — real dollars, not vibes.
-
-The trailers are *stamped* by the directive's own `prepare-commit-msg` populator (reading the runtime's usage data) and *verified* by its check — write and read paths kept separate.
+`new-work = input + cache-create + output` (cache reads are tracked but excluded — you don't pay new-work rates to re-read a warm cache), and `cost-usd` is computed from the runtime-reported model via a rates table (`lib/rates.py`, extensible with `rate <model> …` rows in the overlay). Cross-issue totals come from a read-only aggregation over `receipts/*.md` (`lib/report.py`), not from scraping `git log`.
 
 ## Steering accounting: where the human grabbed the wheel
 
-`agent-steering-accounting` records **human steering events** — interrupts and corrections — as rows under `### Steering` in the issue's receipt:
+`agent-steering-accounting` records **human steering events** — interrupts and classifier-confirmed corrections — as rows under `## Accounting` → `### Steering` in the issue's receipt:
 
 ```
-| steer-key | session | issue | type | tier | user-reason | commit |
+| steer-key | session | issue | type | tier | user-reason | commit | ordinal | timestamp |
 ```
 
-Every commit carries a summary triple, even when nothing happened (always-on, so silence is unambiguous):
+`ordinal` and `timestamp` are the event's absolute transcript coordinates: `ordinal` is its 1-based position in the session's deterministic event stream, and dedup is identity-based — a given `(session, ordinal)` is appended exactly once, ever, which is what makes a cross-branch re-append detectable after a merge.
 
-```
-Steer-Count: 2
-Steer-Types: correction=1,interrupt=1
-Steer-Tiers: classifier=1,structural=1
-```
-
-Detection is two-tier: **structural** (runtime interrupt sentinels — near-zero false positives) and **semantic** (user messages after assistant turns, classified as corrections by the runtime's headless CLI, with a regex fallback). The point is rule-layer steering: where humans repeatedly steer is the signal for which directives are missing or misaligned. You can read, per commit, which changes ran on autopilot and which needed your hand on the wheel.
+Detection is two-tier: **structural** (runtime interrupt sentinels — near-zero false positives) and **semantic** (user messages after assistant turns, classified as corrections by the runtime's headless CLI, with a regex pre-filter as the fallback when the CLI is unreachable). Tool *denials* are excluded by design — a "deny" click is usually "I'll do it myself", not an intent redirect. The point is rule-layer steering: where humans repeatedly steer is the signal for which directives are missing or misaligned.
 
 <Note>
-This directive (and `doc-integrity`) is `always_install: true` — the audit model depends on it unconditionally. It records correction text verbatim; redact via its classifier hook rather than switching it off.
+This directive (and `doc-integrity`) is `always_install: true` — the audit model depends on it unconditionally. `user-reason` records correction text **verbatim** in the receipt, so it becomes part of the repo's public history. Redact via its classifier hook rather than switching it off, and think hard before installing on a public repo.
 </Note>
 
 ## doc-integrity: the record cannot be quietly rewritten
@@ -109,19 +91,19 @@ An audit trail you can edit is not an audit trail. `doc-integrity` makes the sys
 
 | Rule | Semantics |
 |---|---|
-| `frozen-files <glob>` | Once a matching file is on the trunk, it is immutable. New files are fine. (Receipts — which now carry the accounting rows — and the sealed legacy `COSTS.md` / `STEERING.md` ledgers.) |
+| `frozen-files <glob>` | Once a matching file is on the trunk, it is immutable. New files are fine. (Receipts — which carry the accounting rows — and the sealed legacy `COSTS.md` / `STEERING.md` ledgers.) |
 | `append-only <file>` | The trunk version must remain a byte-prefix of the current version. |
 | `frozen-section <file> <heading>` | Lines under the heading survive verbatim; the rest of the file is free. (`QUALITY.md` Resolved, the Evolution Log.) |
 
-Everything is measured against the *trunk baseline* — branch-authored content stays editable until it merges, then freezes. Exceptions are path-scoped waivers in the commit body.
+Everything is measured against the *trunk baseline* — branch-authored content stays editable until it merges, then freezes. This is the directive that makes the receipt-homed accounting rows trustworthy: once a receipt lands on the trunk, neither its cost rows nor its steering rows can be rewritten. Exceptions are path-scoped waivers in the commit body.
 
 ## Reading the record
 
 The payoff is that oversight becomes *reading*, not *re-deriving*:
 
-- `git log` headlines show cost and steering at a glance (`Token-Total`, `Cost-USD`, `Steer-Count`).
 - A receipt's `### Costs` rows answer "what did this issue cost?" with grep.
 - Its `### Steering` rows answer "where do agents go off the rails?" — input for the next directive.
+- `lib/report.py` aggregates `### Costs` across every receipt when you want a cross-issue total.
 - `receipts/` answers "what exactly landed for issue #N, and how was it verified?"
 
 Next: [Limitations](/concepts/limitations) — the honest edges of what the commit path and the accounting can enforce.

--- a/docs/concepts/limitations.mdx
+++ b/docs/concepts/limitations.mdx
@@ -20,9 +20,9 @@ Commit-path checks must be **deterministic, fast, and offline** — same repo st
 
 ## The accounting depends on runtime cooperation
 
-- Token and steering trailers are stamped by populators reading **the runtime's usage data**. Runtimes that don't expose usage need an adapter; without one, those directives report the gap rather than inventing numbers.
-- The audit chain assumes the squash-merge setting **keeps commit bodies** — squashing to blank bodies strips the trailers the trunk checks verify.
-- Steering accounting records human correction text **verbatim**. If that text can contain sensitive content, redact via the directive's classifier hook — the directive is `always_install` and should not simply be switched off.
+- Cost and steering rows are written by `pre-commit` populators reading **the runtime's usage data and transcript**. Runtimes that don't expose those need a per-runtime adapter under the directive's `runtimes/`; without one, the populators no-op rather than inventing numbers, and the checks validate whatever rows exist.
+- Per-commit token attribution needs the commit to go through the hook. A commit made with `--no-verify` has no frozen endpoint to reconcile against, so its tokens roll into the next accounted row — session totals stay correct, but that one commit's slice is not separately recoverable.
+- Steering accounting records human correction text **verbatim** in the receipt. If that text can contain sensitive content, redact via the directive's classifier hook — the directive is `always_install` and should not simply be switched off.
 
 ## One issue, one PR, one receipt
 

--- a/docs/concepts/packs.mdx
+++ b/docs/concepts/packs.mdx
@@ -19,7 +19,7 @@ Three kinds, distinguished by provenance:
 
 | Kind | Where it's authored | Lockfile `source` | Example |
 |---|---|---|---|
-| **Bundled** | Ships with the kit | `gh` | `governance-kit/{foundation,docs,commits,audit}` — the concern packs offered at `init` |
+| **Bundled** | Ships with the kit | `gh` | `governance-kit/{foundation,commits,audit}` — the concern packs offered at `init` |
 | **Community** | Its own GitHub repo | `gh` | `acme/soc2-pack` — installed via `pack add gh:acme/soc2-pack@v1.2.0` |
 | **Repo-local** | Your repo, by hand or via `directive add` | `local` | `<your-org>/<your-repo>` — no upstream, skipped by `pack update` |
 

--- a/docs/concepts/runtime.mdx
+++ b/docs/concepts/runtime.mdx
@@ -39,7 +39,7 @@ This page traces what actually happens between `git commit` and `[PASS]` — the
     Each installed directive declared its `hook:` in `directive.yaml`; the pre-commit dispatcher runs only pre-commit directives, the commit-msg dispatcher only commit-msg ones.
   </Step>
   <Step title="Populators run first">
-    Directives can ship side-effect scripts (`hooks/<kind>.sh`) — e.g. `agent-token-accounting`'s `prepare-commit-msg` helper *stamps* the token trailers, and its check then *verifies* them. Governance reads; remediation writes; the two are separate scripts.
+    Directives can ship side-effect scripts (`hooks/<kind>.sh`) — e.g. `agent-token-accounting`'s `pre-commit` helper *writes* the cost row into the issue's receipt and freezes the sampled token endpoint, and its `commit-msg` check then *reconciles* the staged row against that endpoint. Remediation writes; governance reads; the two are separate scripts.
   </Step>
   <Step title="Each check runs">
     `check.sh` sources `lib.sh`, announces itself with `directive_start`, inspects the repo (staged tree for `change-set` directives, tree-at-rest for `repo-state` ones), records `violation`s, and `directive_end` decides pass/fail.
@@ -85,9 +85,9 @@ Local hooks are a convenience; **CI is the contract**:
 
 ## Mode B: validating history, not just the working tree
 
-`change-set` directives that police *commits* (message format, receipts, accounting trailers) have two operating modes:
+`change-set` directives that police *commits* (message format, receipt touches, ledger shape) have two operating modes:
 
 - **Pending-commit mode** (in the hook) — validate the commit being made right now.
-- **Walker mode** (in CI) — walk the commits between the merge-base and `HEAD`, validating each. This is what makes the rules hold on the trunk even when a local hook was skipped, and what makes them survive squash-merges (which is why accounting uses stable keys rather than commit SHAs — see [the audit chain](/concepts/audit-chain)).
+- **Walker mode** (in CI) — walk the commits between the merge-base and `HEAD`, validating each. This is what makes the rules hold on the trunk even when a local hook was skipped. The audit-chain links are built to survive squash-merges without a walker re-validation step: the commit↔issue anchor is the receipt path (which the squash preserves), and the accounting rows live in the frozen receipt keyed by stable join tokens, not in commit SHAs — see [the audit chain](/concepts/audit-chain).
 
 Next: [Packs, pins & vendoring](/concepts/packs) — where directives come from and how they're trusted.

--- a/docs/concepts/versioning.mdx
+++ b/docs/concepts/versioning.mdx
@@ -16,7 +16,7 @@ Governance Kit versions **two independent things on two independent semver axes*
 | Axis | What it covers | Source of truth | Tag scheme |
 |---|---|---|---|
 | **Kit** (framework) | The `governance` skill, the runtime (`run.sh`, `lib.sh`), hook generators, schemas, verbs | `kit/assets/kit.yaml` | `kit/vX.Y.Z` |
-| **Pack** (content) | Directive code — checks, constitution snippets, presets | Each pack's `pack.yaml` | `<pack>/vX.Y.Z` (e.g. `docs/v0.2.0`) |
+| **Pack** (content) | Directive code — checks, constitution snippets, presets | Each pack's `pack.yaml` | `<pack>/vX.Y.Z` (e.g. `commits/v0.2.0`) |
 
 They move independently: a bundled pack can ship a check fix without the framework moving, and the framework can add a verb without any directive changing. One contract ties them: a pack's `min_governance_kit` must be ≤ the installed kit version.
 
@@ -56,8 +56,8 @@ Version lines are written **only** by `scripts/release.sh`, in `chore(release)` 
 
 ```sh
 bash scripts/release.sh <kit|PACK> <X.Y.Z> --dry-run   # preview from any branch
-bash scripts/release.sh docs 0.2.0                     # cut a pack release (one per changed pack)
-bash scripts/release.sh kit 0.6.0 --push               # cut + push branch and tag
+bash scripts/release.sh commits 0.2.1                  # cut a pack release (one per changed pack)
+bash scripts/release.sh kit 0.10.2 --push              # cut + push branch and tag
 ```
 
 A real run:

--- a/docs/guide/introduction.mdx
+++ b/docs/guide/introduction.mdx
@@ -9,13 +9,15 @@ Governance Kit is a toolkit for **governance-driven development (GDD)**: a workf
 
 It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex, Cursor, and 40+ skills-compatible runtimes. One skill, one entry point: the `governance` verb surface.
 
-## The problem it solves
+## What problem does it solve?
 
-Coding agents author most of the changes now. That shifts the hard problem: it is no longer "tell one agent what to do in one session" — it is **keeping the repository understandable across many branches, many agents, and many handoffs**. OpenAI's [harness engineering](https://openai.com/index/harness-engineering/) article names this failure set from running an agent-first codebase: instruction files that "rot instantly", agents that replicate uneven patterns until the codebase drifts, knowledge trapped in chat threads, and human QA capacity becoming the bottleneck.
+Coding agents often complete the task in a way that is locally fine and globally wrong. They land features through the wrong layer, revive patterns you retired, widen a boundary you wanted held, or half-follow `AGENTS.md` and miss the constraint that mattered. The objective passes; the repo drifts. The next agent has no memory of the correction, so you give it again.
+
+Adding more prompt is the obvious fix, and it does not scale: instruction files grow, context gets crowded, and the rule still only reaches the current session. OpenAI's [harness-engineering](https://openai.com/index/harness-engineering/) write-up names the same failure set from running an agent-first codebase — instruction files that "rot instantly", agents that replicate uneven patterns until the codebase drifts, knowledge trapped in chat threads, and human QA capacity becoming the bottleneck.
 
 Two things stop scaling at agent throughput:
 
-1. **Steering.** Your guidance has to reach the *next* agent, on the *next* branch, without you in the room. Per-turn prompting does not compose — the next agent cannot read your last conversation.
+1. **Steering.** Your guidance has to reach the *next* agent, on the *next* branch, without you in the room. Per-turn prompting doesn't compose — the next agent can't read your last conversation.
 2. **Visibility.** When agents ship the diffs, you need a readable trail, not a stack of PRs and ephemeral chat transcripts.
 
 Governance Kit answers both with repo-native artifacts:
@@ -23,20 +25,35 @@ Governance Kit answers both with repo-native artifacts:
 - **A constitution** — `CONSTITUTION.md`, a versioned set of directives every agent reads and every commit is checked against.
 - **Receipts and ledgers** — per-issue receipts (with cost and steering accounting) and the `QUALITY.md` board, recording what agents were told, what they did, and what it cost.
 
-## The stance in one line
+## How does the loop work?
+
+The repo carries the durable instruction; the agent reconciles reality against it.
 
 > Describe the state, continuously check reality, and let agents reconcile the difference.
 
-This is declarative reconciliation — the Kubernetes/Terraform model — applied to a repository:
+A failed check is not a scolding — it is a *gap report*. It names the directive, the offending file and line, and the rationale, and a frontier-model agent reading that rationale generalizes to cases the rule's author never encoded. This is the [harness-engineering](https://openai.com/index/harness-engineering/) move: coherence comes from executable rails around the agent, not ever-larger instruction blobs.
+
+Under the hood it is declarative reconciliation — the model Kubernetes and Terraform use, applied to a repository:
 
 | | In Governance Kit |
 |---|---|
 | **Desired state** | `CONSTITUTION.md` — directives, rationale, exceptions, evolution log |
-| **Current state** | The working tree, staged diff, commit message, receipts |
+| **Current state** | the working tree, staged diff, commit message, receipts |
 | **Controller** | `.governance/run.sh` + git hook dispatchers + CI |
-| **Reconciler** | The agent — reads the gap and its rationale, fixes the repo, re-runs |
+| **Reconciler** | the agent — reads the gap and its rationale, fixes the repo, re-runs |
 
-A failed check is not a scolding; it is a *gap report*. It names the directive, the offending file and line, and the rationale. A frontier-model agent reading that rationale generalizes to cases the rule's author never encoded.
+## How deep can a rule go?
+
+The real power is the depth of invariant you can express. Start with deterministic checks; escalate only when the rule genuinely needs context or judgment. One rule layer carries all four depths:
+
+| Depth | What you can say | How it runs |
+|---|---|---|
+| **Repo state** | "Every repo needs a README, a license, a security contact, an architecture note." | Cheap `check.sh` over the tree, locally and in CI. |
+| **Change set** | "A CI-config change needs a reason in the commit." "A receipt for issue #42 must name the files this PR changed." | Diff-aware hooks plus CI's merge-base walk. |
+| **Ledger** | "For each agent-authored change, show the issue, receipt, token cost, and steering count." | Receipt accounting rows, cross-checked by directives. |
+| **Sub-agent attestation** | "Before merging a cross-layer refactor, have a fresh reader compare the diff to the architecture map." | The hook fails with a fresh-context sub-agent prompt; the agent records a PASS/REFUTED section; the hook verifies it is there. |
+
+The failures that hurt are rarely mechanical ("forgot the formatter") — they're semantic, and no single enforcement style catches both. Governance Kit matches each rule to a surface: cheap deterministic checks for the mechanical, [fresh-context attestation](https://github.com/Duaility/governance-kit/blob/main/kit/references/SUBAGENT_ATTESTATION.md) for the judgment calls.
 
 ## What a directive looks like
 

--- a/docs/guide/mental-models.mdx
+++ b/docs/guide/mental-models.mdx
@@ -5,7 +5,7 @@ summary: 'The handful of ideas everything in Governance Kit follows from — rec
 
 # Mental models
 
-Everything in Governance Kit follows from a handful of ideas. If you internalize this page, the rest of the docs are details.
+Everything in Governance Kit follows from a handful of ideas. Get these and the rest of the docs are detail. They all serve one stance: coherence comes from executable rails around the agent, not ever-larger instruction blobs — the [harness-engineering](https://openai.com/index/harness-engineering/) move.
 
 ## 1. The repo is a reconciliation loop
 
@@ -35,34 +35,10 @@ Don't chain actions; describe state and let re-evaluation converge.
 
 Governance Kit is three layers, and the analogy to a language toolchain manager carries almost all the way:
 
-```mermaid
-flowchart TB
-    S["<b>governance skill — the installer</b><br/>install · update · uninstall"]
-    K["<b>the kit — kit/vX.Y.Z — the product</b><br/>engines · flows · templates · every verb"]
-    P["<b>packs — pack/vX.Y.Z — the content</b><br/>directive code, lock-pinned"]
-    PIN["<b>the repo decides its versions</b><br/>install.yaml pins the kit · packs.lock pins the packs · the skill honors the pin"]
-    RU["≈ rustup<br/>the version manager"]
-    TC["≈ the toolchain<br/>compiler · libs · tools"]
-    LF["≈ the lockfile<br/>pinned dependencies"]
-
-    S -->|"installs · updates"| K
-    K -->|"consumes"| P
-    P ~~~ PIN
-    S -.- RU
-    K -.- TC
-    P -.- LF
-
-    classDef installer fill:#4938a8,stroke:#4938a8,color:#ffffff
-    classDef product fill:#0c7a52,stroke:#0c7a52,color:#ffffff
-    classDef content fill:#9c3a1d,stroke:#9c3a1d,color:#ffffff
-    classDef analogy fill:#44443e,stroke:#44443e,color:#e8e8e3
-    classDef pin fill:#0d4f86,stroke:#0d4f86,color:#ffffff
-    class S installer
-    class K product
-    class P content
-    class RU,TC,LF analogy
-    class PIN pin
-```
+<Frame caption="The governance skill installs the kit, the kit consumes packs, and the repo pins every version — a language-toolchain manager (rustup · toolchain · lockfile) for governance.">
+  <img className="block dark:hidden" src="/assets/lifecycle-light.svg" alt="Governance lifecycle as a language-toolchain model: the governance skill is the installer (like rustup), the kit is the product (like the toolchain), packs are the content (like the lockfile), and the repo pins every version via install.yaml and packs.lock" />
+  <img className="hidden dark:block" src="/assets/lifecycle-dark.svg" alt="Governance lifecycle as a language-toolchain model: the governance skill is the installer (like rustup), the kit is the product (like the toolchain), packs are the content (like the lockfile), and the repo pins every version via install.yaml and packs.lock" />
+</Frame>
 
 The skill is a two-file shim that fetches and honors pins; the kit is the versioned product every verb executes from; packs are the directive content the kit consumes. Each layer versions independently, and the *repo* — not the installer — decides which versions it runs. See [Versioning & releases](/concepts/versioning).
 

--- a/docs/guide/quickstart.mdx
+++ b/docs/guide/quickstart.mdx
@@ -55,8 +55,8 @@ claude
 
 | Preset | What you get |
 |---|---|
-| `minimal` | Foundation + doc links: required docs, repo hygiene, managed-tree integrity, resolving internal links. |
-| `standard` | `minimal` + commit discipline, kit-version sync, doc freshness, and the full [agent audit chain](/concepts/audit-chain): receipts, issue anchors, token and steering accounting, doc integrity. |
+| `minimal` | Foundation only: required docs, repo hygiene, managed-tree integrity, resolving internal links. |
+| `standard` | `minimal` + Conventional-Commit message format + the full [agent audit chain](/concepts/audit-chain): receipts, issue anchors, token and steering accounting, doc integrity, toolchain-config protection. |
 | `strict` | `standard` + TODO and suppression discipline. |
 
 `standard` is the intended default for agent-heavy repos — it is the preset that turns on the issue → receipt → commit → cost chain.

--- a/docs/guide/troubleshooting.mdx
+++ b/docs/guide/troubleshooting.mdx
@@ -52,9 +52,9 @@ Commit-policing directives run in two modes: the hook validates the *pending* co
 
 | Failure | What it means | Fix |
 |---|---|---|
-| `commit-issue-receipt-match` | The commit's `(#N)` anchor doesn't match a receipt it touches | Create/touch `receipts/issue-<N>-*.md` in the same commit |
+| `commit-issue-receipt-match` | The commit touches no `receipts/issue-<N>.md` | Add or update the issue's receipt in the same commit — the receipt path is the anchor |
 | `receipt-per-issue` | A checked box doesn't crosswalk | Restate the claim under `## What changed` or `## Verification` |
-| `agent-token-accounting` | Trailers and the receipt's cost rows disagree | Commit through the hook path so the populator stamps them — don't hand-write trailers |
+| `agent-token-accounting` | The staged cost row is missing or doesn't match the frozen token endpoint | Commit through the hook path so the `pre-commit` writer records the row — don't hand-write it |
 | `doc-integrity` | A trunk-frozen record was edited | Revert the edit, or carry the directive's path-scoped waiver in the commit body if the change is legitimate |
 
 ## Still stuck

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,9 +5,9 @@ summary: 'The governance layer for AI coding agents — every rule ships with an
 
 # Governance Kit
 
-> **The governance layer for AI coding agents.**
+> **The governance layer for AI coding agents — give every agent the same repo memory.**
 
-Your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant. It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex, Cursor, and 40+ skills-compatible runtimes — one skill, one entry point: the `governance` verb surface.
+Coding agents author most of the changes now, and each one starts cold. Your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships with an executable test, and agents — not humans — do the work of keeping the repo compliant. The correction you make once reaches the next agent, on the next branch, without you re-teaching it. It installs as an [Agent Skill](https://agentskills.io) into Claude Code, Codex, Cursor, and 40+ skills-compatible runtimes — one skill, one entry point: the `governance` verb surface.
 
 <Columns cols={3}>
   <Card title="Quickstart" href="/guide/quickstart" icon="rocket">
@@ -21,22 +21,39 @@ Your repository's rules live in a versioned `CONSTITUTION.md`, every rule ships 
   </Card>
 </Columns>
 
-## How it works
+## How does it work?
 
 > Describe the state, continuously check reality, and let agents reconcile the difference.
 
-This is declarative reconciliation — the Kubernetes/Terraform model — applied to a repository:
+A human states the invariant once, in repo language. A pack captures it as a directive plus its rationale and test. The gate fails with *why*, the agent repairs the repo using that failure as instruction, and the repo carries the durable record the next agent reads. Coherence comes from executable rails around the agent, not ever-larger instruction blobs — the [harness-engineering](https://openai.com/index/harness-engineering/) move.
 
 ```mermaid
 flowchart LR
-  C["CONSTITUTION.md — desired state"] --> G{"Governance checks: run.sh, hooks, CI"}
-  R["Repository — current state"] --> G
-  G -->|"pass"| OK(["Ready to merge"])
-  G -->|"fail: gap + rationale"| A["Agent fixes the gap"]
-  A -->|"commit, re-run"| R
+    H["Human says the invariant<br/>once, in repo language"]
+    P["Pack captures it<br/>directive + rationale + evals"]
+    G{"Git hook / CI"}
+    A["Agent repairs the repo<br/>using the failure as instruction"]
+    R["Repo carries the durable record<br/>constitution + receipts + accounting"]
+
+    H --> P --> G
+    G -- "fails with why" --> A
+    A --> G
+    G -- "passes" --> R
+    R -.->|"next agent reads"| G
+
+    classDef human fill:#3f3586,stroke:#8b7ff0,color:#eeeaff
+    classDef directive fill:#075b4a,stroke:#36d6af,color:#dcfff4
+    classDef gate fill:#7b2b17,stroke:#ef9673,color:#fff0e8
+    classDef agent fill:#0e4e85,stroke:#5aa8e9,color:#e9f5ff
+    classDef record fill:#3f403a,stroke:#a5a49b,color:#efeee8
+    class H human
+    class P directive
+    class G gate
+    class A agent
+    class R record
 ```
 
-A failed check is not a scolding; it is a *gap report*. It names the directive, the offending file and line, and the rationale — and a frontier-model agent reading that rationale generalizes to cases the rule's author never encoded. Why this matters when agents author most of the changes: [What is Governance Kit?](/guide/introduction)
+A failed check is not a scolding; it is a *gap report*: it names the directive, the offending file and line, and the rationale, and a frontier-model agent reading that rationale generalizes to cases the rule's author never encoded. Under the hood it's declarative reconciliation — the Kubernetes/Terraform model applied to a repo, unpacked in [mental models](/guide/mental-models). Why this matters when agents author most of the changes: [What is Governance Kit?](/guide/introduction).
 
 ## Explore the docs
 

--- a/receipts/issue-323-docs-site-refresh.md
+++ b/receipts/issue-323-docs-site-refresh.md
@@ -1,0 +1,77 @@
+# Receipt — issue #323
+
+Refresh the published docs site (`docs/`) so it matches the current kit after the last few releases and reads in the README's developer-to-developer voice — the README being the tonal reference point. The work is in three layers: correct the factual drift (retired accounting trailers, the folded-in `docs` pack, dropped preset directives), align the lead framing and vocabulary to the README (harness-engineering, "locally fine and globally wrong", the depth ladder), and reuse the README's diagrams instead of redrawing them. Every fact was checked against the live kit (`packs/*/pack.yaml`, the audit directives' `constitution.md`, `.governance/install.yaml`) before editing. The generated `docs/reference/*.mdx` pages were deliberately left alone — they regenerate from `kit/references` and were already current.
+
+## Checklist
+
+- [x] Correct the factual drift: remove the retired accounting commit trailers, fix the folded-in `docs` pack, and drop the preset directives that no longer exist.
+- [x] Lead the docs with the README's harness-engineering framing and import the "locally fine and globally wrong" hook and the four-level depth ladder.
+- [x] Reuse the README's diagrams: the harness-loop mermaid on the landing page and the designed lifecycle SVG embedded on the docs site.
+- [x] Keep the governance suite green — `internal-doc-links` passes and no stale trailer or dead-pack references remain in the narrative pages.
+
+## What changed
+
+- **Correct the factual drift: remove the retired accounting commit trailers, fix the folded-in `docs` pack, and drop the preset directives that no longer exist.** — `docs/concepts/audit-chain.mdx` is rewritten off the trailer model (#293/#294): the mermaid, the link table, the cost section (now the v4 `cum-*` row + the frozen-token-endpoint reconciliation), the steering section (v2 row, identity dedup), and "reading the record" no longer mention `Token-Total`/`Cost-Key`/`Steer-Count`; `commit-issue-receipt-match` is described file-first. The same correction propagated to `docs/concepts/runtime.mdx` (the populator step now *writes the cost row + freezes the endpoint*, and the Mode-B list drops "accounting trailers"), `docs/concepts/limitations.mdx` (dropped the stale "squash must keep commit bodies" constraint), and `docs/guide/troubleshooting.mdx` (the `agent-token-accounting` failure row). `docs/concepts/packs.mdx` drops the dead `docs` pack from the bundled list (`{foundation,commits,audit}`), and `docs/concepts/versioning.mdx` replaces the `docs/v0.2.0` tag and `release.sh docs` examples with live packs. `docs/guide/quickstart.mdx`'s preset table no longer names "kit-version sync" / "doc freshness".
+- **Lead the docs with the README's harness-engineering framing and import the "locally fine and globally wrong" hook and the four-level depth ladder.** — `docs/guide/introduction.mdx` is reworked so harness-engineering is the lead lens (reconciliation reframed as the "under the hood" mechanism), opens "What problem does it solve?" with the README's "locally fine and globally wrong" hook, and adds a new "How deep can a rule go?" section carrying the four-level depth ladder (repo-state → change-set → ledger → sub-agent attestation). `docs/index.mdx`'s lead and "How does it work?" now lead with executable-rails/harness-engineering and the repo-memory hook. `docs/guide/mental-models.mdx`'s opening ties the whole page to the harness-engineering stance and drops the academic "internalize" phrasing.
+- **Reuse the README's diagrams: the harness-loop mermaid on the landing page and the designed lifecycle SVG embedded on the docs site.** — `docs/index.mdx`'s hero diagram is now the README's harness-loop mermaid copied verbatim (Human→Pack→Gate→Agent→Record with the colored `classDef`s and the "next agent reads" feedback edge), and its surrounding prose was adjusted so the words match the diagram. `docs/guide/mental-models.mdx`'s second diagram (the installer/product/content model) is now the designed `docs/assets/lifecycle-light.svg` / `lifecycle-dark.svg` embedded via Mintlify's `block dark:hidden` / `hidden dark:block` light/dark pattern inside a `<Frame>`, replacing the hand-drawn mermaid; the purpose-built reconciliation mermaid (mental-models #1) and the audit-chain mermaid are kept.
+- **Keep the governance suite green — `internal-doc-links` passes and no stale trailer or dead-pack references remain in the narrative pages.** — verified by grep sweeps over the narrative pages (no `Token-Total`/`Cost-Key`/`Steer-Count`/`governance-kit/docs`/`doc freshness` survivors) and by running the dead-link directive; brand prose stays "Governance Kit". The full set of changed files is `docs/index.mdx`, `docs/guide/introduction.mdx`, `docs/guide/mental-models.mdx`, `docs/guide/quickstart.mdx`, `docs/guide/troubleshooting.mdx`, `docs/concepts/audit-chain.mdx`, `docs/concepts/limitations.mdx`, `docs/concepts/packs.mdx`, `docs/concepts/runtime.mdx`, and `docs/concepts/versioning.mdx`.
+
+## Out of scope
+
+- `docs/reference/*.mdx` (verbs, directive-catalog, schemas, native-tests, authoring-directives, authoring-packs) — generated from `kit/references/*.md` by `scripts/docs-site/gen-reference.mjs`; they were already current (the catalog already states "no commit trailers, #293") and editing them by hand would break `docs:gen:check`.
+- `kit/references/*.md`, `README.md`, `CONSTITUTION.md`, `.governance/` — not a docs-site refresh; untouched.
+- `ARCHITECTURE.md`'s mermaid (a third rendering of the installer/product/content model, slightly drifted) — a repo-internal doc, not a docs-site page; left for a separate change.
+
+## Verification
+
+Docs-only change. The dead-link directive passes and no stale references survive the grep sweeps:
+
+```sh
+bash .governance/run.sh internal-doc-links        # ✓ internal-doc-links
+# no retired-trailer / dead-pack / dropped-directive strings remain in the narrative:
+grep -rniE 'Token-Total|Cost-Key|Steer-Count|governance-kit/docs|docs/v0|doc freshness|kit-version sync' \
+  docs/index.mdx docs/guide/*.mdx docs/concepts/*.mdx
+# both reused SVG variants exist and are tracked:
+git ls-files docs/assets/lifecycle-light.svg docs/assets/lifecycle-dark.svg
+# the README harness loop is on the landing page; mental-models #2 is now the SVG:
+grep -c '```mermaid' docs/index.mdx docs/guide/mental-models.mdx
+```
+
+The grep sweep returns no matches in the narrative pages (the only `prepare-commit-msg` hits are the legitimate hook-kind enum and dispatcher list). `docs/index.mdx` carries one mermaid (the harness loop); `docs/guide/mental-models.mdx` carries one mermaid (the kept reconciliation diagram), its installer/product/content diagram now the embedded SVG.
+
+## Decisions
+
+- **Harness-engineering leads, reconciliation supports.** The docs led with the Kubernetes/Terraform reconciliation metaphor, which the README never uses; the README leads with harness-engineering. Rather than drop reconciliation (it is accurate and is the right diagram for `mental-models` #1), it was demoted to the "under the hood" mechanism and harness-engineering made the headline lens, so a reader moving README → site meets one stance, not two.
+- **Reuse the designed SVG over the hand-drawn mermaid.** The polished `lifecycle-*.svg` lived in `docs/assets/` but was embedded only by the README; the docs redrew the same idea as a lower-fidelity mermaid. The SVG is embedded via Mintlify's class-based `dark:hidden` pattern (not the README's `<picture>`/`prefers-color-scheme`, which tracks the OS theme rather than Mintlify's in-app toggle). User chose "reuse README's assets" over aligning the mermaids.
+- **Anchored headers preserved.** Four headers are cross-link anchor targets (`mental-models#2-an-installer-a-product-its-content`, `packs#presets`, `packs#update-vs-reset`, `quickstart#choosing-a-preset`); their text was kept verbatim so no intra-site link breaks.
+- **Backing issue created for the flow.** This refresh started from a user request, not a pre-existing issue; issue #323 was opened to satisfy the repo's issue → receipt → commit chain.
+
+## Audit
+
+PASS
+
+- PASS — Every one of the 10 staged non-receipt files is named in `## What changed` and each narrated claim matches the hunks: `audit-chain.mdx` drops `Token-Total`/`Cost-Key`/`Steer-Count` and reframes `commit-issue-receipt-match` file-first, `packs.mdx` changes the bundled list to `{foundation,commits,audit}`, `versioning.mdx` swaps `docs/v0.2.0`→`commits/v0.2.1`, `quickstart.mdx` removes "kit-version sync"/"doc freshness", `index.mdx` replaces the reconciliation hero with the README harness-loop mermaid, and `mental-models.mdx` #2 becomes the embedded `lifecycle-light/dark.svg` while keeping reconciliation mermaid #1.
+- PASS — All four `- [x]` boxes are realized in the diff and crosswalk into `## What changed` / `## Verification`: trailers removed (audit-chain/runtime/limitations/troubleshooting hunks), README framing + depth-ladder added (`introduction.mdx` "How deep can a rule go?" table, mental-models harness lead, index lead), both SVG variants tracked via `git ls-files`, and the green-suite box backed by index/mental-models each carrying exactly one mermaid with no retired-trailer survivors.
+- PASS — The `## Checklist` covers every issue #323 proposed-fix item (factual drift; harness framing + "locally fine and globally wrong" + depth ladder; reuse harness mermaid + lifecycle SVG) and both acceptance criteria (no stale refs; landing + mental-models reuse the diagrams; `internal-doc-links` green), with the reference-page edits correctly excluded per the issue's stated out-of-scope.
+
+This `## Audit` verdict was produced by a fresh-context sub-agent handed only the staged diff (`git diff --cached`), this receipt, and `gh issue view 323`; it confirmed PASS on all three dimensions.
+
+## Layer boundaries
+
+PASS
+
+- PASS — Every staged file sits in its correct surface: all 10 changed files are narrative pages under `docs/{index,guide,concepts}/*.mdx` (the published-site layer) and the one new file is `receipts/issue-323-docs-site-refresh.md` (the ledger layer); no `skill/`, `kit/`, `packs/`, or `.governance/` source was touched, confirmed by `git diff --cached --name-only | grep -vE '^(docs/|receipts/)'` returning nothing.
+- PASS — No dependency crosses a layer edge the wrong way: the docs pages only *describe* lower layers and link sideways within the site (e.g. `mental-models.mdx` embeds the pre-existing `docs/assets/lifecycle-*.svg` and links to `/concepts/versioning`), introducing no code-level import or upward reference from `docs/` / `receipts/` into `skill` / `kit` / `packs`.
+- PASS — No shared logic is duplicated into a consumer layer: the changes are prose/diagram edits that single-source from the lower layers rather than re-implementing them (the receipt leaves generated `docs/reference/*.mdx` untouched because they regenerate from `kit/references`, and the mental-models lifecycle diagram reuses the existing designed SVG instead of redrawing the kit's architecture).
+
+This `## Layer boundaries` verdict was produced by a fresh-context sub-agent handed only the staged diff and the layer model in `ARCHITECTURE.md`; it confirmed PASS on all three dimensions.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque — do not parse. -->
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| claude-code-411c3220-7bb-1781709298-1 | claude-code | 411c3220-7bb7-4fee-a87e-ebb816937323 | #323 | claude-opus-4-8 | 25008 | 34592 | 30540 | 654 | 60254 | 0.3729 | 25008 | 34592 | 30540 | 654 | docs: refresh the published docs site to match recent releases and the README (# |


### PR DESCRIPTION
Closes #323.

## What & why

The published docs site (`docs/`) had drifted from the kit over the last few releases, and its voice and diagrams no longer tracked the README (the tonal reference point). This refreshes the hand-authored narrative pages — Get started, Concepts, Guides — on three axes.

### 1. Factual drift corrected
- **Accounting trailers (#293/#294) removed everywhere.** `concepts/audit-chain.mdx` is rewritten off the trailer model: the mermaid, link table, cost section (now the v4 `cum-*` row + frozen-token-endpoint reconciliation), steering section (v2 row, identity dedup), and "reading the record" no longer mention `Token-Total`/`Cost-Key`/`Steer-Count`; `commit-issue-receipt-match` is described file-first. Propagated to `runtime.mdx`, `limitations.mdx`, `troubleshooting.mdx`.
- **`docs` pack folded into `foundation` (#310).** `packs.mdx` bundled list → `{foundation,commits,audit}`; `versioning.mdx` drops the `docs/v0.2.0` examples.
- **Quickstart preset table** no longer names the dropped "kit-version sync" / "doc freshness" directives.

### 2. Tone aligned to the README
- Lead with the README's **harness-engineering** framing ("executable rails"); reconciliation demoted to the supporting "under the hood" model.
- Imported the README's **"locally fine and globally wrong"** hook and a new **"How deep can a rule go?"** depth-ladder (repo-state → change-set → ledger → sub-agent attestation) into `introduction.mdx`.

### 3. README diagrams reused (not redrawn)
- The landing page hero is now the README's **harness-loop mermaid**, copied verbatim.
- `mental-models` #2 embeds the designed **`lifecycle-*.svg`** (via Mintlify's `block dark:hidden` light/dark pattern) instead of a hand-drawn mermaid. Purpose-built diagrams (reconciliation #1, audit chain) are kept.

## Out of scope
Generated `docs/reference/*.mdx` (regenerate from `kit/references`, already current) and `ARCHITECTURE.md`'s mermaid (repo-internal, not a site page).

## Reviewer notes
- Full audit chain is green: `bash .governance/run.sh` → all 16 directives pass; the receipt carries fresh-context `## Audit` and `## Layer boundaries` attestations.
- I couldn't render Mintlify locally to confirm the SVG theme-switch — worth a glance in preview. The two SVG variants are purpose-built per theme and the class-based pattern is Mintlify's documented approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)