### PR TITLE
fix(audit): make Codex token runtime strict

### DIFF
--- a/kit/assets/dot-governance/lib.sh
+++ b/kit/assets/dot-governance/lib.sh
@@ -173,7 +173,7 @@ _tier_phrase() {
         medium)
             printf 'a mid-capability model (the medium capability tier)' ;;
         low | *)
-            printf 'a small, low-cost model (the low capability tier, e.g. Claude Haiku or a comparable GPT-mini-class model; this is a bounded read-and-record audit whose verdict is independently re-derived by the merge-time sweep lane)' ;;
+            printf 'a small, low-cost model (the low capability tier; for Codex use a mini-class model, for Claude Code use a Haiku-class model; this is a bounded read-and-record audit whose verdict is independently re-derived by the merge-time sweep lane)' ;;
     esac
 }
 
@@ -197,7 +197,7 @@ attestation_prompt() {
         i=$((i + 1))
     done
     numbered="${numbered%; }"
-    printf 'Spawn a fresh-context sub-agent — on %s — with exactly these inputs — %s — and have it report a verdict + evidence for each, rendering each verdict as exactly the token PASS or REFUTED: %s. Default to REFUTED if uncertain. Write the findings into a '\''## %s'\'' section, then re-stage and re-commit. The hook never spawns the sub-agent itself.' \
+    printf 'Spawn a fresh-context sub-agent — on %s — with exactly these inputs — %s — and have it report a verdict + evidence for each, rendering each verdict as exactly the token PASS or REFUTED: %s. Default to REFUTED if uncertain. Write the findings into a '\''## %s'\'' section, then re-stage and re-commit. The hook never spawns the sub-agent itself; do not self-author this section in the primary agent context.' \
         "$(_tier_phrase low)" "$inputs" "$numbered" "$section"
 }
 
@@ -355,7 +355,19 @@ resolve_subagent_input() {
         diff)       printf 'the diff (`git diff`)' ;;
         receipt)    printf 'this receipt (`%s`)' "$receipt" ;;
         issue)      printf 'the linked issue (`gh issue view #%s`)' "$n" ;;
-        transcript) printf 'the session transcript (the JSONL named `$CLAUDE_CODE_SESSION_ID.jsonl` under your Claude Code projects dir)' ;;
+        transcript)
+            if [[ -n "${CODEX_TRANSCRIPT_PATH:-}" ]]; then
+                printf 'the Codex session transcript at `%s`' "$CODEX_TRANSCRIPT_PATH"
+            elif [[ -n "${CODEX_THREAD_ID:-}" ]]; then
+                printf 'the Codex session transcript (the JSONL under `~/.codex/sessions/` or `~/.codex/archived_sessions/` whose filename ends with `$CODEX_THREAD_ID.jsonl`)'
+            elif [[ -n "${CLAUDE_TRANSCRIPT_PATH:-}" ]]; then
+                printf 'the Claude Code session transcript at `%s`' "$CLAUDE_TRANSCRIPT_PATH"
+            elif [[ -n "${CLAUDE_CODE_SESSION_ID:-}" ]]; then
+                printf 'the Claude Code session transcript (the JSONL named `$CLAUDE_CODE_SESSION_ID.jsonl` under your Claude Code projects dir)'
+            else
+                printf 'the active agent session transcript for this commit'
+            fi
+            ;;
         layer-map)  printf 'the declared layer model in `%s`' "${GOVERNANCE_LAYER_DOC:-ARCHITECTURE.md}" ;;
         *)          printf '%s' "$token" ;;
     esac
@@ -524,8 +536,8 @@ def tier_phrase(tier):
                 "Sonnet, or a comparable frontier model)")
     if tier == "medium":
         return "a mid-capability model (the medium capability tier)"
-    return ("a small, low-cost model (the low capability tier, e.g. Claude Haiku "
-            "or a comparable GPT-mini-class model — this is a bounded "
+    return ("a small, low-cost model (the low capability tier; for Codex use "
+            "a mini-class model, for Claude Code use a Haiku-class model — this is a bounded "
             "read-and-record audit whose verdict the merge-time sweep lane "
             "independently re-derives)")
 
@@ -600,7 +612,7 @@ for r in isolated:
     )
 
 out.append("")
-out.append("The hook never spawns the sub-agent itself.")
+out.append("The hook never spawns the sub-agent itself; do not self-author these sections in the primary agent context.")
 out.append("─" * 40)
 print("\n".join(out))
 PY

--- a/kit/references/DIRECTIVE_AMEND_FLOW.md
+++ b/kit/references/DIRECTIVE_AMEND_FLOW.md
@@ -199,6 +199,12 @@ Then run `git status` to confirm the three changes are staged and nothing else u
 
 Append the issue anchor the repo requires (`commit-message-format` enforces `(#N)` in this kit by default). If the user did not name an issue, ask for it as a blocking input — it's a repo directive, not a style preference.
 
+If the flow creates or updates the linked GitHub issue or PR, title it with the
+same Conventional Commits subject stem, without the trailing issue anchor (for
+example, `fix(audit): make Codex token runtime strict`). Squash merges and
+release notes commonly inherit issue/PR titles, so those titles are part of the
+same commit-message contract rather than free-form prose.
+
 The commit body should include:
 - A two-line summary of what the amendment does and why.
 - If smoke-test exited 1: the verbatim violator list so the PR reviewer can act on it.

--- a/kit/references/INIT_FLOW.md
+++ b/kit/references/INIT_FLOW.md
@@ -437,7 +437,7 @@ What happens on this commit:
 
 The install commit lands with a **real cost row in the bootstrap issue's receipt**, reconciled against the transcript — the directives are satisfied with data, not with exemptions, and no trailers are stamped onto the message.
 
-**Runtime-not-detected fallback.** If `init` was invoked from a shell with no `CLAUDECODE` / `CODEX_THREAD_ID` (etc.), the token-accounting populator can't read a transcript and writes no row — and the commit-msg endpoint reconciliation no-ops too (no runtime, nothing to reconcile), so the install commit passes with **no waiver needed**. The steering side likewise no-ops. The accounting simply records nothing for a non-agent bootstrap commit, which is correct.
+**Runtime not detected.** If `init` was invoked from a shell with no `CLAUDECODE` / `CODEX_THREAD_ID` / `CODEX_TRANSCRIPT_PATH` (etc.), the token-accounting populator can't read a transcript and writes no row — and the commit-msg endpoint reconciliation no-ops too (no runtime, nothing to reconcile), so the install commit passes with **no waiver needed**. The steering side likewise no-ops. The accounting simply records nothing for a non-agent bootstrap commit, which is correct.
 
 Print a concise summary:
 

--- a/kit/references/SUBAGENT_ATTESTATION.md
+++ b/kit/references/SUBAGENT_ATTESTATION.md
@@ -65,8 +65,11 @@ subagent:
 
 - **`inputs`** — typed tokens resolved to concrete handles by `resolve_subagent_input`:
   `diff`→`git diff`, `receipt`→the receipt path, `issue`→`gh issue view #N`
-  (derived from the receipt name), `transcript`→the session JSONL named
-  `$CLAUDE_CODE_SESSION_ID.jsonl`, `layer-map`→the doc named by
+  (derived from the receipt name), `transcript`→the active runtime's session
+  JSONL (`CODEX_THREAD_ID` under `~/.codex/sessions/` /
+  `~/.codex/archived_sessions/` for Codex, `CLAUDE_CODE_SESSION_ID` under
+  `~/.claude/projects/` for Claude Code, or the explicit `*_TRANSCRIPT_PATH`
+  override), `layer-map`→the doc named by
   `GOVERNANCE_LAYER_DOC`. An unknown token passes through verbatim.
 - **`checks`** — the numbered rubric the judge adjudicates (the prose rubric is
   the directive's `constitution.md`).
@@ -126,6 +129,10 @@ git commit
   → agent re-stages, re-commits → check.sh: section present + verdict → PASS
 ```
 
+The harness must actually spawn the fresh-context auditor. The primary agent
+must not self-author an attestation section from its own context; doing so
+collapses the author≠auditor split this mechanism exists to enforce.
+
 Two honest limits this pattern owns rather than hides:
 
 - **It records; it does not adjudicate.** `check.sh` verifies the section
@@ -169,12 +176,15 @@ The author-time attestation is a **bounded read-and-record audit**, not the
 final word on truth — the verdict's correctness is independently re-derived by
 the merge-time sweep lane at the high tier. So the attest pass runs on a
 **small, low-cost model** (the *low* capability tier — e.g. Claude Haiku or a
-comparable GPT-mini-class model). This is a deliberate cost optimization (issue
-#321): the audit fires on every newly added attested artifact, and a cheap model
-can read the diff, compare it to the artifact, and record a verdict. The grouped
-instruction names a **capability tier**, not a pinned model id, and asks the
-auditor to render the verdict as literally `PASS` or `REFUTED`; the gate matches
-that token case-insensitively anywhere in the section.
+comparable GPT-mini-class model). In Codex, that means spawning the attest
+sub-agent with a mini-class model, not the primary session's larger model. This is a
+deliberate cost optimization (issue #321): the audit fires on every newly added
+attested artifact, and a cheap model can read the diff, compare it to the
+artifact, and record a verdict. The grouped instruction names a **capability
+tier** and, for current Codex runtimes, includes a mini-class hint so the
+harness does not accidentally inherit the primary model. The auditor renders
+the verdict as literally `PASS` or `REFUTED`; the gate matches that token
+case-insensitively anywhere in the section.
 
 The tier is the default, not a hard floor: a consumer who wants this directive's
 author-time verdict run on a stronger model raises `SUBAGENT_TIERS_ATTEST` in the

--- a/packs/audit/directives/agent-steering-accounting/README.md
+++ b/packs/audit/directives/agent-steering-accounting/README.md
@@ -108,9 +108,11 @@ validated to the v1 rules.
 
 When a newly added receipt lacks a `## Steering` section, `check.sh` fails and
 the run-level orchestrator emits a grouped remediation instruction. The harness
-agent spawns a fresh-context sub-agent, handed the **session transcript** (the
-JSONL named `$CLAUDE_CODE_SESSION_ID.jsonl` under the Claude Code projects dir)
-and the receipt. The sub-agent:
+agent spawns a fresh-context sub-agent, handed the **session transcript** for
+the active runtime (`CODEX_THREAD_ID` under `~/.codex/sessions/` /
+`~/.codex/archived_sessions/` for Codex, `CLAUDE_CODE_SESSION_ID` under
+`~/.claude/projects/` for Claude Code, or an explicit `*_TRANSCRIPT_PATH`) and
+the receipt. The sub-agent:
 
 1. Walks the transcript and identifies each human-steering event — an
    **interrupt** (a user message beginning `[Request interrupted by user`) or a
@@ -195,5 +197,4 @@ the `## Steering` attestation gate over the branch's added receipts.
 
 - Wiring the **sweep** consumer to re-derive the `## Steering` verdict at the
   high tier from the same `subagent:` declaration (the schema is designed for it).
-- Codex runtime support — same schema, a different transcript the sub-agent reads.
 - Cross-session aggregation / dashboards.

--- a/packs/audit/directives/agent-token-accounting/README.md
+++ b/packs/audit/directives/agent-token-accounting/README.md
@@ -257,7 +257,7 @@ silently.
 |---|---|
 | `AGENT_NAME` set (any value) | `manual` — caller supplies `AGENT_SESSION_ID`, `AGENT_CUM_INPUT`, `AGENT_CUM_OUTPUT` |
 | `CLAUDECODE=1` | `claude-code` — reads `~/.claude/projects/<encoded-cwd>/*.jsonl` |
-| `CODEX_THREAD_ID` set | `codex` — reads `~/.codex/sessions/*.jsonl` |
+| `CODEX_THREAD_ID` or `CODEX_TRANSCRIPT_PATH` set | `codex` — reads `~/.codex/sessions/*.jsonl` |
 | none of the above | no agent runtime — the writer no-ops and the check passes |
 
 The issue anchor is parsed from the parent git's `-m` / `--message` argv, or
@@ -291,22 +291,18 @@ The reader at `runtimes/claude-code.sh` inside the directive folder:
 Same story — `CODEX_THREAD_ID` is already set in Codex sessions, so no
 wrapper is needed. The reader at `runtimes/codex.sh` inside the directive folder:
 
-1. Locates the transcript by searching recursively under
-   `~/.codex/sessions/` and `~/.codex/archived_sessions/` for a filename
-   containing `CODEX_THREAD_ID`, falling back to the most recently modified
-   `*.jsonl`. Override with `CODEX_TRANSCRIPT_PATH`.
-2. Derives the session id from `CODEX_THREAD_ID`, `session_meta.payload.id`,
-   or finally the transcript filename.
+1. Locates the transcript from `CODEX_TRANSCRIPT_PATH`, or by searching
+   recursively under `~/.codex/sessions/` and `~/.codex/archived_sessions/`
+   for a filename ending with `CODEX_THREAD_ID.jsonl`.
+2. Reads the session id from `CODEX_THREAD_ID` or `session_meta.payload.id`.
 3. Reads Codex Desktop's cumulative
-   `event_msg.payload.info.total_token_usage` records when present. For
+   `event_msg.payload.info.total_token_usage` records. For
    OpenAI cached input, `cached_input_tokens` is a subset of `input_tokens`,
    so the reader emits `input = input_tokens - cached_input_tokens`,
    `cache_read = cached_input_tokens`, and `cache_create = 0`.
-4. Falls back to summing common API shapes — top-level `usage`,
-   `message.usage`, `response.usage`.
-5. Tracks `model` from `payload.model`, `collaboration_mode.settings.model`,
-   and the older fields. Defaults to `unknown` if none carry it.
-6. Prints `<session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>`.
+4. Tracks `model` from `turn_context.payload.collaboration_mode.settings.model`.
+   Defaults to `unknown` if the transcript does not carry it.
+5. Prints `<session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>`.
 
 ### Other runtimes
 

--- a/packs/audit/directives/agent-token-accounting/hooks/pre-commit.sh
+++ b/packs/audit/directives/agent-token-accounting/hooks/pre-commit.sh
@@ -15,7 +15,8 @@
 #
 # Runtime detection is automatic from the environment:
 #   CLAUDECODE=1                 → claude-code
-#   CODEX_THREAD_ID set          → codex
+#   CODEX_THREAD_ID or CODEX_TRANSCRIPT_PATH set
+#                                  → codex
 #   AGENT_NAME set manually      → whatever the user said, with explicit
 #                                   AGENT_SESSION_ID / AGENT_CUM_INPUT /
 #                                   AGENT_CUM_CACHE_CREATE /

--- a/packs/audit/directives/agent-token-accounting/lib/runtime.sh
+++ b/packs/audit/directives/agent-token-accounting/lib/runtime.sh
@@ -20,7 +20,7 @@
 # Detection mirrors the historical pre-commit contract:
 #   AGENT_NAME set            → manual   (explicit AGENT_SESSION_ID / AGENT_CUM_*)
 #   CLAUDECODE=1              → claude-code
-#   CODEX_THREAD_ID set       → codex
+#   CODEX_THREAD_ID or CODEX_TRANSCRIPT_PATH set → codex
 #
 # Per-runtime transcript readers live in sibling runtimes/<runtime>.sh and emit
 #   <session_id> <cum_input> <cum_cache_create> <cum_cache_read> <cum_output> <model>
@@ -43,7 +43,7 @@ resolve_runtime_cumulative() {
         RUNTIME="manual"
     elif [[ "${CLAUDECODE:-}" == "1" ]]; then
         RUNTIME="claude-code"
-    elif [[ -n "${CODEX_THREAD_ID:-}" ]]; then
+    elif [[ -n "${CODEX_THREAD_ID:-}" || -n "${CODEX_TRANSCRIPT_PATH:-}" ]]; then
         RUNTIME="codex"
     fi
 

--- a/packs/audit/directives/agent-token-accounting/runtimes/codex.sh
+++ b/packs/audit/directives/agent-token-accounting/runtimes/codex.sh
@@ -14,9 +14,11 @@
 # runtime readers uniformly.
 #
 # Environment overrides:
-#   CODEX_TRANSCRIPT_PATH   absolute path to the session JSONL
-#   CODEX_SESSIONS_DIR      override ~/.codex/sessions
-#   CODEX_THREAD_ID         the thread/session id (otherwise derived from filename)
+#   CODEX_TRANSCRIPT_PATH    absolute path to the session JSONL
+#   CODEX_SESSIONS_DIR       override ~/.codex/sessions
+#   CODEX_ARCHIVED_SESSIONS_DIR override ~/.codex/archived_sessions
+#   CODEX_THREAD_ID          the live thread/session id (exported into the hook
+#                            env by Codex) — names the transcript.
 
 set -u
 
@@ -25,27 +27,20 @@ CODEX_ARCHIVED_SESSIONS="${CODEX_ARCHIVED_SESSIONS_DIR:-${HOME}/.codex/archived_
 
 TRANSCRIPT="${CODEX_TRANSCRIPT_PATH:-}"
 if [[ -z "$TRANSCRIPT" ]]; then
-    if [[ -n "${CODEX_THREAD_ID:-}" ]]; then
-        for dir in "$CODEX_SESSIONS" "$CODEX_ARCHIVED_SESSIONS"; do
-            [[ -d "$dir" ]] || continue
-            TRANSCRIPT="$(find "$dir" -type f -name "*${CODEX_THREAD_ID}*.jsonl" -print 2>/dev/null | head -n1)"
-            [[ -n "$TRANSCRIPT" ]] && break
-        done
-    fi
-    if [[ -z "$TRANSCRIPT" && -d "$CODEX_SESSIONS" ]]; then
-        TRANSCRIPT="$(find "$CODEX_SESSIONS" -type f -name "*.jsonl" -print0 2>/dev/null \
-            | xargs -0 ls -t 2>/dev/null \
-            | head -n1)"
-    fi
+    [[ -n "${CODEX_THREAD_ID:-}" ]] || exit 1
+    for dir in "$CODEX_SESSIONS" "$CODEX_ARCHIVED_SESSIONS"; do
+        [[ -d "$dir" ]] || continue
+        TRANSCRIPT="$(find "$dir" -type f -name "*${CODEX_THREAD_ID}.jsonl" -print 2>/dev/null | LC_ALL=C sort | head -n1)"
+        [[ -n "$TRANSCRIPT" ]] && break
+    done
 fi
 
 [[ -z "$TRANSCRIPT" || ! -f "$TRANSCRIPT" ]] && exit 1
 
-# Read cumulative tokens across the common Codex transcript shapes:
-#   - Codex Desktop event_msg token_count.info.total_token_usage
-#   - top-level usage / message.usage / response.usage dictionaries
-#   - OpenAI input_tokens_details.cached_tokens dictionaries
-#   - prompt_tokens / completion_tokens fallback keys
+# Read cumulative tokens from the current Codex Desktop transcript shape:
+#   - session_meta.payload.id carries the session id
+#   - turn_context.payload.collaboration_mode.settings.model carries the model
+#   - event_msg.payload.info.total_token_usage carries cumulative tokens
 OUT="$(python3 - "$TRANSCRIPT" "${CODEX_THREAD_ID:-}" <<'PY'
 import json, sys
 path = sys.argv[1]
@@ -58,33 +53,17 @@ t_output = 0
 model = ""
 latest_total = None
 
-def pull(u):
-    """Return (input, cache_create, cache_read, output) from a usage dict."""
-    if not isinstance(u, dict):
-        return 0, 0, 0, 0
-    i  = u.get("input_tokens")  or u.get("prompt_tokens")     or 0
-    o  = u.get("output_tokens") or u.get("completion_tokens") or 0
-    cc = u.get("cache_creation_input_tokens", 0) or 0
-    cr = u.get("cache_read_input_tokens", 0) or 0
-    # OpenAI-style cached input is a subset of input tokens, not an additional
-    # bucket. Split it out so pricing uses cached-input rates for those tokens.
-    if not cr:
-        cr = u.get("cached_input_tokens", 0) or 0
-    details = u.get("input_tokens_details") or u.get("prompt_tokens_details")
-    if not cr and isinstance(details, dict):
-        cr = details.get("cached_tokens", 0) or 0
+def pull_total(total):
+    i = total.get("input_tokens", 0) or 0
+    cr = total.get("cached_input_tokens", 0) or 0
+    o = total.get("output_tokens", 0) or 0
     try:
         i = int(i or 0)
-        cc = int(cc or 0)
         cr = int(cr or 0)
         o = int(o or 0)
     except (TypeError, ValueError):
         return 0, 0, 0, 0
-    # Only OpenAI cached-input fields are included in input_tokens. Anthropic
-    # cache_read_input_tokens is already separate, so do not subtract it.
-    if ("cached_input_tokens" in u) or isinstance(details, dict):
-        i = max(i - cr, 0)
-    return i, cc, cr, o
+    return max(i - cr, 0), 0, cr, o
 
 with open(path) as f:
     for line in f:
@@ -97,50 +76,20 @@ with open(path) as f:
             candidate = payload.get("id")
             if isinstance(candidate, str) and candidate:
                 sid = candidate
-        # Model can live at any of several places depending on transcript version.
-        for container in (d, payload, d.get("message"), d.get("response")):
-            if isinstance(container, dict):
-                m = container.get("model") or container.get("model_slug") or container.get("model_id")
-                if isinstance(m, str) and m:
-                    model = m
-                    break
-                collaboration = container.get("collaboration_mode")
-                if isinstance(collaboration, dict):
-                    settings = collaboration.get("settings")
-                    if isinstance(settings, dict):
-                        m = settings.get("model")
-                        if isinstance(m, str) and m:
-                            model = m
-                            break
+        collaboration = payload.get("collaboration_mode") if payload else None
+        settings = collaboration.get("settings") if isinstance(collaboration, dict) else None
+        m = settings.get("model") if isinstance(settings, dict) else None
+        if isinstance(m, str) and m:
+            model = m
         if payload and payload.get("type") == "token_count":
             info = payload.get("info")
             total = info.get("total_token_usage") if isinstance(info, dict) else None
             if isinstance(total, dict):
-                latest_total = pull(total)
-                continue
-        for container in (
-            d,
-            payload,
-            d.get("message")  if isinstance(d.get("message"),  dict) else None,
-            d.get("response") if isinstance(d.get("response"), dict) else None,
-        ):
-            if container is None:
-                continue
-            u = container.get("usage") if container is not d else container.get("usage", container)
-            i, cc, cr, o = pull(u if isinstance(u, dict) else {})
-            if i or o or cc or cr:
-                t_input        += i
-                t_cache_create += cc
-                t_cache_read   += cr
-                t_output       += o
-                break
+                latest_total = pull_total(total)
 if latest_total is not None:
     t_input, t_cache_create, t_cache_read, t_output = latest_total
 if not sid:
-    base = path.rsplit("/", 1)[-1]
-    if base.endswith(".jsonl"):
-        base = base[:-6]
-    sid = base.split("rollout-", 1)[-1] if base.startswith("rollout-") else base
+    sys.exit(2)
 print(f"{sid} {t_input} {t_cache_create} {t_cache_read} {t_output} {model or 'unknown'}")
 PY
 )"

--- a/receipts/issue-335-codex-runtime-token-accounting.md
+++ b/receipts/issue-335-codex-runtime-token-accounting.md
@@ -1,0 +1,141 @@
+# issue-335: fix(audit): make Codex token runtime strict
+
+Closes [#335](https://github.com/Duaility/governance-kit/issues/335).
+
+## Checklist
+
+- [x] Make Codex token accounting resolve transcripts from the current Codex contract
+- [x] Remove newest-transcript guessing and legacy transcript-shape parsing
+- [x] Make transcript remediation text runtime-aware
+- [x] Add regression coverage for Codex transcript resolution and strict no-guess behavior
+- [x] Harden sub-agent attestation remediation for Codex mini-model execution
+- [x] Document conventional issue/PR titles for governance work
+
+## What changed
+
+- **Make Codex token accounting resolve transcripts from the current Codex contract.**
+  `packs/audit/directives/agent-token-accounting/runtimes/codex.sh` now accepts
+  `CODEX_TRANSCRIPT_PATH` as an explicit transcript path, otherwise requires
+  `CODEX_THREAD_ID` and searches `~/.codex/sessions/` plus
+  `~/.codex/archived_sessions/` for a filename ending in
+  `$CODEX_THREAD_ID.jsonl`. `packs/audit/directives/agent-token-accounting/lib/runtime.sh`
+  and `packs/audit/directives/agent-token-accounting/hooks/pre-commit.sh`
+  document/detect the same Codex signals.
+- **Remove newest-transcript guessing and legacy transcript-shape parsing.**
+  `packs/audit/directives/agent-token-accounting/runtimes/codex.sh` no longer
+  chooses the newest `.jsonl`, derives a session id from the filename, or sums
+  older `usage` / `message.usage` / `response.usage` shapes. It reads the current
+  Codex Desktop transcript shape only: `session_meta.payload.id`,
+  `turn_context.payload.collaboration_mode.settings.model`, and
+  `event_msg.payload.info.total_token_usage`.
+- **Make transcript remediation text runtime-aware.**
+  `kit/assets/dot-governance/lib.sh` resolves the `transcript` sub-agent input
+  to Codex-specific guidance when `CODEX_THREAD_ID` or `CODEX_TRANSCRIPT_PATH`
+  is present, and preserves Claude Code guidance when `CLAUDE_CODE_SESSION_ID`
+  or `CLAUDE_TRANSCRIPT_PATH` is present. The reference docs in
+  `kit/references/SUBAGENT_ATTESTATION.md`,
+  `kit/references/INIT_FLOW.md`,
+  `packs/audit/directives/agent-token-accounting/README.md`, and
+  `packs/audit/directives/agent-steering-accounting/README.md` were updated to
+  match the current runtime behavior.
+- **Add regression coverage for Codex transcript resolution and strict no-guess behavior.**
+  `scripts/test-runtime.sh` now builds current-shape Codex JSONL fixtures,
+  asserts that the thread-id transcript wins over a newer unrelated transcript,
+  asserts that the reader refuses to guess without `CODEX_THREAD_ID` or
+  `CODEX_TRANSCRIPT_PATH`, and checks the runtime-aware transcript prompt.
+- **Receipt coverage.** This receipt is tracked as
+  `receipts/issue-335-codex-runtime-token-accounting.md`.
+- **Harden sub-agent attestation remediation for Codex mini-model execution.**
+  `kit/assets/dot-governance/lib.sh` now names a Codex mini-class model for the
+  low-tier attest lane and explicitly tells the primary agent not to
+  self-author attestation sections. `scripts/test-runtime.sh` locks both
+  strings into the remediation output.
+- **Document conventional issue/PR titles for governance work.**
+  `kit/references/DIRECTIVE_AMEND_FLOW.md` now says GitHub issue and PR titles
+  created by the flow should use the same Conventional Commits subject stem
+  because squash merges and release notes commonly inherit those titles.
+
+## Out of scope
+
+- Updating the consumed `.governance/` tree. This repo treats `.governance/` as
+  a released consumer materialization, so source changes land under `kit/`,
+  `packs/`, and `scripts/` only.
+- Changing Claude Code transcript resolution.
+- Changing model rate-card behavior such as family-prefix pricing rows.
+
+## Decisions
+
+- **No newest-transcript fallback for Codex.** In v0 the current runtime
+  contract is enough: a Codex-authored commit has `CODEX_THREAD_ID`, and an
+  operator can supply `CODEX_TRANSCRIPT_PATH` explicitly. If neither is present,
+  the reader exits non-zero instead of guessing.
+- **Current transcript shape only.** The Codex adapter now prices the shape
+  Codex Desktop writes today. Older transcript layouts can fail loudly rather
+  than staying as hidden compatibility paths.
+- **Explicit transcript paths remain supported.** `CODEX_TRANSCRIPT_PATH` is an
+  operator-provided coordinate, not a heuristic path; it is useful for targeted
+  debugging and scripted tests.
+- **Low-tier attestations should not inherit the primary model.** Codex
+  harnesses now get a version-agnostic mini-class hint for the bounded
+  read-and-record attest lane, while stronger models remain available through
+  the operator-owned `SUBAGENT_TIERS_ATTEST` overlay.
+
+## Verification
+
+```sh
+bash scripts/test-runtime.sh
+npm run docs:gen:check
+git diff --check
+bash .governance/run.sh
+bash scripts/test-packs.sh
+bash scripts/test.sh
+```
+
+All commands passed locally. `scripts/test-runtime.sh` reports 119 assertions,
+including the new Codex strict-reader cases.
+
+## Audit
+
+Fresh-context sub-agent audit of the branch diff against `main`, issue #335,
+and this receipt:
+
+- PASS - The receipt's `## What changed` faithfully describes the branch diff against `main`; the changed files and behavioral claims match the diff.
+- PASS - Each checked checklist item is realized in the diff: strict Codex transcript resolution, removal of newest/legacy parsing paths, runtime-aware transcript guidance, and regression coverage are all present.
+- PASS - The receipt checklist mirrors issue #335's proposed fix bullets.
+
+## Layer boundaries
+
+Fresh-context sub-agent layer audit against `ARCHITECTURE.md`:
+
+- PASS - Changed files sit in appropriate layers: Codex runtime logic stays in the audit pack, shared sub-agent prompt resolution stays in kit runtime support, reference/docs stay in kit/directive docs, and tests stay under `scripts/`.
+- PASS - No changed dependency points the wrong way across the `skill -> kit -> packs` architecture edges; `skill/` and consumed `.governance/` are untouched.
+- PASS - No shared logic is duplicated into a consumer layer; the shared transcript-input wording remains centralized in `kit/assets/dot-governance/lib.sh`.
+
+## Steering
+
+Fresh-context sub-agent review of the session transcript:
+
+- PASS - The operator correction to remove legacy fallback behavior is recorded in `### Steering` with transcript ordinal 3 and timestamp `2026-06-18T05:53:43.041Z`.
+- PASS - The later correction that the receipt claimed fresh-context attestation before a sub-agent was actually triggered is recorded in `### Steering` with transcript ordinal 8 and timestamp `2026-06-18T06:10:44.466Z`.
+- PASS - The correction covering conventional GitHub titles, mini-model attestations, and systemic pack/kit fixes is recorded in `### Steering` with transcript ordinal 9 and timestamp `2026-06-18T06:16:23.867Z`.
+- PASS - The later correction to avoid enforcing the cache-create clarification and to avoid explicit mini-model version names is recorded in `### Steering` with transcript ordinal 10 and timestamp `2026-06-18T06:25:46.133Z`.
+
+## Accounting
+
+<!-- Accounting rows are maintained by the agent-token-accounting and agent-steering-accounting pre-commit hooks. Keys are opaque - do not parse. -->
+
+### Steering
+
+| steer-key | session | issue | type | tier | user-reason | commit | ordinal | timestamp |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| steer-019ed941f410-1781762023-1 | 019ed941-f410-7871-bacf-6db3af231768 | #335 | correction | classifier | Remove legacy fallback behavior; keep only the current v0 Codex runtime path. | fix(audit): make codex token runtime strict (#335) | 3 | 2026-06-18T05:53:43.041Z |
+| steer-019ed941f410-1781763044-1 | 019ed941-f410-7871-bacf-6db3af231768 | #335 | correction | classifier | Correct false claim that fresh-context attestation had already been triggered. | fix(audit): make codex token runtime strict (#335) | 8 | 2026-06-18T06:10:44.466Z |
+| steer-019ed941f410-1781763383-1 | 019ed941-f410-7871-bacf-6db3af231768 | #335 | correction | classifier | Use Conventional Commits-style issue/PR titles, spawn attestations on a Codex mini model, and add systemic pack/kit fixes for the mistakes above. | fix(audit): make codex token runtime strict (#335) | 9 | 2026-06-18T06:16:23.867Z |
+| steer-019ed941f410-1781763946-1 | 019ed941-f410-7871-bacf-6db3af231768 | #335 | correction | classifier | Do not add cache-create clarification as an enforced change, and keep Codex mini-model guidance version-agnostic. | fix(audit): make codex token runtime strict (#335) | 10 | 2026-06-18T06:25:46.133Z |
+
+### Costs
+
+| cost-key | agent | session | issue | model | input | cache-create | cache-read | output | new-work | cost-usd | cum-input | cum-cache-create | cum-cache-read | cum-output | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| codex-019ed941-f41-1781762894-1 | codex | 019ed941-f410-7871-bacf-6db3af231768 | #335 | gpt-5.5 | 506794 | 0 | 9999872 | 30304 | 537098 | 8.4430 | 506794 | 0 | 9999872 | 30304 | fix(audit): make codex token runtime strict (#335) -m governance: allow-toolchai |
+| codex-019ed941-f41-1781764366-1 | codex | 019ed941-f410-7871-bacf-6db3af231768 | #335 | gpt-5.5 | 284217 | 0 | 7691264 | 24133 | 308350 | 5.9907 | 791011 | 0 | 17691136 | 54437 | fix(audit): make codex token runtime strict (#335) -m governance: allow-toolchai |

--- a/scripts/test-runtime.sh
+++ b/scripts/test-runtime.sh
@@ -40,6 +40,8 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUN_SH="$ROOT/kit/assets/dot-governance/run.sh"
 LIB_SH="$ROOT/kit/assets/dot-governance/lib.sh"
+TOKEN_RUNTIME_LIB="$ROOT/packs/audit/directives/agent-token-accounting/lib/runtime.sh"
+TOKEN_CODEX_SH="$ROOT/packs/audit/directives/agent-token-accounting/runtimes/codex.sh"
 
 PASS=0
 FAIL=0
@@ -489,6 +491,8 @@ assert_contains "attestation_prompt numbers the first check" "(1) check one" "$o
 assert_contains "attestation_prompt numbers the second check" "(2) check two" "$output"
 assert_contains "attestation_prompt names the target section" "into a '## Audit' section" "$output"
 assert_contains "attestation_prompt states the no-spawn invariant" "hook never spawns" "$output"
+assert_contains "attestation_prompt names Codex mini class for low tier" "for Codex use a mini-class model" "$output"
+assert_contains "attestation_prompt rejects self-authored sections" "do not self-author this section" "$output"
 
 # require_attestation: present + verdict-bearing section → no violation, returns 0.
 set +e
@@ -592,6 +596,8 @@ assert_contains "remediation names the target section" "write the '## Audit' sec
 assert_contains "remediation numbers the first check" "(1) What changed matches the diff" "$output"
 assert_contains "remediation numbers the second check" "(2) checklist mirrors the issue" "$output"
 assert_contains "remediation unions the resolved inputs" "the diff (\`git diff\`)" "$output"
+assert_contains "remediation names Codex mini class for low tier" "for Codex use a mini-class model" "$output"
+assert_contains "remediation rejects self-authored sections" "do not self-author these sections" "$output"
 
 # An isolated record gets its own sub-agent instruction (US-joined inner fields).
 printf 'isolated\t%s\tSteering\t%s\t%s\n' \
@@ -614,6 +620,27 @@ assert_eq "no registration when the section is well-formed" "" "$(cat "$sa_ledge
 : > "$sa_ledger"
 output=$(set +u; source "$LIB_SH"; attestation_remediation "$sa_ledger" 2>&1)
 assert_eq "remediation is silent with no pending attestations" "" "$output"
+
+# The transcript input is runtime-aware, so Codex users are not handed a
+# Claude-only lookup instruction.
+output=$(
+    set +u
+    unset CLAUDE_TRANSCRIPT_PATH CLAUDE_CODE_SESSION_ID
+    CODEX_THREAD_ID="019ed941-f410-7871-bacf-6db3af231768"
+    source "$LIB_SH"
+    resolve_subagent_input transcript "$sa_receipt"
+)
+assert_contains "transcript input names Codex sessions" "~/.codex/sessions/" "$output"
+assert_contains "transcript input names CODEX_THREAD_ID" 'CODEX_THREAD_ID.jsonl' "$output"
+
+output=$(
+    set +u
+    unset CODEX_TRANSCRIPT_PATH CODEX_THREAD_ID
+    CLAUDE_CODE_SESSION_ID="9e05791b-0ee0-423e-b0c8-2234df57840a"
+    source "$LIB_SH"
+    resolve_subagent_input transcript "$sa_receipt"
+)
+assert_contains "transcript input still supports Claude session ids" 'CLAUDE_CODE_SESSION_ID.jsonl' "$output"
 
 # ---- lib.sh: operator-tunable subagent tier/isolation (issue #331) ---------
 
@@ -837,6 +864,65 @@ cat > "$list_repo/.governance/conf/cmf.conf" <<'EOF'
 EOF
 output=$(cd "$list_repo"; set +u; source "$LIB_SH"; conf_list cmf ./defaults.conf)
 assert_eq "conf_list can empty the list" "" "$output"
+
+# ---- agent-token-accounting: Codex runtime reader -------------------------
+
+printf '── agent-token-accounting: codex runtime reader ────────\n'
+codex_sessions="$WORK/codex-sessions"
+codex_archived="$WORK/codex-archived"
+mkdir -p "$codex_sessions/2026/06/18" "$codex_archived"
+codex_thread="019ed941-f410-7871-bacf-6db3af231768"
+codex_wanted="$codex_sessions/2026/06/18/rollout-2026-06-18T11-13-58-$codex_thread.jsonl"
+codex_newer="$codex_sessions/2026/06/18/rollout-2026-06-18T11-14-30-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"
+cat > "$codex_wanted" <<EOF
+{"type":"session_meta","payload":{"id":"$codex_thread"}}
+{"type":"turn_context","payload":{"collaboration_mode":{"settings":{"model":"gpt-5.5"}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":30,"output_tokens":7}}}}
+EOF
+cat > "$codex_newer" <<'EOF'
+{"type":"session_meta","payload":{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}}
+{"type":"turn_context","payload":{"collaboration_mode":{"settings":{"model":"gpt-5.5"}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":900,"cached_input_tokens":0,"output_tokens":9}}}}
+EOF
+touch -t 202606181114 "$codex_wanted"
+touch -t 202606181115 "$codex_newer"
+
+set +e
+output=$(
+    CODEX_THREAD_ID="$codex_thread" \
+    CODEX_SESSIONS_DIR="$codex_sessions" \
+    CODEX_ARCHIVED_SESSIONS_DIR="$codex_archived" \
+    bash "$TOKEN_CODEX_SH"
+)
+exit_code=$?
+set -e
+assert_eq "codex reader exits 0 with CODEX_THREAD_ID" 0 "$exit_code"
+assert_eq "codex reader chooses thread match over newer unrelated transcript" "$codex_thread 70 0 30 7 gpt-5.5" "$output"
+
+set +e
+output=$(
+    unset CODEX_THREAD_ID CODEX_TRANSCRIPT_PATH
+    CODEX_SESSIONS_DIR="$codex_sessions" \
+    CODEX_ARCHIVED_SESSIONS_DIR="$codex_archived" \
+    bash "$TOKEN_CODEX_SH"
+)
+exit_code=$?
+set -e
+assert_eq "codex reader refuses to guess without thread id or transcript path" 1 "$exit_code"
+
+set +e
+output=$(
+    unset AGENT_NAME CLAUDECODE CODEX_THREAD_ID
+    export CODEX_TRANSCRIPT_PATH="$codex_wanted"
+    source "$TOKEN_RUNTIME_LIB"
+    resolve_runtime_cumulative
+    rc=$?
+    printf '%s %s %s %s %s %s\n' "$rc" "$RUNTIME" "$SESSION_ID" "$CUM_INPUT" "$CUM_CACHE_READ" "$MODEL"
+)
+exit_code=$?
+set -e
+assert_eq "runtime detection accepts explicit Codex transcript path" 0 "$exit_code"
+assert_eq "runtime detection reads Codex transcript path coordinates" "0 codex $codex_thread 70 30 gpt-5.5" "$output"
 
 # ---- summary --------------------------------------------------------------
 


### PR DESCRIPTION
## What changed

- Tightens the Codex token-accounting runtime to the current contract: `CODEX_TRANSCRIPT_PATH` or `CODEX_THREAD_ID` only.
- Removes newest-transcript guessing, filename-derived session ids, and legacy transcript-shape parsing from `runtimes/codex.sh`.
- Makes sub-agent transcript remediation text runtime-aware for Codex and Claude Code.
- Strengthens attestation remediation so Codex low-tier attestations ask for a mini-class model and tell the primary agent not to self-author attestation sections.
- Documents that governance-created issue/PR titles should use the Conventional Commits subject stem.
- Adds runtime regression coverage and the receipt for issue #335.

## Why

Claude Code already had deterministic session resolution from its live session id. Codex still had heuristic behavior that could choose the wrong transcript and retained compatibility paths that are unnecessary while the project is v0.

The follow-up hardening addresses process mistakes found while publishing this PR: attestation must actually run in a fresh context, low-tier Codex attestations should use a mini-class model, and issue/PR titles should remain squash-merge friendly.

Closes #335.

## Validation

- `bash scripts/test-runtime.sh`
- `npm run docs:gen:check`
- `git diff --check`
- `bash .governance/run.sh`
- `bash scripts/test-packs.sh`
- `bash scripts/test.sh`

The amended commit hook also reran the full internal test gate and commit-msg governance before creating `5d220c8`.
